### PR TITLE
fix: 普通用户可获取rds账号密码

### DIFF
--- a/pkg/compute/models/dbinstance_accounts.go
+++ b/pkg/compute/models/dbinstance_accounts.go
@@ -64,7 +64,7 @@ type SDBInstanceAccount struct {
 	SDBInstanceResourceBase `width:"36" charset:"ascii" name:"dbinstance_id" nullable:"false" list:"user" create:"required" index:"true"`
 
 	// 数据库密码
-	Secret string `width:"256" charset:"ascii" nullable:"false" list:"domain" create:"optional"`
+	Secret string `width:"256" charset:"ascii" nullable:"false" list:"user" create:"optional"`
 
 	// RDS实例Id
 	// DBInstanceId string `width:"36" charset:"ascii" name:"dbinstance_id" nullable:"false" list:"user" create:"required" index:"true"`


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
普通用户可获取rds账号密码


**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @zexi 