### PR TITLE
fix(cloudid): avoid new public account sync system policy delay 1 day

### DIFF
--- a/pkg/cloudid/models/cloudaccount.go
+++ b/pkg/cloudid/models/cloudaccount.go
@@ -172,6 +172,7 @@ func (manager *SCloudaccountManager) syncCloudaccounts(ctx context.Context, user
 			continue
 		}
 		account.StartSyncCloudIdResourcesTask(ctx, userCred, "")
+		account.StartSystemCloudpolicySyncTask(ctx, userCred, false, "") // 避免新加账号未能及时同步策略
 		localAccounts = append(localAccounts, *account)
 		result.Add()
 	}
@@ -763,7 +764,16 @@ func (self *SCloudaccount) GetCloudaccountByProvider(provider string) ([]SClouda
 	return accounts, nil
 }
 
-func (self *SCloudaccount) SyncSystemCloudpoliciesFromCloud(ctx context.Context, userCred mcclient.TokenCredential) error {
+func (self *SCloudaccount) SyncSystemCloudpoliciesFromCloud(ctx context.Context, userCred mcclient.TokenCredential, refresh bool) error {
+	dbPolicies, err := self.GetSystemCloudpolicies()
+	if err != nil {
+		return errors.Wrapf(err, "GetSystemCloudpolicies")
+	}
+
+	if len(dbPolicies) > 0 && !refresh {
+		return nil
+	}
+
 	factory, err := self.GetProviderFactory()
 	if err != nil {
 		return errors.Wrapf(err, "GetProviderFactory")
@@ -803,22 +813,18 @@ func (self *SCloudaccount) SyncSystemCloudpoliciesFromCloud(ctx context.Context,
 			return errors.Wrapf(err, "GetISystemCloudpolicies for account %s(%s)", self.Name, self.Provider)
 		}
 	}
-	return self.syncSystemCloudpoliciesFromCloud(ctx, userCred, iPolicies)
+	return self.syncSystemCloudpoliciesFromCloud(ctx, userCred, iPolicies, dbPolicies)
 }
 
-func (self *SCloudaccount) syncSystemCloudpoliciesFromCloud(ctx context.Context, userCred mcclient.TokenCredential, iPolicies []cloudprovider.ICloudpolicy) error {
+func (self *SCloudaccount) syncSystemCloudpoliciesFromCloud(ctx context.Context, userCred mcclient.TokenCredential, iPolicies []cloudprovider.ICloudpolicy, dbPolicies []SCloudpolicy) error {
 	result := compare.SyncResult{}
-	dbPolicies, err := self.GetSystemCloudpolicies()
-	if err != nil {
-		return errors.Wrapf(err, "GetSystemCloudpolicies")
-	}
 
 	removed := make([]SCloudpolicy, 0)
 	commondb := make([]SCloudpolicy, 0)
 	commonext := make([]cloudprovider.ICloudpolicy, 0)
 	added := make([]cloudprovider.ICloudpolicy, 0)
 
-	err = compare.CompareSets(dbPolicies, iPolicies, &removed, &commondb, &commonext, &added)
+	err := compare.CompareSets(dbPolicies, iPolicies, &removed, &commondb, &commonext, &added)
 	if err != nil {
 		return errors.Wrapf(err, "compare.CompareSets")
 	}
@@ -919,6 +925,9 @@ func (self *SCloudaccount) GetICloudprovider() ([]SCloudprovider, error) {
 }
 
 func (self *SCloudaccount) syncCloudprovider(ctx context.Context, userCred mcclient.TokenCredential) compare.SyncResult {
+	lockman.LockRawObject(ctx, "cloudproviders", self.Id)
+	defer lockman.ReleaseRawObject(ctx, "cloudproviders", self.Id)
+
 	result := compare.SyncResult{}
 
 	providers, err := self.GetICloudprovider()
@@ -1019,22 +1028,28 @@ func (manager *SCloudaccountManager) SyncCloudidSystemPolicies(ctx context.Conte
 		log.Errorf("GetSupportCloudIdAccounts error: %v", err)
 		return
 	}
+	providers := []string{}
 	for i := range accounts {
 		_, err := accounts[i].GetProvider() // 检查账号是否可以正常连接
 		if err != nil {
 			log.Errorf("GetProvider for account %s(%s) error: %v", accounts[i].Name, accounts[i].Provider, err)
 			continue
 		}
-		err = accounts[i].StartSystemCloudpolicySyncTask(ctx, userCred, "")
+		if utils.IsInStringArray(accounts[i].Provider, providers) {
+			continue
+		}
+		err = accounts[i].StartSystemCloudpolicySyncTask(ctx, userCred, true, "")
 		if err != nil {
 			log.Errorf("StartSystemCloudpolicySyncTask for account %s(%s) error: %v", accounts[i].Name, accounts[i].Provider, err)
 			continue
 		}
+		providers = append(providers, accounts[i].Provider)
 	}
 }
 
-func (self *SCloudaccount) StartSystemCloudpolicySyncTask(ctx context.Context, userCred mcclient.TokenCredential, parentTaskId string) error {
+func (self *SCloudaccount) StartSystemCloudpolicySyncTask(ctx context.Context, userCred mcclient.TokenCredential, refresh bool, parentTaskId string) error {
 	params := jsonutils.NewDict()
+	params.Add(jsonutils.NewBool(refresh), "refresh")
 	task, err := taskman.TaskManager.NewTask(ctx, "SystemCloudpolicySyncTask", self, userCred, params, parentTaskId, "", nil)
 	if err != nil {
 		return errors.Wrap(err, "NewTask")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免新建云账号权限同步周期太长

- [x] 功能、bugfix描述
- [x] 冒烟测试
- [ ] 单元测试编写

**是否需要 backport 到之前的 release 分支**:
- release/3.5

/area cloudid
/cc @zexi 