### PR TITLE
Automated cherry pick of #9217: fix(region): optimized qcloud secgroup sync, only redis need secgroup be in same project

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -329,7 +329,7 @@ func (self *SManagedVirtualizedGuestDriver) RequestDeployGuestOnHost(ctx context
 			return errors.Wrap(err, "GetSecgroups")
 		}
 		for i, secgroup := range secgroups {
-			externalId, err := region.GetDriver().RequestSyncSecurityGroup(ctx, task.GetUserCred(), vpcId, vpc, &secgroup, desc.ProjectId)
+			externalId, err := region.GetDriver().RequestSyncSecurityGroup(ctx, task.GetUserCred(), vpcId, vpc, &secgroup, desc.ProjectId, "")
 			if err != nil {
 				return errors.Wrap(err, "RequestSyncSecurityGroup")
 			}
@@ -998,7 +998,7 @@ func (self *SManagedVirtualizedGuestDriver) RequestSyncSecgroupsOnHost(ctx conte
 	}
 	externalIds := []string{}
 	for _, secgroup := range secgroups {
-		externalId, err := region.GetDriver().RequestSyncSecurityGroup(ctx, task.GetUserCred(), vpcId, vpc, &secgroup, remoteProjectId)
+		externalId, err := region.GetDriver().RequestSyncSecurityGroup(ctx, task.GetUserCred(), vpcId, vpc, &secgroup, remoteProjectId, "")
 		if err != nil {
 			return errors.Wrap(err, "RequestSyncSecurityGroup")
 		}

--- a/pkg/compute/models/regiondrivers.go
+++ b/pkg/compute/models/regiondrivers.go
@@ -126,7 +126,7 @@ type IRegionDriver interface {
 	BindIPToNatgatewayRollback(ctx context.Context, eipId string) error
 
 	RequestCacheSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, region *SCloudregion, vpc *SVpc, secgroup *SSecurityGroup, classic bool, removeProjectId string, task taskman.ITask) error
-	RequestSyncSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, vpcId string, vpc *SVpc, secgroup *SSecurityGroup, removeProjectId string) (string, error)
+	RequestSyncSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, vpcId string, vpc *SVpc, secgroup *SSecurityGroup, removeProjectId, service string) (string, error)
 	GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder // Desc(priority值越大,优先级越高) Asc(priority值越小,优先级越高)
 	GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule
 	GetDefaultSecurityGroupOutRule() cloudprovider.SecurityRule
@@ -139,7 +139,7 @@ type IRegionDriver interface {
 	IsSecurityGroupBelongGlobalVpc() bool //安全组子账号范围内可用
 	GetDefaultSecurityGroupVpcId() string
 	GetSecurityGroupVpcId(ctx context.Context, userCred mcclient.TokenCredential, region *SCloudregion, host *SHost, vpc *SVpc, classic bool) (string, error)
-	GetSecurityGroupPublicScope() rbacutils.TRbacScope
+	GetSecurityGroupPublicScope(service string) rbacutils.TRbacScope
 
 	IsSupportedBillingCycle(bc billing.SBillingCycle, resource string) bool
 	GetSecgroupVpcid(vpcId string) string

--- a/pkg/compute/regiondrivers/base.go
+++ b/pkg/compute/regiondrivers/base.go
@@ -251,7 +251,7 @@ func (self *SBaseRegionDriver) GetDefaultSecurityGroupVpcId() string {
 	return api.NORMAL_VPC_ID
 }
 
-func (self *SBaseRegionDriver) GetSecurityGroupPublicScope() rbacutils.TRbacScope {
+func (self *SBaseRegionDriver) GetSecurityGroupPublicScope(service string) rbacutils.TRbacScope {
 	return rbacutils.ScopeSystem
 }
 
@@ -259,7 +259,7 @@ func (self *SBaseRegionDriver) GetSecurityGroupVpcId(ctx context.Context, userCr
 	return "", cloudprovider.ErrNotImplemented
 }
 
-func (self *SBaseRegionDriver) RequestSyncSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, vpcId string, vpc *models.SVpc, secgroup *models.SSecurityGroup, removeProjectId string) (string, error) {
+func (self *SBaseRegionDriver) RequestSyncSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, vpcId string, vpc *models.SVpc, secgroup *models.SSecurityGroup, removeProjectId, service string) (string, error) {
 	return "", fmt.Errorf("Not Implemented RequestSyncSecurityGroup")
 }
 

--- a/pkg/compute/regiondrivers/openstack.go
+++ b/pkg/compute/regiondrivers/openstack.go
@@ -72,7 +72,7 @@ func (self *SOpenStackRegionDriver) IsOnlySupportAllowRules() bool {
 	return true
 }
 
-func (self *SOpenStackRegionDriver) GetSecurityGroupPublicScope() rbacutils.TRbacScope {
+func (self *SOpenStackRegionDriver) GetSecurityGroupPublicScope(service string) rbacutils.TRbacScope {
 	return rbacutils.ScopeProject
 }
 

--- a/pkg/compute/regiondrivers/qcloud.go
+++ b/pkg/compute/regiondrivers/qcloud.go
@@ -1628,8 +1628,11 @@ func (self *SQcloudRegionDriver) RequestCreateElasticcache(ctx context.Context, 
 	return nil
 }
 
-func (self *SQcloudRegionDriver) GetSecurityGroupPublicScope() rbacutils.TRbacScope {
-	return rbacutils.ScopeProject
+func (self *SQcloudRegionDriver) GetSecurityGroupPublicScope(service string) rbacutils.TRbacScope {
+	if service == "redis" {
+		return rbacutils.ScopeProject
+	}
+	return rbacutils.ScopeSystem
 }
 
 func (self *SQcloudRegionDriver) RequestSyncSecgroupsForElasticcache(ctx context.Context, userCred mcclient.TokenCredential, ec *models.SElasticcache, task taskman.ITask) error {
@@ -1659,7 +1662,7 @@ func (self *SQcloudRegionDriver) RequestSyncSecgroupsForElasticcache(ctx context
 			}
 
 			for i := range ess {
-				externalId, err := self.RequestSyncSecurityGroup(ctx, task.GetUserCred(), vpcId, vpc, ess[i].GetSecGroup(), extProjectId)
+				externalId, err := self.RequestSyncSecurityGroup(ctx, task.GetUserCred(), vpcId, vpc, ess[i].GetSecGroup(), extProjectId, "redis")
 				if err != nil {
 					return nil, errors.Wrap(err, "RequestSyncSecurityGroup")
 				}


### PR DESCRIPTION
Cherry pick of #9217 on release/3.5.

#9217: fix(region): optimized qcloud secgroup sync, only redis need secgroup be in same project