### PR TITLE
Automated cherry pick of #7560: fix: avoid virtual resource project id is empty when cloudaccount with no project

### DIFF
--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -1229,7 +1229,7 @@ func SyncCloudProject(userCred mcclient.TokenCredential, model db.IVirtualModel,
 		extProject, err := ExternalProjectManager.GetProject(extProjectId, managerId)
 		if err != nil {
 			log.Errorf("sync project for %s %s error: %v", model.Keyword(), model.GetName(), err)
-		} else {
+		} else if len(extProject.ProjectId) > 0 {
 			newOwnerId = extProject.GetOwnerId()
 		}
 	}


### PR DESCRIPTION
Cherry pick of #7560 on release/3.3.

#7560: fix: avoid virtual resource project id is empty when cloudaccount with no project