### PR TITLE
Automated cherry pick of #6095: fix: 普通用户可获取rds账号密码

### DIFF
--- a/pkg/compute/models/dbinstance_accounts.go
+++ b/pkg/compute/models/dbinstance_accounts.go
@@ -59,7 +59,7 @@ type SDBInstanceAccount struct {
 	db.SStatusStandaloneResourceBase
 	db.SExternalizedResourceBase
 
-	Secret       string `width:"256" charset:"ascii" nullable:"false" list:"domain" create:"optional"`
+	Secret       string `width:"256" charset:"ascii" nullable:"false" list:"user" create:"optional"`
 	DBInstanceId string `width:"36" charset:"ascii" name:"dbinstance_id" nullable:"false" list:"user" create:"required" index:"true"`
 }
 


### PR DESCRIPTION
Cherry pick of #6095 on release/2.12.

#6095: fix: 普通用户可获取rds账号密码