### PR TITLE
Automated cherry pick of #6268: fix: gcp rds 默认不使用vpc网络

### DIFF
--- a/pkg/multicloud/google/dbinstance.go
+++ b/pkg/multicloud/google/dbinstance.go
@@ -541,10 +541,6 @@ func (region *SRegion) CreateRds(name, databaseVersion, category, instanceType, 
 			"value": "0.0.0.0/0",
 		},
 	}
-	if len(vpcId) > 0 {
-		vpcId = strings.TrimPrefix(vpcId, region.GetGlobalId()+"/")
-		ipConfiguration["privateNetwork"] = vpcId
-	}
 	settings["ipConfiguration"] = ipConfiguration
 	body := map[string]interface{}{
 		"databaseVersion": databaseVersion,


### PR DESCRIPTION
Cherry pick of #6268 on release/3.2.

#6268: fix: gcp rds 默认不使用vpc网络