### PR TITLE
Automated cherry pick of #6123: fix: usage-handler 不统计虚拟的vpc wire

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -915,13 +915,13 @@ func (self *SCloudaccount) GetHostCount() (int, error) {
 
 func (self *SCloudaccount) GetVpcCount() (int, error) {
 	subq := CloudproviderManager.Query("id").Equals("cloudaccount_id", self.Id).SubQuery()
-	q := VpcManager.Query().In("manager_id", subq)
+	q := VpcManager.Query().In("manager_id", subq).IsFalse("is_emulated")
 	return q.CountWithError()
 }
 
 func (self *SCloudaccount) GetStorageCount() (int, error) {
 	subq := CloudproviderManager.Query("id").Equals("cloudaccount_id", self.Id).SubQuery()
-	q := StorageManager.Query().In("manager_id", subq)
+	q := StorageManager.Query().In("manager_id", subq).IsFalse("is_emulated")
 	return q.CountWithError()
 }
 

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -243,15 +243,15 @@ func (self *SCloudprovider) GetGuestCount() (int, error) {
 }
 
 func (self *SCloudprovider) GetHostCount() (int, error) {
-	return HostManager.Query().Equals("manager_id", self.Id).CountWithError()
+	return HostManager.Query().Equals("manager_id", self.Id).IsFalse("is_emulated").CountWithError()
 }
 
 func (self *SCloudprovider) getVpcCount() (int, error) {
-	return VpcManager.Query().Equals("manager_id", self.Id).CountWithError()
+	return VpcManager.Query().Equals("manager_id", self.Id).IsFalse("is_emulated").CountWithError()
 }
 
 func (self *SCloudprovider) getStorageCount() (int, error) {
-	return StorageManager.Query().Equals("manager_id", self.Id).CountWithError()
+	return StorageManager.Query().Equals("manager_id", self.Id).IsFalse("is_emulated").CountWithError()
 }
 
 func (self *SCloudprovider) getStoragecacheCount() (int, error) {

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -546,6 +546,7 @@ func (manager *SWireManager) totalCountQ(
 	wires := WireManager.Query().SubQuery()
 	q := wires.Query(
 		sqlchemy.COUNT("id").Label("wires_count"),
+		sqlchemy.SUM("emulated_wires_count", wires.Field("is_emulated")),
 		sqlchemy.SUM("net_count", netSQ.Field("net_count")),
 		sqlchemy.SUM("guest_nic_count", netSQ.Field("gnic_count")),
 		sqlchemy.SUM("host_nic_count", netSQ.Field("hnic_count")),
@@ -576,13 +577,14 @@ func (manager *SWireManager) totalCountQ(
 }
 
 type WiresCountStat struct {
-	WiresCount    int
-	NetCount      int
-	GuestNicCount int
-	HostNicCount  int
-	ReservedCount int
-	GroupNicCount int
-	LbNicCount    int
+	WiresCount         int
+	EmulatedWiresCount int
+	NetCount           int
+	GuestNicCount      int
+	HostNicCount       int
+	ReservedCount      int
+	GroupNicCount      int
+	LbNicCount         int
 }
 
 func (wstat WiresCountStat) NicCount() int {

--- a/pkg/compute/usages/handler.go
+++ b/pkg/compute/usages/handler.go
@@ -419,7 +419,7 @@ func ZoneUsage(providers []string, brands []string, cloudEnv string) Usage {
 }
 
 func VpcUsage(providers []string, brands []string, cloudEnv string) Usage {
-	q := models.VpcManager.Query()
+	q := models.VpcManager.Query().IsFalse("is_emulated")
 	if len(providers) > 0 || len(brands) > 0 || len(cloudEnv) > 0 {
 		q = models.CloudProviderFilter(q, q.Field("manager_id"), providers, brands, cloudEnv)
 	}
@@ -514,7 +514,7 @@ func DisksUsage(
 func WireUsage(rangeObjs []db.IStandaloneModel, hostTypes []string, providers []string, brands []string, cloudEnv string) Usage {
 	count := make(map[string]interface{})
 	result := models.WireManager.TotalCount(rangeObjs, hostTypes, providers, brands, cloudEnv, rbacutils.ScopeSystem, nil, false)
-	count["wires"] = result.WiresCount
+	count["wires"] = result.WiresCount - result.EmulatedWiresCount
 	count["networks"] = result.NetCount
 	count["all.nics.guest"] = result.GuestNicCount
 	count["all.nics.host"] = result.HostNicCount


### PR DESCRIPTION
Cherry pick of #6123 on release/3.1.

#6123: fix: usage-handler 不统计虚拟的vpc wire