### PR TITLE
Automated cherry pick of #8973: fix(region): set qcloud instance del timeout to 20m

### DIFF
--- a/pkg/multicloud/qcloud/instance.go
+++ b/pkg/multicloud/qcloud/instance.go
@@ -751,7 +751,7 @@ func (self *SInstance) DeleteVM(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "region.DeleteVM(%s)", self.InstanceId)
 	}
-	return cloudprovider.WaitDeleted(self, 10*time.Second, 10*time.Minute) // 5minutes
+	return cloudprovider.WaitDeleted(self, 10*time.Second, 20*time.Minute) // 20minutes
 }
 
 func (self *SRegion) UpdateVM(instanceId string, name, osType string) error {


### PR DESCRIPTION
Cherry pick of #8973 on release/3.6.

#8973: fix(region): set qcloud instance del timeout to 20m