### PR TITLE
Automated cherry pick of #6428: fix: 避免设置自动释放后磁盘的expired_at失效

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1441,9 +1441,15 @@ func (self *SDisk) syncWithCloudDisk(ctx context.Context, userCred mcclient.Toke
 		self.IsEmulated = extDisk.IsEmulated()
 
 		if provider.GetFactory().IsSupportPrepaidResources() && !recycle {
-			self.BillingType = extDisk.GetBillingType()
-			self.ExpiredAt = extDisk.GetExpiredAt()
-			self.AutoRenew = extDisk.IsAutoRenew()
+			if billintType := extDisk.GetBillingType(); len(billintType) > 0 {
+				self.BillingType = extDisk.GetBillingType()
+				if self.BillingType == billing_api.BILLING_TYPE_PREPAID {
+					self.AutoRenew = extDisk.IsAutoRenew()
+				}
+			}
+			if expiredAt := extDisk.GetExpiredAt(); !expiredAt.IsZero() {
+				self.ExpiredAt = extDisk.GetExpiredAt()
+			}
 		}
 
 		if createdAt := extDisk.GetCreatedAt(); !createdAt.IsZero() {


### PR DESCRIPTION
Cherry pick of #6428 on release/3.2.

#6428: fix: 避免设置自动释放后磁盘的expired_at失效