### PR TITLE
Automated cherry pick of #6511: fix: 避免忽略本地allow any云上deny any安全组规则同步

### DIFF
--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1492,7 +1492,7 @@ func (self *SManagedVirtualizationRegionDriver) RequestSyncSecurityGroup(ctx con
 	sort.Sort(outRules)
 	_inAllowList := inRules.AllowList()
 	_outAllowList := outRules.AllowList()
-	if inAllowList.Equals(_inAllowList) && outAllowList.Equals(_outAllowList) {
+	if inAllowList.Equals(_inAllowList) && outAllowList.Equals(_outAllowList) && (len(_inAllowList) > 0 && len(_outAllowList) > 0) { // 避免单个deny any的allowList为空,导致安全组规则未同步
 		return cache.ExternalId, nil
 	}
 


### PR DESCRIPTION
Cherry pick of #6511 on release/2.13.

#6511: fix: 避免忽略本地allow any云上deny any安全组规则同步