### PR TITLE
Automated cherry pick of #8747: fix: avoid check region log every time when account status is unknown

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -2413,8 +2413,10 @@ func (account *SCloudaccount) probeAccountStatus(ctx context.Context, userCred m
 		case cloudprovider.ErrNoBalancePermission:
 			status = api.CLOUD_PROVIDER_HEALTH_NO_PERMISSION
 		default:
-			log.Errorf("manager.GetBalance %s fail %s", account.Name, err)
 			status = api.CLOUD_PROVIDER_HEALTH_UNKNOWN
+			if account.Status != status {
+				logclient.AddSimpleActionLog(account, logclient.ACT_PROBE, errors.Wrapf(err, "GetBalance"), userCred, false)
+			}
 		}
 	}
 	version := manager.GetVersion()


### PR DESCRIPTION
Cherry pick of #8747 on release/3.5.

#8747: fix: avoid check region log every time when account status is unknown