### PR TITLE
Automated cherry pick of #11289: fix(host): avoid panic when params is nil

### DIFF
--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -689,12 +689,13 @@ func (m *SGuestManager) GuestStart(ctx context.Context, sid string, body jsonuti
 			guest.SaveDesc(desc)
 		}
 		if guest.IsStopped() {
-			var data *jsonutils.JSONDict
-			params, err := body.Get("params")
-			if err != nil {
-				data, _ = params.(*jsonutils.JSONDict)
+			data := struct {
+				Params *jsonutils.JSONDict
+			}{
+				Params: jsonutils.NewDict(),
 			}
-			guest.StartGuest(ctx, data)
+			body.Unmarshal(&data)
+			guest.StartGuest(ctx, data.Params)
 			res := jsonutils.NewDict()
 			res.Set("vnc_port", jsonutils.NewInt(0))
 			return res, nil


### PR DESCRIPTION
Cherry pick of #11289 on release/3.7.

#11289: fix(host): avoid panic when params is nil