### PR TITLE
Automated cherry pick of #10956: fix: avoid host worker is locked when image cache is deleted

### DIFF
--- a/pkg/hostman/storageman/imagecache_local.go
+++ b/pkg/hostman/storageman/imagecache_local.go
@@ -205,6 +205,10 @@ func (l *SLocalImageCache) fetch(ctx context.Context, zone, srcUrl, format strin
 		defer l.cond.L.Unlock()
 
 		l.Desc = l.remoteFile.GetInfo()
+		if l.Desc == nil {
+			l.remoteFile = nil
+			return false
+		}
 		l.Size = l.GetSize() / 1024 / 1024
 		l.Desc.Id = l.imageId
 		l.remoteFile = nil


### PR DESCRIPTION
Cherry pick of #10956 on release/3.6.

#10956: fix: avoid host worker is locked when image cache is deleted