### PR TITLE
fix: 避免gcp创建创建文件夹失败

### DIFF
--- a/pkg/multicloud/google/bucket.go
+++ b/pkg/multicloud/google/bucket.go
@@ -512,7 +512,7 @@ func (region *SRegion) PutObject(bucket string, name string, input io.Reader, si
 	params.Set("uploadType", "media")
 	header := http.Header{}
 	header.Set("Content-Length", fmt.Sprintf("%v", sizeBytes))
-
+	name = url.QueryEscape(name)
 	err := region.UploadObject(bucket, params, header, input)
 	if err != nil {
 		return errors.Wrap(err, "UploadObject")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免gcp创建创建文件夹失败

**是否需要 backport 到之前的 release 分支**:
- release/3.2

/area region
/cc @zexi 
