### PR TITLE
Automated cherry pick of #8998: fix(region): allow member user get saml auth addr

### DIFF
--- a/pkg/compute/policy/defaults.go
+++ b/pkg/compute/policy/defaults.go
@@ -155,6 +155,13 @@ var (
 					Action:   PolicyActionGet,
 					Result:   rbacutils.Allow,
 				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "cloudaccounts",
+					Action:   PolicyActionGet,
+					Extra:    []string{"saml"},
+					Result:   rbacutils.Allow,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Cherry pick of #8998 on release/3.6.

#8998: fix(region): allow member user get saml auth addr