### PR TITLE
Automated cherry pick of #11415: fix: do not resize LVM paritition and skip and return success

### DIFF
--- a/pkg/hostman/diskutils/libguestfs/driver.go
+++ b/pkg/hostman/diskutils/libguestfs/driver.go
@@ -207,6 +207,10 @@ func (d *SLibguestfsDriver) Zerofree() {
 }
 
 func (d *SLibguestfsDriver) ResizePartition() error {
+	if d.IsLVMPartition() {
+		// do not try to resize LVM partition
+		return nil
+	}
 	return fsutils.ResizeDiskFs(d.nbddev, 0)
 }
 

--- a/pkg/hostman/diskutils/nbd/driver.go
+++ b/pkg/hostman/diskutils/nbd/driver.go
@@ -241,6 +241,10 @@ func (d *NBDDriver) FormatPartition(fs, uuid string) error {
 }
 
 func (d *NBDDriver) ResizePartition() error {
+	if d.IsLVMPartition() {
+		// do not resize LVM partition
+		return nil
+	}
 	return fsutils.ResizeDiskFs(d.nbdDev, 0)
 }
 


### PR DESCRIPTION
Cherry pick of #11415 on release/3.7.

#11415: fix: do not resize LVM paritition and skip and return success