### PR TITLE
Automated cherry pick of #6684: fix: gcp path escape for object

### DIFF
--- a/pkg/multicloud/google/bucket.go
+++ b/pkg/multicloud/google/bucket.go
@@ -227,7 +227,7 @@ func (b *SBucket) AbortMultipartUpload(ctx context.Context, key string, uploadId
 }
 
 func (b *SBucket) CompleteMultipartUpload(ctx context.Context, key string, uploadId string, partEtags []string) error {
-	resource := fmt.Sprintf("b/%s/o/%s", b.Name, key)
+	resource := fmt.Sprintf("b/%s/o/%s", b.Name, url.PathEscape(key))
 	err := b.region.StorageGet(resource, nil)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get object %s", key)
@@ -236,8 +236,8 @@ func (b *SBucket) CompleteMultipartUpload(ctx context.Context, key string, uploa
 }
 
 func (b *SBucket) CopyObject(ctx context.Context, destKey string, srcBucket, srcKey string, cannedAcl cloudprovider.TBucketACLType, storageClassStr string, meta http.Header) error {
-	resource := fmt.Sprintf("b/%s/o/%s", srcBucket, srcKey)
-	action := fmt.Sprintf("copyTo/b/%s/o/%s", b.Name, destKey)
+	resource := fmt.Sprintf("b/%s/o/%s", srcBucket, url.PathEscape(srcKey))
+	action := fmt.Sprintf("copyTo/b/%s/o/%s", b.Name, url.PathEscape(destKey))
 	err := b.region.StorageDo(resource, action, nil, nil)
 	if err != nil {
 		return errors.Wrap(err, "CopyObject")
@@ -267,7 +267,7 @@ func (b *SBucket) DeleteObject(ctx context.Context, key string) error {
 }
 
 func (region *SRegion) DownloadObjectRange(bucket, object string, start, end int64) (io.ReadCloser, error) {
-	resource := fmt.Sprintf("b/%s/o/%s?alt=media", bucket, object)
+	resource := fmt.Sprintf("b/%s/o/%s?alt=media", bucket, url.PathEscape(object))
 	header := http.Header{}
 	if start <= 0 {
 		if end > 0 {

--- a/pkg/multicloud/google/bucketacl.go
+++ b/pkg/multicloud/google/bucketacl.go
@@ -16,6 +16,7 @@ package google
 
 import (
 	"fmt"
+	"net/url"
 
 	"cloud.google.com/go/storage"
 
@@ -47,7 +48,7 @@ func (region *SRegion) GetBucketAcl(bucket string) ([]GCSAcl, error) {
 }
 
 func (region *SRegion) SetObjectAcl(bucket, object string, cannedAcl cloudprovider.TBucketACLType) error {
-	resource := fmt.Sprintf("b/%s/o/%s", bucket, object)
+	resource := fmt.Sprintf("b/%s/o/%s", bucket, url.PathEscape(object))
 	acl := map[string]string{}
 	switch cannedAcl {
 	case cloudprovider.ACLPrivate:
@@ -57,7 +58,7 @@ func (region *SRegion) SetObjectAcl(bucket, object string, cannedAcl cloudprovid
 		}
 		for _, _acl := range acls {
 			if _acl.Entity == string(storage.AllUsers) || _acl.Entity == string(storage.AllAuthenticatedUsers) {
-				resource := fmt.Sprintf("b/%s/o/%s/acl/%s", bucket, object, _acl.Entity)
+				resource := fmt.Sprintf("b/%s/o/%s/acl/%s", bucket, url.PathEscape(object), _acl.Entity)
 				err = region.StorageDelete(resource)
 				if err != nil {
 					return errors.Wrapf(err, "StorageDelete(%s)", resource)
@@ -120,7 +121,7 @@ func (region *SRegion) SetBucketIam(bucket string, iam *SBucketIam) (*SBucketIam
 }
 
 func (region *SRegion) GetObjectAcl(bucket string, object string) ([]GCSAcl, error) {
-	resource := fmt.Sprintf("b/%s/o/%s/acl", bucket, object)
+	resource := fmt.Sprintf("b/%s/o/%s/acl", bucket, url.PathEscape(object))
 	acls := []GCSAcl{}
 	err := region.StorageListAll(resource, map[string]string{}, &acls)
 	if err != nil {

--- a/pkg/multicloud/google/s3object.go
+++ b/pkg/multicloud/google/s3object.go
@@ -33,6 +33,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -197,7 +198,7 @@ func (region *SRegion) SetObjectMeta(bucket, object string, meta http.Header) er
 			body[fmt.Sprintf("metadata.%s", k)] = meta.Get(k)
 		}
 	}
-	resource := fmt.Sprintf("b/%s/o/%s", bucket, object)
+	resource := fmt.Sprintf("b/%s/o/%s", bucket, url.PathEscape(object))
 	return region.StoragePut(resource, jsonutils.Marshal(body), nil)
 }
 


### PR DESCRIPTION
Cherry pick of #6684 on release/3.2.

#6684: fix: gcp path escape for object