### PR TITLE
fix(region): 避免从云上同步下来的主机，创建相同配置时network_id为空

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -5408,6 +5408,7 @@ func (self *SGuest) ToNetworksConfig() []*api.NetworkConfig {
 
 		// XXX: same wire
 		netConf.Wire = network.WireId
+		netConf.Network = network.Id
 		netConf.Exit = guestNetwork.IsExit()
 		// netConf.Private
 		// netConf.Reserved


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

- [x] 功能、bugfix描述
- [x] 冒烟测试
- [ ] 单元测试编写

**是否需要 backport 到之前的 release 分支**:
- release/3.5

/area region
/cc @zexi 