### PR TITLE
fix: hide locked cloud policy by default

### DIFF
--- a/pkg/apis/cloudid/cloudpolicy.go
+++ b/pkg/apis/cloudid/cloudpolicy.go
@@ -54,6 +54,9 @@ type CloudpolicyListInput struct {
 	// | system  |  过滤系统权限		|
 	// | custom  |  过滤自定义权限      |
 	PolicyType string `json:"policy_type"`
+
+	// 是否显示Locked的权限
+	Locked *bool `json:"locked"`
 }
 
 type CloudpolicyDetails struct {

--- a/pkg/cloudid/models/cloudpolicy.go
+++ b/pkg/cloudid/models/cloudpolicy.go
@@ -147,6 +147,10 @@ func (manager *SCloudpolicyManager) ListItemFilter(ctx context.Context, q *sqlch
 		q = q.In("id", sq.SubQuery())
 	}
 
+	if query.Locked == nil || !*query.Locked {
+		q = q.IsFalse("locked")
+	}
+
 	return q, nil
 }
 

--- a/pkg/mcclient/modules/mod_cloudpolicy.go
+++ b/pkg/mcclient/modules/mod_cloudpolicy.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	Cloudpolicies = NewCloudIdManager("cloudpolicy", "cloudpolicies",
-		[]string{},
+		[]string{"id", "name", "description", "domain_id", "domain", "public_scope", "policy_type", "status", "locked"},
 		[]string{})
 
 	register(&Cloudpolicies)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：缺省过滤locked的云上权限

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @ioito @zexi 
/area cloudid
