### PR TITLE
fix: 允许gcp创建vpc时不指定cidr

### DIFF
--- a/pkg/compute/models/regiondrivers.go
+++ b/pkg/compute/models/regiondrivers.go
@@ -86,6 +86,7 @@ type IRegionDriver interface {
 	RequestDeleteLoadbalancerListenerRule(ctx context.Context, userCred mcclient.TokenCredential, lbr *SLoadbalancerListenerRule, task taskman.ITask) error
 
 	ValidateCreateVpcData(ctx context.Context, userCred mcclient.TokenCredential, input api.VpcCreateInput) (api.VpcCreateInput, error)
+	IsVpcCreateNeedInputCidr() bool
 	ValidateCreateEipData(ctx context.Context, userCred mcclient.TokenCredential, input *api.SElasticipCreateInput) error
 	RequestCreateVpc(ctx context.Context, userCred mcclient.TokenCredential, region *SCloudregion, vpc *SVpc, task taskman.ITask) error
 	RequestDeleteVpc(ctx context.Context, userCred mcclient.TokenCredential, region *SCloudregion, vpc *SVpc, task taskman.ITask) error

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -78,7 +78,7 @@ type SVpc struct {
 
 	// CIDR地址段
 	// example: 192.168.222.0/24
-	CidrBlock string `charset:"ascii" nullable:"true" list:"domain" create:"domain_required"`
+	CidrBlock string `charset:"ascii" nullable:"true" list:"domain" create:"domain_optional"`
 
 	// 区域Id
 	// CloudregionId string `width:"36" charset:"ascii" nullable:"false" list:"domain" create:"domain_required" default:"default"`
@@ -658,6 +658,10 @@ func (manager *SVpcManager) ValidateCreateData(
 	input, err = region.GetDriver().ValidateCreateVpcData(ctx, userCred, input)
 	if err != nil {
 		return input, errors.Wrapf(err, "region.GetDriver().ValidateCreateVpcData")
+	}
+
+	if region.GetDriver().IsVpcCreateNeedInputCidr() && len(input.CidrBlock) == 0 {
+		return input, httperrors.NewMissingParameterError("cidr")
 	}
 
 	keys := GetVpcQuotaKeysFromCreateInput(input)

--- a/pkg/compute/regiondrivers/base.go
+++ b/pkg/compute/regiondrivers/base.go
@@ -203,6 +203,10 @@ func (self *SBaseRegionDriver) RequestBingToNatgateway(ctx context.Context, task
 	return fmt.Errorf("Not implement RequestBindIPToNatgateway")
 }
 
+func (self *SBaseRegionDriver) IsVpcCreateNeedInputCidr() bool {
+	return true
+}
+
 func (self *SBaseRegionDriver) RequestCreateVpc(ctx context.Context, userCred mcclient.TokenCredential, region *models.SCloudregion, vpc *models.SVpc, task taskman.ITask) error {
 	return fmt.Errorf("Not implement RequestCreateVpc")
 }

--- a/pkg/compute/regiondrivers/google.go
+++ b/pkg/compute/regiondrivers/google.go
@@ -53,6 +53,10 @@ func (self *SGoogleRegionDriver) IsVpcBelongGlobalVpc() bool {
 	return true
 }
 
+func (self *SGoogleRegionDriver) IsVpcCreateNeedInputCidr() bool {
+	return false
+}
+
 func (self *SGoogleRegionDriver) RequestCreateVpc(ctx context.Context, userCred mcclient.TokenCredential, region *models.SCloudregion, vpc *models.SVpc, task taskman.ITask) error {
 	taskman.LocalTaskRun(task, func() (jsonutils.JSONObject, error) {
 		provider := vpc.GetCloudprovider()

--- a/pkg/compute/regiondrivers/openstack.go
+++ b/pkg/compute/regiondrivers/openstack.go
@@ -39,6 +39,10 @@ func (self *SOpenStackRegionDriver) GetProvider() string {
 	return api.CLOUD_PROVIDER_OPENSTACK
 }
 
+func (self *SOpenStackRegionDriver) IsVpcCreateNeedInputCidr() bool {
+	return false
+}
+
 func (self *SOpenStackRegionDriver) ValidateCreateLoadbalancerData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 	return nil, httperrors.NewNotImplementedError("%s does not currently support creating loadbalancer", self.GetProvider())
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
 允许gcp创建vpc时不指定cidr

**是否需要 backport 到之前的 release 分支**:
- release/3.2

/area region
/cc @zexi 