### PR TITLE
fix: hpssacli should skip empty slots

### DIFF
--- a/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
+++ b/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
@@ -20,9 +20,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/stringutils"
 	"yunion.io/x/pkg/utils"
@@ -382,10 +381,17 @@ func (r *HPSARaid) parsePhyDevs(lines []string) error {
 			r.adapters = append(r.adapters, adapter)
 		}
 	}
+	var errs []error
 	for _, a := range r.adapters {
-		if err := a.ParsePhyDevs(); err != nil {
-			return err
+		err := a.ParsePhyDevs()
+		if err != nil {
+			log.Errorf("parse adapter %d fail: %s", a.GetIndex(), err)
+			errs = append(errs, err)
 		}
+	}
+	if len(errs) == len(r.adapters) {
+		// all failed
+		return errors.NewAggregate(errs)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: hpssacli may fail when probing disks on empty slots, which cause raid detection failure

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
