### PR TITLE
Automated cherry pick of #9009: fix(climc): replace ' -> "

### DIFF
--- a/cmd/climc/shell/compute/cloudproviders.go
+++ b/cmd/climc/shell/compute/cloudproviders.go
@@ -235,7 +235,7 @@ func init() {
 			return err
 		}
 		for k, v := range rc {
-			fmt.Printf("export %s='%s'\n", k, v)
+			fmt.Printf(`export %s="%s"`+"\n", k, v)
 		}
 		return nil
 	})


### PR DESCRIPTION
Cherry pick of #9009 on release/3.6.

#9009: fix(climc): replace ' -> "