### PR TITLE
fix: 允许域管理员可以看到共享的dns zone cache列表

### DIFF
--- a/pkg/compute/policy/defaults.go
+++ b/pkg/compute/policy/defaults.go
@@ -143,6 +143,18 @@ var (
 					Action:   PolicyActionGet,
 					Result:   rbacutils.Allow,
 				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "dns_zonecaches",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "dns_zonecaches",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: 允许域管理员可以看到共享的dns zone cache列表

- [x] 功能、bugfix描述
- [x] 冒烟测试
- [ ] 单元测试编写

**是否需要 backport 到之前的 release 分支**:
- release/3.4

/area region
/cc @swordqiu 
