### PR TITLE
fix: avoid sync natgateway eip panic

### DIFF
--- a/pkg/compute/models/elasticips.go
+++ b/pkg/compute/models/elasticips.go
@@ -426,8 +426,11 @@ func (self *SElasticip) SyncInstanceWithCloudEip(ctx context.Context, userCred m
 			case api.EIP_ASSOCIATE_TYPE_SERVER:
 				sq := HostManager.Query().SubQuery()
 				return q.Join(sq, sqlchemy.Equals(sq.Field("id"), q.Field("host_id"))).Filter(sqlchemy.Equals(sq.Field("manager_id"), self.ManagerId))
-			case api.EIP_ASSOCIATE_TYPE_NAT_GATEWAY, api.EIP_ASSOCIATE_TYPE_LOADBALANCER:
+			case api.EIP_ASSOCIATE_TYPE_LOADBALANCER:
 				return q.Equals("manager_id", self.ManagerId)
+			case api.EIP_ASSOCIATE_TYPE_NAT_GATEWAY:
+				sq := VpcManager.Query("id").Equals("manager_id", self.ManagerId)
+				return q.In("vpc_id", sq.SubQuery())
 			}
 			return q
 		})


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: avoid sync natgateway eip panic


**是否需要 backport 到之前的 release 分支**:
- release/3.2

/area region
/cc @zexi 