### PR TITLE
Automated cherry pick of #9938: fix(region): azure default subscription id

### DIFF
--- a/pkg/multicloud/azure/azure.go
+++ b/pkg/multicloud/azure/azure.go
@@ -471,7 +471,7 @@ func (self *SAzureClient) _list(resource string, params url.Values) (jsonutils.J
 		if len(subId) == 0 {
 			return nil, fmt.Errorf("no avaiable subscriptions")
 		}
-		path = fmt.Sprintf("subscriptions/%s/providers/%s", self.subscriptionId, resource)
+		path = fmt.Sprintf("subscriptions/%s/providers/%s", subId, resource)
 	}
 	params.Set("api-version", self._apiVersion(resource, params))
 	return self.jsonRequest("GET", path, nil, params, true)


### PR DESCRIPTION
Cherry pick of #9938 on release/3.6.

#9938: fix(region): azure default subscription id