### PR TITLE
Automated cherry pick of #8171: fix: 允许域管理员可以看到共享的dns zone cache列表

### DIFF
--- a/pkg/compute/policy/defaults.go
+++ b/pkg/compute/policy/defaults.go
@@ -143,6 +143,18 @@ var (
 					Action:   PolicyActionGet,
 					Result:   rbacutils.Allow,
 				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "dns_zonecaches",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "dns_zonecaches",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Cherry pick of #8171 on release/3.4.

#8171: fix: 允许域管理员可以看到共享的dns zone cache列表