### PR TITLE
Automated cherry pick of #6068: fix: gcp use project name for cloudprovider

### DIFF
--- a/pkg/multicloud/google/google.go
+++ b/pkg/multicloud/google/google.go
@@ -750,7 +750,7 @@ func (client *SGoogleClient) GetSubAccounts() ([]cloudprovider.SSubAccount, erro
 	accounts := []cloudprovider.SSubAccount{}
 	for _, project := range projects {
 		subAccount := cloudprovider.SSubAccount{}
-		subAccount.Name = client.cpcfg.Name
+		subAccount.Name = project.Name
 		subAccount.Account = fmt.Sprintf("%s/%s", project.ProjectId, client.clientEmail)
 		if project.LifecycleState == "ACTIVE" {
 			subAccount.HealthStatus = api.CLOUD_PROVIDER_HEALTH_NORMAL


### PR DESCRIPTION
Cherry pick of #6068 on release/3.2.

#6068: fix: gcp use project name for cloudprovider