### PR TITLE
fix: limit the length of error message when do idp redirect

### DIFF
--- a/pkg/apigateway/handler/idp.go
+++ b/pkg/apigateway/handler/idp.go
@@ -241,6 +241,10 @@ func generateRedirectUrl(originUrl *url.URL, stateQs jsonutils.JSONObject, err e
 			errCls = errors.Cause(err).Error()
 			errDetails = err.Error()
 		}
+		msgLen := 100
+		if len(errDetails) > msgLen {
+			errDetails = errDetails[:msgLen] + "..."
+		}
 		qs.(*jsonutils.JSONDict).Add(jsonutils.NewString(errCls), "error_class")
 		qs.(*jsonutils.JSONDict).Add(jsonutils.NewString(errDetails), "error_details")
 		qs.(*jsonutils.JSONDict).Add(jsonutils.NewString("error"), "result")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：限制idp错误redirect的err message长度，可能导致请求URL过长，导致网关502

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area apigateway