### PR TITLE
Automated cherry pick of #6702: fix: gcp默认创建允许所有地址访问的用户

### DIFF
--- a/pkg/multicloud/google/dbinstance.go
+++ b/pkg/multicloud/google/dbinstance.go
@@ -498,7 +498,7 @@ func (rds *SDBInstance) CreateDatabase(conf *cloudprovider.SDBInstanceDatabaseCr
 }
 
 func (rds *SDBInstance) CreateAccount(conf *cloudprovider.SDBInstanceAccountCreateConfig) error {
-	return rds.region.CreateDBInstanceAccount(rds.SelfLink, conf.Name, conf.Password, "")
+	return rds.region.CreateDBInstanceAccount(rds.SelfLink, conf.Name, conf.Password, "%")
 }
 
 func (rds *SDBInstance) CreateIBackup(conf *cloudprovider.SDBInstanceBackupCreateConfig) (string, error) {


### PR DESCRIPTION
Cherry pick of #6702 on release/3.2.

#6702: fix: gcp默认创建允许所有地址访问的用户