### PR TITLE
fix: avoid virtual resource project id is empty when cloudaccount wit…

### DIFF
--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -1222,7 +1222,7 @@ func SyncCloudProject(userCred mcclient.TokenCredential, model db.IVirtualModel,
 		extProject, err := ExternalProjectManager.GetProject(extProjectId, managerId)
 		if err != nil {
 			log.Errorf("sync project for %s %s error: %v", model.Keyword(), model.GetName(), err)
-		} else {
+		} else if len(extProject.ProjectId) > 0 {
 			newOwnerId = extProject.GetOwnerId()
 		}
 	}


### PR DESCRIPTION
avoid virtual resource project id is empty when cloudaccount with no project

**这个 PR 实现什么功能/修复什么问题**:


- [x] 功能、bugfix描述
- [x] 冒烟测试
- [ ] 单元测试编写


**是否需要 backport 到之前的 release 分支**:
- release/3.2

/area region
/cc @zexi 
