### PR TITLE
Automated cherry pick of #9768: fix(region): sync cachedimage info

### DIFF
--- a/pkg/compute/models/cloudimages.go
+++ b/pkg/compute/models/cloudimages.go
@@ -90,3 +90,18 @@ func (self *SCloudimage) syncRemove(ctx context.Context, userCred mcclient.Token
 
 	return self.Delete(ctx, userCred)
 }
+
+func (self *SCloudimage) syncWithImage(ctx context.Context, userCred mcclient.TokenCredential, image SCachedimage) error {
+	_cachedImage, err := db.FetchByExternalId(CachedimageManager, image.GetGlobalId())
+	if err != nil {
+		return errors.Wrapf(err, "db.FetchByExternalId(%s)", image.GetGlobalId())
+	}
+	cachedImage := _cachedImage.(*SCachedimage)
+	_, err = db.Update(cachedImage, func() error {
+		cachedImage.Info = image.Info
+		cachedImage.Size = image.Size
+		cachedImage.UEFI = image.UEFI
+		return nil
+	})
+	return err
+}

--- a/pkg/compute/models/cloudregions.go
+++ b/pkg/compute/models/cloudregions.go
@@ -1038,7 +1038,6 @@ func (self *SCloudregion) SyncCloudImages(ctx context.Context, userCred mcclient
 	}
 
 	result := compare.SyncResult{}
-	result.UpdateCnt = len(commondb)
 
 	for i := 0; i < len(removed); i++ {
 		err := removed[i].syncRemove(ctx, userCred)
@@ -1047,6 +1046,15 @@ func (self *SCloudregion) SyncCloudImages(ctx context.Context, userCred mcclient
 			continue
 		}
 		result.Delete()
+	}
+
+	for i := 0; i < len(commonext); i++ {
+		err := commondb[i].syncWithImage(ctx, userCred, commonext[i])
+		if err != nil {
+			result.UpdateError(errors.Wrapf(err, "updateCachedImage"))
+			continue
+		}
+		result.Update()
 	}
 
 	for i := 0; i < len(added); i++ {


### PR DESCRIPTION
Cherry pick of #9768 on release/3.7.

#9768: fix(region): sync cachedimage info