### PR TITLE
Automated cherry pick of #2908: fix: 避免cache raw格式的镜像

### DIFF
--- a/pkg/hostman/storageman/imagecachemanager_rbd.go
+++ b/pkg/hostman/storageman/imagecachemanager_rbd.go
@@ -112,7 +112,7 @@ func (c *SRbdImageCacheManager) PrefetchImageCache(ctx context.Context, data int
 	if err != nil {
 		return nil, err
 	}
-	format, _ := body.GetString("format")
+	format := "qcow2"
 	srcUrl, _ := body.GetString("src_url")
 	zone, _ := body.GetString("zone")
 


### PR DESCRIPTION
Cherry pick of #2908 on release/2.10.0.

#2908: fix: 避免cache raw格式的镜像