### PR TITLE
Automated cherry pick of #11299: fix: hpssacli should skip empty slots

### DIFF
--- a/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
+++ b/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
@@ -20,9 +20,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/stringutils"
 	"yunion.io/x/pkg/utils"
@@ -382,10 +381,17 @@ func (r *HPSARaid) parsePhyDevs(lines []string) error {
 			r.adapters = append(r.adapters, adapter)
 		}
 	}
+	var errs []error
 	for _, a := range r.adapters {
-		if err := a.ParsePhyDevs(); err != nil {
-			return err
+		err := a.ParsePhyDevs()
+		if err != nil {
+			log.Errorf("parse adapter %d fail: %s", a.GetIndex(), err)
+			errs = append(errs, err)
 		}
+	}
+	if len(errs) == len(r.adapters) {
+		// all failed
+		return errors.NewAggregate(errs)
 	}
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #11299 on release/3.5.

#11299: fix: hpssacli should skip empty slots