### PR TITLE
Automated cherry pick of #11154: fix(region): avoid azure secgroup sync removed

### DIFF
--- a/pkg/multicloud/azure/classic_vpc.go
+++ b/pkg/multicloud/azure/classic_vpc.go
@@ -87,7 +87,16 @@ func (self *SClassicVpc) Delete() error {
 }
 
 func (self *SClassicVpc) GetISecurityGroups() ([]cloudprovider.ICloudSecurityGroup, error) {
-	return []cloudprovider.ICloudSecurityGroup{}, nil
+	secgroups, err := self.region.ListSecgroups()
+	if err != nil {
+		return nil, errors.Wrapf(err, "ListSecgroups")
+	}
+	ret := []cloudprovider.ICloudSecurityGroup{}
+	for i := range secgroups {
+		secgroups[i].region = self.region
+		ret = append(ret, &secgroups[i])
+	}
+	return ret, nil
 }
 
 func (self *SClassicVpc) GetIRouteTables() ([]cloudprovider.ICloudRouteTable, error) {


### PR DESCRIPTION
Cherry pick of #11154 on release/3.7.

#11154: fix(region): avoid azure secgroup sync removed