### PR TITLE
fix: avoid check region log every time when account status is unknown

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -2413,8 +2413,10 @@ func (account *SCloudaccount) probeAccountStatus(ctx context.Context, userCred m
 		case cloudprovider.ErrNoBalancePermission:
 			status = api.CLOUD_PROVIDER_HEALTH_NO_PERMISSION
 		default:
-			log.Errorf("manager.GetBalance %s fail %s", account.Name, err)
 			status = api.CLOUD_PROVIDER_HEALTH_UNKNOWN
+			if account.Status != status {
+				logclient.AddSimpleActionLog(account, logclient.ACT_PROBE, errors.Wrapf(err, "GetBalance"), userCred, false)
+			}
 		}
 	}
 	version := manager.GetVersion()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
 avoid check region log every time when account status is unknown

- [x] 功能、bugfix描述
- [x] 冒烟测试
- [ ] 单元测试编写

**是否需要 backport 到之前的 release 分支**:
- release/3.5

/area region
/cc @zexi 
