### PR TITLE
Automated cherry pick of #6531: fix: gcp bucket文件夹默认设为private

### DIFF
--- a/pkg/multicloud/google/s3object.go
+++ b/pkg/multicloud/google/s3object.go
@@ -124,7 +124,7 @@ func (region *SRegion) ConvertAcl(acls []GCSAcl) cloudprovider.TBucketACLType {
 
 func (o *SObject) GetAcl() cloudprovider.TBucketACLType {
 	if strings.HasSuffix(o.Name, "/") {
-		return cloudprovider.ACLUnknown
+		return cloudprovider.ACLPrivate
 	}
 	acls, err := o.bucket.region.GetObjectAcl(o.bucket.Name, o.Name)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #6531 on release/3.2.

#6531: fix: gcp bucket文件夹默认设为private