### PR TITLE
fix: avoid host worker is locked when image cache is deleted

### DIFF
--- a/pkg/hostman/storageman/imagecache_local.go
+++ b/pkg/hostman/storageman/imagecache_local.go
@@ -205,6 +205,10 @@ func (l *SLocalImageCache) fetch(ctx context.Context, zone, srcUrl, format strin
 		defer l.cond.L.Unlock()
 
 		l.Desc = l.remoteFile.GetInfo()
+		if l.Desc == nil {
+			l.remoteFile = nil
+			return false
+		}
 		l.Size = l.GetSize() / 1024 / 1024
 		l.Desc.Id = l.imageId
 		l.remoteFile = nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:


- [x] 功能、bugfix描述
- [x] 冒烟测试
- [ ] 单元测试编写


**是否需要 backport 到之前的 release 分支**:
- release/3.5

/area host
/cc @zexi 
