### PR TITLE
Automated cherry pick of #7177: fix: 避免华为云安全组规则删除失败

### DIFF
--- a/pkg/multicloud/huawei/region.go
+++ b/pkg/multicloud/huawei/region.go
@@ -712,7 +712,16 @@ func (self *SRegion) CreateSecurityGroup(vpcId string, name string, desc string)
 
 // https://support.huaweicloud.com/api-vpc/zh-cn_topic_0087467071.html
 func (self *SRegion) delSecurityGroupRule(secGrpRuleId string) error {
-	return DoDelete(self.ecsClient.SecurityGroupRules.Delete, secGrpRuleId, nil, nil)
+	_, err := self.ecsClient.SecurityGroupRules.DeleteInContextWithSpec(nil, secGrpRuleId, "", nil, nil, "")
+	return err
+}
+
+func (self *SRegion) DeleteSecurityGroupRule(ruleId string) error {
+	return self.delSecurityGroupRule(ruleId)
+}
+
+func (self *SRegion) CreateSecurityGroupRule(secgroupId string, rule cloudprovider.SecurityRule) error {
+	return self.addSecurityGroupRules(secgroupId, rule)
 }
 
 // https://support.huaweicloud.com/api-vpc/zh-cn_topic_0087451723.html

--- a/pkg/multicloud/huawei/shell/secgroup.go
+++ b/pkg/multicloud/huawei/shell/secgroup.go
@@ -15,6 +15,10 @@
 package shell
 
 import (
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/secrules"
+
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud/huawei"
 	"yunion.io/x/onecloud/pkg/util/shellutils"
 )
@@ -57,6 +61,30 @@ func init() {
 		}
 		printObject(result)
 		return nil
+	})
+
+	type SecurityGroupRuleIdOptions struct {
+		ID string
+	}
+
+	shellutils.R(&SecurityGroupRuleIdOptions{}, "security-group-rule-delete", "Delete security group rule", func(cli *huawei.SRegion, args *SecurityGroupRuleIdOptions) error {
+		return cli.DeleteSecurityGroupRule(args.ID)
+	})
+
+	type SecurityGroupRuleCreateOptions struct {
+		SECGROUP_ID string
+		RULE        string
+	}
+
+	shellutils.R(&SecurityGroupRuleCreateOptions{}, "security-group-rule-create", "Create security group rule", func(cli *huawei.SRegion, args *SecurityGroupRuleCreateOptions) error {
+		_rule, err := secrules.ParseSecurityRule(args.RULE)
+		if err != nil {
+			return errors.Wrapf(err, "invalid rule %s", args.RULE)
+		}
+		rule := cloudprovider.SecurityRule{
+			SecurityRule: *_rule,
+		}
+		return cli.CreateSecurityGroupRule(args.SECGROUP_ID, rule)
 	})
 
 }


### PR DESCRIPTION
Cherry pick of #7177 on release/3.2.

#7177: fix: 避免华为云安全组规则删除失败