### PR TITLE
Automated cherry pick of #11349: fix(cloudid): avoid duplicate create saml provider

### DIFF
--- a/pkg/cloudid/models/cloudaccount.go
+++ b/pkg/cloudid/models/cloudaccount.go
@@ -1130,6 +1130,7 @@ func (self *SCloudaccount) RegisterSAMProvider() (*SSAMLProvider, error) {
 	}()
 	sp.EntityId = options.Options.ApiServer
 	sp.CloudaccountId = self.Id
+	sp.DomainId = self.DomainId
 	sp.Status = api.SAML_PROVIDER_STATUS_CREATING
 	metadata := SamlIdpInstance().GetMetadata(self.Id).String()
 	sp.MetadataDocument = metadata
@@ -1193,7 +1194,7 @@ func (self *SCloudaccount) StartSyncCloudrolesTask(ctx context.Context, userCred
 }
 
 func (self *SCloudaccount) GetSAMLProviders() ([]SSAMLProvider, error) {
-	q := SAMLProviderManager.Query().Equals("cloudaccount_id", self.Id)
+	q := SAMLProviderManager.Query().Equals("cloudaccount_id", self.Id).Desc("external_id")
 	samls := []SSAMLProvider{}
 	err := db.FetchModelObjects(SAMLProviderManager, q, &samls)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #11349 on release/3.6.

#11349: fix(cloudid): avoid duplicate create saml provider