### PR TITLE
Automated cherry pick of #9570: fix(region): 避免从云上同步下来的主机，创建相同配置时network_id为空

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -5408,6 +5408,7 @@ func (self *SGuest) ToNetworksConfig() []*api.NetworkConfig {
 
 		// XXX: same wire
 		netConf.Wire = network.WireId
+		netConf.Network = network.Id
 		netConf.Exit = guestNetwork.IsExit()
 		// netConf.Private
 		// netConf.Reserved


### PR DESCRIPTION
Cherry pick of #9570 on release/3.6.

#9570: fix(region): 避免从云上同步下来的主机，创建相同配置时network_id为空