### PR TITLE
Automated cherry pick of #9329: fix(region): aws default account

### DIFF
--- a/pkg/compute/guestdrivers/aws.go
+++ b/pkg/compute/guestdrivers/aws.go
@@ -92,7 +92,7 @@ func (self *SAwsGuestDriver) GetInstanceCapability() cloudprovider.SInstanceCapa
 		Provider:   self.GetProvider(),
 		DefaultAccount: cloudprovider.SDefaultAccount{
 			Linux: cloudprovider.SOsDefaultAccount{
-				DefaultAccount: api.VM_DEFAULT_LINUX_LOGIN_USER,
+				DefaultAccount: api.VM_AWS_DEFAULT_LOGIN_USER,
 				Changeable:     false,
 			},
 			Windows: cloudprovider.SOsDefaultAccount{


### PR DESCRIPTION
Cherry pick of #9329 on release/3.6.

#9329: fix(region): aws default account