### PR TITLE
Automated cherry pick of #9285: fix(region): sync account id

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -2565,6 +2565,9 @@ func (account *SCloudaccount) probeAccountStatus(ctx context.Context, userCred m
 		if !options.Options.CloudaccountHealthStatusCheck {
 			status = api.CLOUD_PROVIDER_HEALTH_NORMAL
 		}
+		if len(account.AccountId) == 0 {
+			account.AccountId = manager.GetAccountId()
+		}
 		account.HealthStatus = status
 		account.ProbeAt = timeutils.UtcNow()
 		account.Version = version


### PR DESCRIPTION
Cherry pick of #9285 on release/3.6.

#9285: fix(region): sync account id