### PR TITLE
Automated cherry pick of #9973: fix(region): avoid clean all rules when sync secgroups

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2353,7 +2353,8 @@ func (self *SGuest) getSecurityGroupsRules() string {
 func (self *SGuest) getAdminSecurityRules() string {
 	secgrp := self.getAdminSecgroup()
 	if secgrp != nil {
-		return secgrp.getSecurityRuleString("")
+		ret, _ := secgrp.getSecurityRuleString()
+		return ret
 	} else {
 		return options.Options.DefaultAdminSecurityRules
 	}

--- a/pkg/compute/models/regiondrivers.go
+++ b/pkg/compute/models/regiondrivers.go
@@ -129,7 +129,6 @@ type IRegionDriver interface {
 
 	RequestCacheSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, region *SCloudregion, vpc *SVpc, secgroup *SSecurityGroup, classic bool, removeProjectId string, task taskman.ITask) error
 	RequestSyncSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, vpcId string, vpc *SVpc, secgroup *SSecurityGroup, removeProjectId, service string) (string, error)
-	GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder // Desc(priority值越大,优先级越高) Asc(priority值越小,优先级越高)
 	GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule
 	GetDefaultSecurityGroupOutRule() cloudprovider.SecurityRule
 	GetSecurityGroupRuleMaxPriority() int

--- a/pkg/compute/models/secgrouprules.go
+++ b/pkg/compute/models/secgrouprules.go
@@ -150,13 +150,6 @@ func (self *SSecurityGroupRule) AllowDeleteItem(ctx context.Context, userCred mc
 	return false
 }
 
-/*func (self *SSecurityGroupRule) GetSecGroup() *SSecurityGroup {
-	if secgroup, _ := SecurityGroupManager.FetchById(self.SecgroupI); secgroup != nil {
-		return secgroup.(*SSecurityGroup)
-	}
-	return nil
-}*/
-
 func (manager *SSecurityGroupRuleManager) FilterById(q *sqlchemy.SQuery, idStr string) *sqlchemy.SQuery {
 	return q.Equals("id", idStr)
 }
@@ -462,23 +455,6 @@ func (manager *SSecurityGroupRuleManager) getRulesBySecurityGroup(secgroup *SSec
 	return rules, nil
 }
 
-func (self *SSecurityGroup) SyncRules(ctx context.Context, userCred mcclient.TokenCredential, rules cloudprovider.SecurityRuleSet) error {
-	priority, prePriority := 10, 0
-	for i := 0; i < len(rules); i++ {
-		// 这里避免了Rule规则优先级在 1-100之外的问题,ext.GetRules()不需要进行优先级转换
-		if prePriority != 0 && rules[i].Priority != prePriority && priority < 100 {
-			priority++
-		}
-		prePriority = rules[i].Priority
-		rules[i].Priority = priority
-		_, err := self.newFromCloudSecurityGroupRule(ctx, userCred, rules[i])
-		if err != nil {
-			return errors.Wrapf(err, "newFromCloudSecurityGroupRule")
-		}
-	}
-	return nil
-}
-
 func (self *SSecurityGroup) newFromCloudSecurityGroupRule(ctx context.Context, userCred mcclient.TokenCredential, rule cloudprovider.SecurityRule) (*SSecurityGroupRule, error) {
 	lockman.LockObject(ctx, self)
 	defer lockman.ReleaseObject(ctx, self)
@@ -493,8 +469,15 @@ func (self *SSecurityGroup) newFromCloudSecurityGroupRule(ctx context.Context, u
 		cidr = rule.IPNet.String()
 	}
 
+	rule.Priority = rule.LocalRulePrority
+
+	err := rule.ValidateRule()
+	if err != nil {
+		return nil, errors.Wrapf(err, "ValidateRule")
+	}
+
 	secrule := &SSecurityGroupRule{
-		Priority:    int64(rule.Priority),
+		Priority:    int64(rule.LocalRulePrority),
 		Protocol:    protocol,
 		Ports:       rule.GetPortsString(),
 		Direction:   string(rule.Direction),
@@ -505,7 +488,7 @@ func (self *SSecurityGroup) newFromCloudSecurityGroupRule(ctx context.Context, u
 	secrule.SetModelManager(SecurityGroupRuleManager, secrule)
 	secrule.SecgroupId = self.Id
 
-	err := SecurityGroupRuleManager.TableSpec().Insert(ctx, secrule)
+	err = SecurityGroupRuleManager.TableSpec().Insert(ctx, secrule)
 	if err != nil {
 		return nil, errors.Wrapf(err, "SecurityGroupRuleManager.Insert")
 	}

--- a/pkg/compute/regiondrivers/aliyun.go
+++ b/pkg/compute/regiondrivers/aliyun.go
@@ -53,10 +53,6 @@ func init() {
 	models.RegisterRegionDriver(&driver)
 }
 
-func (self *SAliyunRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByAsc
-}
-
 func (self *SAliyunRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }

--- a/pkg/compute/regiondrivers/aws.go
+++ b/pkg/compute/regiondrivers/aws.go
@@ -52,10 +52,6 @@ func init() {
 	models.RegisterRegionDriver(&driver)
 }
 
-func (self *SAwsRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByAsc
-}
-
 func (self *SAwsRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }

--- a/pkg/compute/regiondrivers/azure.go
+++ b/pkg/compute/regiondrivers/azure.go
@@ -57,10 +57,6 @@ func (self *SAzureRegionDriver) IsSupportClassicSecurityGroup() bool {
 	return true
 }
 
-func (self *SAzureRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByAsc
-}
-
 func (self *SAzureRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }

--- a/pkg/compute/regiondrivers/base.go
+++ b/pkg/compute/regiondrivers/base.go
@@ -263,10 +263,6 @@ func (self *SBaseRegionDriver) RequestSyncSecurityGroup(ctx context.Context, use
 	return "", fmt.Errorf("Not Implemented RequestSyncSecurityGroup")
 }
 
-func (self *SBaseRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByDesc
-}
-
 func (self *SBaseRegionDriver) IsOnlySupportAllowRules() bool {
 	return false
 }

--- a/pkg/compute/regiondrivers/ctyun.go
+++ b/pkg/compute/regiondrivers/ctyun.go
@@ -37,10 +37,6 @@ func init() {
 	models.RegisterRegionDriver(&driver)
 }
 
-func (self *SCtyunRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByAsc
-}
-
 func (self *SCtyunRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }

--- a/pkg/compute/regiondrivers/google.go
+++ b/pkg/compute/regiondrivers/google.go
@@ -43,10 +43,6 @@ func init() {
 	models.RegisterRegionDriver(&driver)
 }
 
-func (self *SGoogleRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByAsc
-}
-
 func (self *SGoogleRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }

--- a/pkg/compute/regiondrivers/huawei.go
+++ b/pkg/compute/regiondrivers/huawei.go
@@ -54,10 +54,6 @@ func init() {
 	models.RegisterRegionDriver(&driver)
 }
 
-func (self *SHuaWeiRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByAsc
-}
-
 func (self *SHuaWeiRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }

--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -25,7 +25,6 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/netutils"
-	"yunion.io/x/pkg/util/secrules"
 	"yunion.io/x/pkg/utils"
 
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
@@ -1656,7 +1655,10 @@ func (self *SManagedVirtualizationRegionDriver) RequestSyncSecurityGroup(ctx con
 					Desc:      secgroup.Description,
 					VpcId:     vpcId,
 					ProjectId: remoteProjectId,
-					Rules:     secgroup.GetSecRules(""),
+				}
+				conf.Rules, err = secgroup.GetSecRules()
+				if err != nil {
+					return errors.Wrapf(err, "GetSecRules")
 				}
 				iSecgroup, err = iRegion.CreateISecurityGroup(conf)
 				if err != nil {
@@ -1685,12 +1687,14 @@ func (self *SManagedVirtualizationRegionDriver) RequestSyncSecurityGroup(ctx con
 
 			defaultInRule := region.GetDriver().GetDefaultSecurityGroupInRule()
 			defaultOutRule := region.GetDriver().GetDefaultSecurityGroupOutRule()
-			order := region.GetDriver().GetSecurityGroupRuleOrder()
 			onlyAllowRules := region.GetDriver().IsOnlySupportAllowRules()
 
-			localRules := secrules.SecurityRuleSet(secgroup.GetSecRules(""))
+			localRules, err := secgroup.GetSecuritRuleSet()
+			if err != nil {
+				return errors.Wrapf(err, "GetSecuritRuleSet")
+			}
 
-			common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, order, localRules, rules, defaultInRule, defaultOutRule, onlyAllowRules, false)
+			common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, localRules, rules, defaultInRule, defaultOutRule, onlyAllowRules, false, false)
 
 			if len(inAdds) == 0 && len(inDels) == 0 && len(outAdds) == 0 && len(outDels) == 0 {
 				return nil

--- a/pkg/compute/regiondrivers/openstack.go
+++ b/pkg/compute/regiondrivers/openstack.go
@@ -48,10 +48,6 @@ func init() {
 	models.RegisterRegionDriver(&driver)
 }
 
-func (self *SOpenStackRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByDesc
-}
-
 func (self *SOpenStackRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }

--- a/pkg/compute/regiondrivers/qcloud.go
+++ b/pkg/compute/regiondrivers/qcloud.go
@@ -53,10 +53,6 @@ func init() {
 	models.RegisterRegionDriver(&driver)
 }
 
-func (self *SQcloudRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByAsc
-}
-
 func (self *SQcloudRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }

--- a/pkg/compute/regiondrivers/secgroup_aliyun_test.go
+++ b/pkg/compute/regiondrivers/secgroup_aliyun_test.go
@@ -21,8 +21,8 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
-func TestCtyunRuleSync(t *testing.T) {
-	driver := SCtyunRegionDriver{}
+func TestAliyunRuleSync(t *testing.T) {
+	driver := SAliyunRegionDriver{}
 	maxPriority := driver.GetSecurityGroupRuleMaxPriority()
 	minPriority := driver.GetSecurityGroupRuleMinPriority()
 
@@ -32,19 +32,24 @@ func TestCtyunRuleSync(t *testing.T) {
 
 	data := []TestData{
 		{
-			Name: "Test out deny rules",
+			Name: "Test out rules",
 			LocalRules: cloudprovider.LocalSecurityRuleSet{
-				localRuleWithPriority("out:deny tcp 200", 1),
+				localRuleWithPriority("in:allow tcp 1212", 52),
+				localRuleWithPriority("in:allow tcp 22", 51),
+				localRuleWithPriority("in:allow tcp 3389", 50),
+				localRuleWithPriority("in:allow udp 1231", 49),
+				localRuleWithPriority("in:deny tcp 443", 48),
 			},
-			RemoteRules: []cloudprovider.SecurityRule{},
-			Common:      []cloudprovider.SecurityRule{},
-			InAdds:      []cloudprovider.SecurityRule{},
-			OutAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "out:allow icmp", 0),
-				remoteRuleWithName("", "out:allow tcp 1-199", 0),
-				remoteRuleWithName("", "out:allow tcp 201-65535", 0),
-				remoteRuleWithName("", "out:allow udp", 0),
+			RemoteRules: []cloudprovider.SecurityRule{
+				remoteRuleWithName("", "in:deny tcp 443", 1),
+				remoteRuleWithName("", "in:allow udp 1231", 1),
+				remoteRuleWithName("", "in:allow tcp 3389", 100),
+				remoteRuleWithName("", "in:allow tcp 22", 100),
+				remoteRuleWithName("", "in:allow tcp 1212", 100),
 			},
+			Common:  []cloudprovider.SecurityRule{},
+			InAdds:  []cloudprovider.SecurityRule{},
+			OutAdds: []cloudprovider.SecurityRule{},
 			InDels:  []cloudprovider.SecurityRule{},
 			OutDels: []cloudprovider.SecurityRule{},
 		},
@@ -52,7 +57,7 @@ func TestCtyunRuleSync(t *testing.T) {
 
 	for _, d := range data {
 		t.Logf("check %s", d.Name)
-		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true, false)
+		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true, true)
 		sort.Sort(cloudprovider.SecurityRuleSet(common))
 		sort.Sort(cloudprovider.SecurityRuleSet(inAdds))
 		sort.Sort(cloudprovider.SecurityRuleSet(outAdds))

--- a/pkg/compute/regiondrivers/secgroup_aws_test.go
+++ b/pkg/compute/regiondrivers/secgroup_aws_test.go
@@ -17,8 +17,6 @@ package regiondrivers
 import (
 	"testing"
 
-	"yunion.io/x/pkg/util/secrules"
-
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
@@ -29,13 +27,12 @@ func TestAwsRuleSync(t *testing.T) {
 
 	defaultInRule := driver.GetDefaultSecurityGroupInRule()
 	defaultOutRule := driver.GetDefaultSecurityGroupOutRule()
-	order := driver.GetSecurityGroupRuleOrder()
 	isOnlyAllowRules := driver.IsOnlySupportAllowRules()
 
 	data := []TestData{
 		{
 			Name: "Test remove out allow rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("out:deny any", 1),
 			},
 			RemoteRules: []cloudprovider.SecurityRule{
@@ -51,7 +48,7 @@ func TestAwsRuleSync(t *testing.T) {
 		},
 		{
 			Name: "Test out deny rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("out:deny any", 1),
 			},
 			RemoteRules: []cloudprovider.SecurityRule{},
@@ -63,7 +60,7 @@ func TestAwsRuleSync(t *testing.T) {
 		},
 		{
 			Name:        "Test out allow rules",
-			LocalRules:  secrules.SecurityRuleSet{},
+			LocalRules:  cloudprovider.LocalSecurityRuleSet{},
 			RemoteRules: []cloudprovider.SecurityRule{},
 			Common:      []cloudprovider.SecurityRule{},
 			InAdds:      []cloudprovider.SecurityRule{},
@@ -77,7 +74,7 @@ func TestAwsRuleSync(t *testing.T) {
 
 	for _, d := range data {
 		t.Logf("check %s", d.Name)
-		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, order, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true)
+		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true, false)
 		check(t, "common", common, d.Common)
 		check(t, "inAdds", inAdds, d.InAdds)
 		check(t, "outAdds", outAdds, d.OutAdds)

--- a/pkg/compute/regiondrivers/secgroup_azure_test.go
+++ b/pkg/compute/regiondrivers/secgroup_azure_test.go
@@ -18,8 +18,6 @@ import (
 	"sort"
 	"testing"
 
-	"yunion.io/x/pkg/util/secrules"
-
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
@@ -30,41 +28,24 @@ func TestAzureRuleSync(t *testing.T) {
 
 	defaultInRule := driver.GetDefaultSecurityGroupInRule()
 	defaultOutRule := driver.GetDefaultSecurityGroupOutRule()
-	order := driver.GetSecurityGroupRuleOrder()
 	isOnlyAllowRules := driver.IsOnlySupportAllowRules()
 
 	data := []TestData{
 		{
 			Name:        "Test empty rules",
-			LocalRules:  secrules.SecurityRuleSet{},
+			LocalRules:  cloudprovider.LocalSecurityRuleSet{},
 			RemoteRules: []cloudprovider.SecurityRule{},
 			Common:      []cloudprovider.SecurityRule{},
 			InAdds:      []cloudprovider.SecurityRule{},
 			OutAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "out:allow any", 2097),
+				remoteRuleWithName("", "out:allow any", 2099),
 			},
 			InDels:  []cloudprovider.SecurityRule{},
 			OutDels: []cloudprovider.SecurityRule{},
 		},
 		{
-			Name:       "Test remove rules",
-			LocalRules: secrules.SecurityRuleSet{},
-			RemoteRules: []cloudprovider.SecurityRule{
-				remoteRuleWithName("test-name", "out:allow any", 1000),
-			},
-			Common: []cloudprovider.SecurityRule{},
-			InAdds: []cloudprovider.SecurityRule{},
-			OutAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "out:allow any", 2097),
-			},
-			InDels: []cloudprovider.SecurityRule{},
-			OutDels: []cloudprovider.SecurityRule{
-				remoteRuleWithName("test-name", "out:allow any", 1000),
-			},
-		},
-		{
 			Name: "Test diff rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("out:allow tcp 100-200", 99),
 				localRuleWithPriority("out:allow udp 200-300", 98),
 			},
@@ -78,14 +59,14 @@ func TestAzureRuleSync(t *testing.T) {
 			},
 			InAdds: []cloudprovider.SecurityRule{},
 			OutAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "out:allow any", 2097),
+				remoteRuleWithName("", "out:allow any", 2099),
 			},
 			InDels:  []cloudprovider.SecurityRule{},
 			OutDels: []cloudprovider.SecurityRule{},
 		},
 		{
 			Name: "Test add rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("in:allow tcp", 100),
 				localRuleWithPriority("in:allow udp", 99),
 				localRuleWithPriority("out:deny any", 1),
@@ -95,8 +76,8 @@ func TestAzureRuleSync(t *testing.T) {
 			},
 			Common: []cloudprovider.SecurityRule{},
 			InAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "in:allow tcp", 2097),
-				remoteRuleWithName("", "in:allow udp", 2097),
+				remoteRuleWithName("", "in:allow tcp", 2099),
+				remoteRuleWithName("", "in:allow udp", 2099),
 			},
 			OutAdds: []cloudprovider.SecurityRule{},
 			InDels: []cloudprovider.SecurityRule{
@@ -106,7 +87,7 @@ func TestAzureRuleSync(t *testing.T) {
 		},
 		{
 			Name: "Test insert rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("in:allow tcp", 100),
 				localRuleWithPriority("in:allow udp", 99),
 				localRuleWithPriority("in:allow icmp", 98),
@@ -121,7 +102,7 @@ func TestAzureRuleSync(t *testing.T) {
 				remoteRuleWithName("allow-icmp", "in:allow icmp", 400),
 			},
 			InAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "in:allow udp", 2097),
+				remoteRuleWithName("", "in:allow udp", 2099),
 			},
 			OutAdds: []cloudprovider.SecurityRule{},
 			InDels:  []cloudprovider.SecurityRule{},
@@ -129,7 +110,7 @@ func TestAzureRuleSync(t *testing.T) {
 		},
 		{
 			Name: "Test icmp rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("in:allow tcp 33", 10),
 				localRuleWithPriority("in:allow tcp 22", 1),
 				localRuleWithPriority("out:deny any", 1),
@@ -141,7 +122,7 @@ func TestAzureRuleSync(t *testing.T) {
 				remoteRuleWithName("allow-tcp-22", "in:allow tcp 22", 300),
 			},
 			InAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "in:allow tcp 33", 299),
+				remoteRuleWithName("", "in:allow tcp 33", 301),
 			},
 			OutAdds: []cloudprovider.SecurityRule{},
 			InDels:  []cloudprovider.SecurityRule{},
@@ -149,7 +130,7 @@ func TestAzureRuleSync(t *testing.T) {
 		},
 		{
 			Name: "Test a rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("in:allow tcp 1050", 5),
 				localRuleWithPriority("in:allow tcp 1011", 4),
 				localRuleWithPriority("in:allow tcp 1002", 3),
@@ -171,7 +152,7 @@ func TestAzureRuleSync(t *testing.T) {
 				remoteRuleWithName("in_allow_udp_55_4014", "in:allow udp 55", 4014),
 			},
 			InAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "in:allow tcp 1011", 4011),
+				remoteRuleWithName("", "in:allow tcp 1011", 4013),
 			},
 			OutAdds: []cloudprovider.SecurityRule{},
 			InDels: []cloudprovider.SecurityRule{
@@ -181,7 +162,7 @@ func TestAzureRuleSync(t *testing.T) {
 		},
 		{
 			Name: "Test b rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("in:allow udp 1055", 20),
 				localRuleWithPriority("in:allow icmp", 15),
 				localRuleWithPriority("in:allow tcp 1050", 5),
@@ -207,8 +188,8 @@ func TestAzureRuleSync(t *testing.T) {
 				remoteRuleWithName("in_allow_udp_55_4014", "in:allow udp 55", 4014),
 			},
 			InAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "in:allow icmp", 2097),
-				remoteRuleWithName("", "in:allow udp 1055", 4013),
+				remoteRuleWithName("", "in:allow icmp", 2099),
+				remoteRuleWithName("", "in:allow udp 1055", 4015),
 			},
 			OutAdds: []cloudprovider.SecurityRule{},
 			InDels: []cloudprovider.SecurityRule{
@@ -220,7 +201,7 @@ func TestAzureRuleSync(t *testing.T) {
 
 	for _, d := range data {
 		t.Logf("check %s", d.Name)
-		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, order, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true)
+		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true, false)
 		sort.Sort(cloudprovider.SecurityRuleSet(common))
 		sort.Sort(cloudprovider.SecurityRuleSet(inAdds))
 		sort.Sort(cloudprovider.SecurityRuleSet(outAdds))

--- a/pkg/compute/regiondrivers/secgroup_openstack_test.go
+++ b/pkg/compute/regiondrivers/secgroup_openstack_test.go
@@ -17,8 +17,6 @@ package regiondrivers
 import (
 	"testing"
 
-	"yunion.io/x/pkg/util/secrules"
-
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
@@ -29,13 +27,12 @@ func TestOpenStackRuleSync(t *testing.T) {
 
 	defaultInRule := driver.GetDefaultSecurityGroupInRule()
 	defaultOutRule := driver.GetDefaultSecurityGroupOutRule()
-	order := driver.GetSecurityGroupRuleOrder()
 	isOnlyAllowRules := driver.IsOnlySupportAllowRules()
 
 	data := []TestData{
 		{
 			Name: "Test deny rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("in:deny any", 100),
 				localRuleWithPriority("in:allow any", 99),
 				localRuleWithPriority("out:allow any", 100),
@@ -57,7 +54,7 @@ func TestOpenStackRuleSync(t *testing.T) {
 
 	for _, d := range data {
 		t.Logf("check %s", d.Name)
-		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, order, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true)
+		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true, false)
 		check(t, "common", common, d.Common)
 		check(t, "inAdds", inAdds, d.InAdds)
 		check(t, "outAdds", outAdds, d.OutAdds)

--- a/pkg/compute/regiondrivers/secgroup_qcloud_test.go
+++ b/pkg/compute/regiondrivers/secgroup_qcloud_test.go
@@ -18,8 +18,6 @@ import (
 	"sort"
 	"testing"
 
-	"yunion.io/x/pkg/util/secrules"
-
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
@@ -30,13 +28,12 @@ func TestQcloudRuleSync(t *testing.T) {
 
 	defaultInRule := driver.GetDefaultSecurityGroupInRule()
 	defaultOutRule := driver.GetDefaultSecurityGroupOutRule()
-	order := driver.GetSecurityGroupRuleOrder()
 	isOnlyAllowRules := driver.IsOnlySupportAllowRules()
 
 	data := []TestData{
 		{
 			Name: "Test out rules",
-			LocalRules: secrules.SecurityRuleSet{
+			LocalRules: cloudprovider.LocalSecurityRuleSet{
 				localRuleWithPriority("out:allow any", 11),
 				localRuleWithPriority("out:deny any", 10),
 			},
@@ -44,7 +41,7 @@ func TestQcloudRuleSync(t *testing.T) {
 			Common:      []cloudprovider.SecurityRule{},
 			InAdds:      []cloudprovider.SecurityRule{},
 			OutAdds: []cloudprovider.SecurityRule{
-				remoteRuleWithName("", "out:allow any", 100),
+				remoteRuleWithName("", "out:allow any", 49),
 			},
 			InDels:  []cloudprovider.SecurityRule{},
 			OutDels: []cloudprovider.SecurityRule{},
@@ -53,7 +50,7 @@ func TestQcloudRuleSync(t *testing.T) {
 
 	for _, d := range data {
 		t.Logf("check %s", d.Name)
-		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, order, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true)
+		common, inAdds, outAdds, inDels, outDels := cloudprovider.CompareRules(minPriority, maxPriority, d.LocalRules, d.RemoteRules, defaultInRule, defaultOutRule, isOnlyAllowRules, true, false)
 		sort.Sort(cloudprovider.SecurityRuleSet(common))
 		sort.Sort(cloudprovider.SecurityRuleSet(inAdds))
 		sort.Sort(cloudprovider.SecurityRuleSet(outAdds))

--- a/pkg/compute/regiondrivers/secgroup_test.go
+++ b/pkg/compute/regiondrivers/secgroup_test.go
@@ -26,7 +26,7 @@ import (
 
 type TestData struct {
 	Name        string
-	LocalRules  secrules.SecurityRuleSet
+	LocalRules  cloudprovider.LocalSecurityRuleSet
 	RemoteRules cloudprovider.SecurityRuleSet
 	Common      cloudprovider.SecurityRuleSet
 	InAdds      cloudprovider.SecurityRuleSet
@@ -35,20 +35,20 @@ type TestData struct {
 	OutDels     cloudprovider.SecurityRuleSet
 }
 
-var localRuleWithPriority = func(ruleStr string, priority int) secrules.SecurityRule {
+var localRuleWithPriority = func(ruleStr string, priority int) cloudprovider.LocalSecurityRule {
 	rule := secrules.MustParseSecurityRule(ruleStr)
 	if rule == nil {
 		log.Errorf("invalid rule str %s", ruleStr)
-		return secrules.SecurityRule{}
+		return cloudprovider.LocalSecurityRule{}
 	}
 	rule.Priority = priority
-	return *rule
+	return cloudprovider.LocalSecurityRule{SecurityRule: *rule}
 }
 
 var remoteRuleWithName = func(name, ruleStr string, priority int) cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{
 		Name:         name,
-		SecurityRule: localRuleWithPriority(ruleStr, priority),
+		SecurityRule: localRuleWithPriority(ruleStr, priority).SecurityRule,
 	}
 }
 

--- a/pkg/compute/regiondrivers/ucloud.go
+++ b/pkg/compute/regiondrivers/ucloud.go
@@ -37,10 +37,6 @@ func init() {
 	models.RegisterRegionDriver(&driver)
 }
 
-func (self *SUcloudRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByDesc
-}
-
 func (self *SUcloudRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }

--- a/pkg/compute/regiondrivers/zstack.go
+++ b/pkg/compute/regiondrivers/zstack.go
@@ -37,10 +37,6 @@ func init() {
 	models.RegisterRegionDriver(&driver)
 }
 
-func (self *SZStackRegionDriver) GetSecurityGroupRuleOrder() cloudprovider.TPriorityOrder {
-	return cloudprovider.PriorityOrderByAsc
-}
-
 func (self *SZStackRegionDriver) GetDefaultSecurityGroupInRule() cloudprovider.SecurityRule {
 	return cloudprovider.SecurityRule{SecurityRule: *secrules.MustParseSecurityRule("in:deny any")}
 }


### PR DESCRIPTION
Cherry pick of #9973 on release/3.7.

#9973: fix(region): avoid clean all rules when sync secgroups