### PR TITLE
Automated cherry pick of #9619: fix(region): avolid panic when list role's policies

### DIFF
--- a/pkg/multicloud/aws/iam_role.go
+++ b/pkg/multicloud/aws/iam_role.go
@@ -110,6 +110,7 @@ func (self *SRole) GetICloudpolicies() ([]cloudprovider.ICloudpolicy, error) {
 	}
 	ret := []cloudprovider.ICloudpolicy{}
 	for i := range policies {
+		policies[i].client = self.client
 		ret = append(ret, &policies[i])
 	}
 	return ret, nil
@@ -179,6 +180,7 @@ func (self *SAwsClient) GetICloudroles() ([]cloudprovider.ICloudrole, error) {
 	}
 	ret := []cloudprovider.ICloudrole{}
 	for i := range roles {
+		roles[i].client = self
 		ret = append(ret, &roles[i])
 	}
 	return ret, nil


### PR DESCRIPTION
Cherry pick of #9619 on release/3.6.

#9619: fix(region): avolid panic when list role's policies