### PR TITLE
fix(telegraf-raid-plugin): add image-telegraf-raid-plugin in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,9 @@ image:
 
 .PHONY: image
 
+image-telegraf-raid-plugin:
+	VERSION=release-1.6.1 ARCH=all make image telegraf-raid-plugin
+
 %:
 	@:
 


### PR DESCRIPTION
**What this PR does / why we need it**:



**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

/cc @zexi 
/area host
