### PR TITLE
fix: ignore invalid zone sku for rds sku sync

### DIFF
--- a/pkg/compute/models/skus_tools.go
+++ b/pkg/compute/models/skus_tools.go
@@ -72,9 +72,10 @@ func (self *SSkuResourcesMeta) GetDBInstanceSkusByRegionExternalId(regionExterna
 			return nil, errors.Wrapf(err, "obj.Unmarshal")
 		}
 		if len(sku.Zone1) > 0 {
-			zoneId := self.getZoneIdBySuffix(zoneMaps, sku.Zone1)
+			zoneId := self.getZoneIdBySuffix(zoneMaps, sku.Zone1) // Huawei rds sku zone1 maybe is cn-north-4f
 			if len(zoneId) == 0 {
-				return nil, fmt.Errorf("invalid sku %s %s zone1: %s", sku.Id, sku.CloudregionId, sku.Zone1)
+				log.Errorf("invalid sku %s(%s) %s zone1: %s", sku.Name, sku.Id, sku.CloudregionId, sku.Zone1)
+				continue
 			}
 			sku.Zone1 = zoneId
 		}
@@ -82,7 +83,8 @@ func (self *SSkuResourcesMeta) GetDBInstanceSkusByRegionExternalId(regionExterna
 		if len(sku.Zone2) > 0 {
 			zoneId := self.getZoneIdBySuffix(zoneMaps, sku.Zone2)
 			if len(zoneId) == 0 {
-				return nil, fmt.Errorf("invalid sku %s %s zone2: %s", sku.Id, sku.CloudregionId, sku.Zone2)
+				log.Errorf("invalid sku %s(%s) %s zone2: %s", sku.Name, sku.Id, sku.CloudregionId, sku.Zone2)
+				continue
 			}
 			sku.Zone2 = zoneId
 		}
@@ -90,7 +92,8 @@ func (self *SSkuResourcesMeta) GetDBInstanceSkusByRegionExternalId(regionExterna
 		if len(sku.Zone3) > 0 {
 			zoneId := self.getZoneIdBySuffix(zoneMaps, sku.Zone3)
 			if len(zoneId) == 0 {
-				return nil, fmt.Errorf("invalid sku %s %s zone3: %s", sku.Id, sku.CloudregionId, sku.Zone3)
+				log.Errorf("invalid sku %s(%s) %s zone3: %s", sku.Name, sku.Id, sku.CloudregionId, sku.Zone3)
+				continue
 			}
 			sku.Zone3 = zoneId
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: ignore invalid zone sku for rds sku sync

**是否需要 backport 到之前的 release 分支**:
- release/3.3

/area region
/cc @zexi 
