### PR TITLE
fix: 避免在仅调整虚拟机磁盘时opslog日志记录mem cpu异常

### DIFF
--- a/pkg/compute/tasks/guest_change_config_task.go
+++ b/pkg/compute/tasks/guest_change_config_task.go
@@ -199,10 +199,10 @@ func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecComplete(ctx context.C
 		return
 	}
 	changeConfigSpec := jsonutils.NewDict()
-	if addCpu != 0 {
+	if vcpuCount > 0 && addCpu != 0 {
 		changeConfigSpec.Set("add_cpu", jsonutils.NewInt(int64(addCpu)))
 	}
-	if addMem != 0 {
+	if vmemSize > 0 && addMem != 0 {
 		changeConfigSpec.Set("add_mem", jsonutils.NewInt(int64(addMem)))
 	}
 	if len(instanceType) > 0 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: 避免在仅调整虚拟机磁盘时opslog日志记录mem cpu异常


**是否需要 backport 到之前的 release 分支**:
- release/3.2

/area region
/cc @zexi 
