### PR TITLE
fix: gcp bucket文件夹默认设为private

### DIFF
--- a/pkg/multicloud/google/s3object.go
+++ b/pkg/multicloud/google/s3object.go
@@ -124,7 +124,7 @@ func (region *SRegion) ConvertAcl(acls []GCSAcl) cloudprovider.TBucketACLType {
 
 func (o *SObject) GetAcl() cloudprovider.TBucketACLType {
 	if strings.HasSuffix(o.Name, "/") {
-		return cloudprovider.ACLUnknown
+		return cloudprovider.ACLPrivate
 	}
 	acls, err := o.bucket.region.GetObjectAcl(o.bucket.Name, o.Name)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
gcp bucket文件夹默认设为private


**是否需要 backport 到之前的 release 分支**:
- release/3.2

/area region
/cc @zexi 
