### PR TITLE
fix: aws secgroup out rule is deny any

### DIFF
--- a/pkg/cloudprovider/securitygroup.go
+++ b/pkg/cloudprovider/securitygroup.go
@@ -125,9 +125,6 @@ func AddDefaultRule(rules []SecurityRule, defaultRule SecurityRule, localRuleStr
 		defaultRule.Priority = max
 	}
 	defaultRule.Priority -= int(order)
-	if onlyAllowRules {
-		defaultRule.Priority = -1
-	}
 	return append(rules, defaultRule)
 }
 

--- a/pkg/compute/regiondrivers/aws.go
+++ b/pkg/compute/regiondrivers/aws.go
@@ -60,7 +60,7 @@ func (self *SAwsRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.Secu
 }
 
 func (self *SAwsRegionDriver) GetDefaultSecurityGroupOutRule() cloudprovider.SecurityRule {
-	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("out:allow any")}
+	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("out:deny any")}
 }
 
 func (self *SAwsRegionDriver) GetSecurityGroupRuleMaxPriority() int {

--- a/pkg/compute/regiondrivers/secgroup_aws_test.go
+++ b/pkg/compute/regiondrivers/secgroup_aws_test.go
@@ -34,7 +34,7 @@ func TestAwsRuleSync(t *testing.T) {
 
 	data := []TestData{
 		{
-			Name: "Test out deny rules",
+			Name: "Test remove out allow rules",
 			LocalRules: secrules.SecurityRuleSet{
 				localRuleWithPriority("out:deny any", 1),
 			},
@@ -48,6 +48,30 @@ func TestAwsRuleSync(t *testing.T) {
 			OutDels: []cloudprovider.SecurityRule{
 				remoteRuleWithName("", "out:allow any", 1),
 			},
+		},
+		{
+			Name: "Test out deny rules",
+			LocalRules: secrules.SecurityRuleSet{
+				localRuleWithPriority("out:deny any", 1),
+			},
+			RemoteRules: []cloudprovider.SecurityRule{},
+			Common:      []cloudprovider.SecurityRule{},
+			InAdds:      []cloudprovider.SecurityRule{},
+			OutAdds:     []cloudprovider.SecurityRule{},
+			InDels:      []cloudprovider.SecurityRule{},
+			OutDels:     []cloudprovider.SecurityRule{},
+		},
+		{
+			Name:        "Test out allow rules",
+			LocalRules:  secrules.SecurityRuleSet{},
+			RemoteRules: []cloudprovider.SecurityRule{},
+			Common:      []cloudprovider.SecurityRule{},
+			InAdds:      []cloudprovider.SecurityRule{},
+			OutAdds: []cloudprovider.SecurityRule{
+				remoteRuleWithName("", "out:allow any", 0),
+			},
+			InDels:  []cloudprovider.SecurityRule{},
+			OutDels: []cloudprovider.SecurityRule{},
 		},
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: aws secgroup out rule is deny any

- [x] 功能、bugfix描述
- [x] 冒烟测试
- [ ] 单元测试编写

**是否需要 backport 到之前的 release 分支**:
- release/3.3

/area region
/cc @zexi 