### PR TITLE
Automated cherry pick of #11335: fix(telegraf-raid-plugin): add image-telegraf-raid-plugin in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,9 @@ image:
 
 .PHONY: image
 
+image-telegraf-raid-plugin:
+	VERSION=release-1.6.1 ARCH=all make image telegraf-raid-plugin
+
 %:
 	@:
 


### PR DESCRIPTION
Cherry pick of #11335 on release/3.7.

#11335: fix(telegraf-raid-plugin): add image-telegraf-raid-plugin in Makefile