### PR TITLE
Automated cherry pick of #8084: fix: openstack zone not emulated

### DIFF
--- a/pkg/multicloud/openstack/zone.go
+++ b/pkg/multicloud/openstack/zone.go
@@ -61,7 +61,7 @@ func (zone *SZone) GetGlobalId() string {
 }
 
 func (zone *SZone) IsEmulated() bool {
-	return true
+	return false
 }
 
 func (zone *SZone) GetStatus() string {


### PR DESCRIPTION
Cherry pick of #8084 on release/3.4.

#8084: fix: openstack zone not emulated