### PR TITLE
Automated cherry pick of #10867: fix(region): avoid network create failed when vpc is ok but wire not sync

### DIFF
--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1234,15 +1234,16 @@ func (self *SManagedVirtualizationRegionDriver) RequestCreateVpc(ctx context.Con
 			}
 		}
 
+		err = vpc.SyncRemoteWires(ctx, userCred)
+		if err != nil {
+			return nil, errors.Wrap(err, "vpc.SyncRemoteWires")
+		}
+
 		err = vpc.SyncWithCloudVpc(ctx, userCred, ivpc, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "vpc.SyncWithCloudVpc")
 		}
 
-		err = vpc.SyncRemoteWires(ctx, userCred)
-		if err != nil {
-			return nil, errors.Wrap(err, "vpc.SyncRemoteWires")
-		}
 		return nil, nil
 	})
 	return nil


### PR DESCRIPTION
Cherry pick of #10867 on release/3.7.

#10867: fix(region): avoid network create failed when vpc is ok but wire not sync