### PR TITLE
Automated cherry pick of #6137: fix: 云账号创建可以指定项目

### DIFF
--- a/pkg/mcclient/options/cloudaccounts.go
+++ b/pkg/mcclient/options/cloudaccounts.go
@@ -82,6 +82,7 @@ type SCloudAccountCreateBaseOptions struct {
 
 	SyncIntervalSeconds int `help:"Interval to synchronize if auto sync is enable" metavar:"SECONDS"`
 
+	Project       string `help:"project for this account"`
 	ProjectDomain string `help:"domain for this account"`
 
 	ProxySetting string `help:"proxy setting id or name" json:"proxy_setting"`


### PR DESCRIPTION
Cherry pick of #6137 on release/3.2.

#6137: fix: 云账号创建可以指定项目