### PR TITLE
fix: gcp rds 默认不使用vpc网络

### DIFF
--- a/pkg/multicloud/google/dbinstance.go
+++ b/pkg/multicloud/google/dbinstance.go
@@ -541,10 +541,6 @@ func (region *SRegion) CreateRds(name, databaseVersion, category, instanceType, 
 			"value": "0.0.0.0/0",
 		},
 	}
-	if len(vpcId) > 0 {
-		vpcId = strings.TrimPrefix(vpcId, region.GetGlobalId()+"/")
-		ipConfiguration["privateNetwork"] = vpcId
-	}
 	settings["ipConfiguration"] = ipConfiguration
 	body := map[string]interface{}{
 		"databaseVersion": databaseVersion,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
gcp rds 默认不使用vpc网络

**是否需要 backport 到之前的 release 分支**:
- release/3.2

/area region
/cc @zexi 