### PR TITLE
Automated cherry pick of #8056: fix: 仅在可用区故障时可强制挂载磁盘

### DIFF
--- a/pkg/multicloud/google/instance.go
+++ b/pkg/multicloud/google/instance.go
@@ -783,7 +783,7 @@ func (region *SRegion) AttachDisk(instanceId, diskId string, boot bool) error {
 	if boot {
 		body["autoDelete"] = true
 	}
-	params := map[string]string{"forceAttach": "true"}
+	params := map[string]string{}
 	return region.Do(instanceId, "attachDisk", params, jsonutils.Marshal(body))
 }
 


### PR DESCRIPTION
Cherry pick of #8056 on release/3.4.

#8056: fix: 仅在可用区故障时可强制挂载磁盘