### PR TITLE
Automated cherry pick of #8188: fix: avoid qcloud secgroup cache name not sync

### DIFF
--- a/pkg/multicloud/qcloud/region.go
+++ b/pkg/multicloud/qcloud/region.go
@@ -931,11 +931,19 @@ func (region *SRegion) GetIBucketByName(name string) (cloudprovider.ICloudBucket
 }
 
 func (self *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICloudSecurityGroup, error) {
-	return self.GetSecurityGroupDetails(secgroupId)
+	secgroups, total, err := self.GetSecurityGroups([]string{secgroupId}, "", "", 0, 1)
+	if err != nil {
+		return nil, errors.Wrapf(err, "GetSecurityGroups(%s)", secgroupId)
+	}
+	if total < 1 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	secgroups[0].region = self
+	return &secgroups[0], nil
 }
 
 func (self *SRegion) GetISecurityGroupByName(opts *cloudprovider.SecurityGroupFilterOptions) (cloudprovider.ICloudSecurityGroup, error) {
-	secgroups, total, err := self.GetSecurityGroups(opts.VpcId, opts.Name, 0, 0)
+	secgroups, total, err := self.GetSecurityGroups([]string{}, opts.VpcId, opts.Name, 0, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/qcloud/shell/securitygroup.go
+++ b/pkg/multicloud/qcloud/shell/securitygroup.go
@@ -25,12 +25,14 @@ import (
 
 func init() {
 	type SecurityGroupListOptions struct {
-		Name   string `help:"Secgroup Name"`
-		Limit  int    `help:"page size"`
-		Offset int    `help:"page offset"`
+		Ids    []string `help:"Secgroup Ids"`
+		VpcId  string   `help:"Vpc Id"`
+		Name   string   `help:"Secgroup Name"`
+		Limit  int      `help:"page size"`
+		Offset int      `help:"page offset"`
 	}
 	shellutils.R(&SecurityGroupListOptions{}, "security-group-list", "List SecurityGroup", func(cli *qcloud.SRegion, args *SecurityGroupListOptions) error {
-		secgrps, total, err := cli.GetSecurityGroups("", args.Name, args.Limit, args.Offset)
+		secgrps, total, err := cli.GetSecurityGroups(args.Ids, args.VpcId, args.Name, args.Limit, args.Offset)
 		if err != nil {
 			return err
 		}
@@ -42,12 +44,15 @@ func init() {
 		ID string `help:"SecurityGroup ID"`
 	}
 	shellutils.R(&SecurityGroupOptions{}, "security-group-show", "Show SecurityGroup", func(cli *qcloud.SRegion, args *SecurityGroupOptions) error {
-		secgroup, err := cli.GetSecurityGroupDetails(args.ID)
+		secgroups, _, err := cli.GetSecurityGroups([]string{args.ID}, "", "", 0, 1)
 		if err != nil {
 			return err
 		}
-		printObject(secgroup)
-		return nil
+		if len(secgroups) == 1 {
+			printObject(secgroups[0])
+			return nil
+		}
+		return cloudprovider.ErrNotFound
 	})
 
 	shellutils.R(&SecurityGroupOptions{}, "security-group-delete", "Delete SecurityGroup", func(cli *qcloud.SRegion, args *SecurityGroupOptions) error {

--- a/pkg/multicloud/qcloud/vpc.go
+++ b/pkg/multicloud/qcloud/vpc.go
@@ -86,7 +86,7 @@ func (self *SVpc) Delete() error {
 func (self *SVpc) GetISecurityGroups() ([]cloudprovider.ICloudSecurityGroup, error) {
 	secgroups := make([]SSecurityGroup, 0)
 	for {
-		parts, total, err := self.region.GetSecurityGroups(self.VpcId, "", len(secgroups), 50)
+		parts, total, err := self.region.GetSecurityGroups([]string{}, self.VpcId, "", len(secgroups), 50)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Cherry pick of #8188 on release/3.4.

#8188: fix: avoid qcloud secgroup cache name not sync