### PR TITLE
fix: 修复云账号和宿主机报警问题

### DIFF
--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -489,9 +489,23 @@ func newQueryCondition(model *monitor.AlertCondition, index int) (*QueryConditio
 		operator = "and"
 	}
 	cond.Operator = operator
+
+	cond.checkGroupByField()
 	cond.setResType()
 
 	return cond, nil
+}
+
+func (c *QueryCondition) checkGroupByField() {
+	metricMeasurement, _ := models.MetricMeasurementManager.GetCache().Get(c.Query.Model.Measurement)
+	if metricMeasurement == nil {
+		return
+	}
+	for i, group := range c.Query.Model.GroupBy {
+		if group.Params[0] == "*" {
+			c.Query.Model.GroupBy[i].Params = []string{monitor.MEASUREMENT_TAG_ID[metricMeasurement.ResType]}
+		}
+	}
 }
 
 func (c *QueryCondition) setResType() {
@@ -559,6 +573,7 @@ func (c *QueryCondition) getOnecloudResources() ([]jsonutils.JSONObject, error) 
 		allResources, err = ListAllResources(&mc_mds.Buckets, query)
 	case monitor.METRIC_RES_TYPE_CLOUDACCOUNT:
 		query.Remove("status")
+		query.Add(jsonutils.NewBool(true), "enabled")
 		allResources, err = ListAllResources(&mc_mds.Cloudaccounts, query)
 	case monitor.METRIC_RES_TYPE_TENANT:
 		allResources, err = ListAllResources(&mc_mds.Projects, query)


### PR DESCRIPTION
**What this PR does / why we need it**:
1.云账号报警时过滤掉已经禁用的云账号
2.修复宿主机报警时资源名称重复的问题


**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

/cc @zexi 
/area monitor
