### PR TITLE
Automated cherry pick of #7664: fix: avoid delete aws iam user failed

### DIFF
--- a/pkg/multicloud/aws/iam_user.go
+++ b/pkg/multicloud/aws/iam_user.go
@@ -220,6 +220,7 @@ func (self *SAwsClient) CreateUser(path string, username string) (*SUser, error)
 }
 
 func (self *SAwsClient) DeleteUser(name string) error {
+	self.DeleteLoginProfile(name)
 	params := map[string]string{
 		"UserName": name,
 	}


### PR DESCRIPTION
Cherry pick of #7664 on release/3.4.

#7664: fix: avoid delete aws iam user failed