### PR TITLE
Automated cherry pick of #8149: fix: allow domain admin view shared dns zone records

### DIFF
--- a/pkg/compute/models/dns_recordsets.go
+++ b/pkg/compute/models/dns_recordsets.go
@@ -387,6 +387,14 @@ func (manager *SDnsRecordSetManager) ResourceScope() rbacutils.TRbacScope {
 	return rbacutils.ScopeDomain
 }
 
+func (self *SDnsRecordSet) IsSharable(reqUsrId mcclient.IIdentityProvider) bool {
+	dnsZone, err := self.GetDnsZone()
+	if err != nil {
+		return false
+	}
+	return dnsZone.IsSharable(reqUsrId)
+}
+
 func (self *SDnsRecordSet) GetOwnerId() mcclient.IIdentityProvider {
 	dnsZone, err := self.GetDnsZone()
 	if err != nil {

--- a/pkg/compute/policy/defaults.go
+++ b/pkg/compute/policy/defaults.go
@@ -131,6 +131,18 @@ var (
 					Action:   PolicyActionList,
 					Result:   rbacutils.Allow,
 				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "dns_recordsets",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "dns_recodsets",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Cherry pick of #8149 on release/3.4.

#8149: fix: allow domain admin view shared dns zone records