### PR TITLE
fix: 修复zstack使用win镜像时userdata base64加密问题

### DIFF
--- a/pkg/compute/guestdrivers/zstack.go
+++ b/pkg/compute/guestdrivers/zstack.go
@@ -154,6 +154,10 @@ func (self *SZStackGuestDriver) GetUserDataType() string {
 	return cloudprovider.CLOUD_SHELL
 }
 
+func (self *SZStackGuestDriver) IsWindowsUserDataTypeNeedEncode() bool {
+	return true
+}
+
 func (self *SZStackGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	userName := "root"
 	if desc.OsType == "Windows" {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复zstack使用win镜像时userdata base64加密问题

**是否需要 backport 到之前的 release 分支**:
- release/3.1

/area region
/cc @zexi 
