### PR TITLE
Automated cherry pick of #11274: fix(region): disable public cloud ip pre allocate

### DIFF
--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -116,7 +116,7 @@ type ComputeOptions struct {
 	SyncCloudImagesDay  int `default:"1" help:"Days auto sync public cloud images data, default 1 day"`
 	SyncCloudImagesHour int `default:"3" help:"What hour start sync public cloud images, default 03:00"`
 
-	EnablePreAllocateIpAddr bool `help:"Enable private and public cloud private ip pre allocate, default true" default:"true"`
+	EnablePreAllocateIpAddr bool `help:"Enable private and public cloud private ip pre allocate, default false" default:"false"`
 
 	DefaultImageCacheDir string `default:"image_cache"`
 


### PR DESCRIPTION
Cherry pick of #11274 on release/3.7.

#11274: fix(region): disable public cloud ip pre allocate