### PR TITLE
fix(monitor): exit monitor engine in time when happen err

### DIFF
--- a/pkg/monitor/alerting/engine.go
+++ b/pkg/monitor/alerting/engine.go
@@ -211,6 +211,9 @@ func (e *AlertEngine) processJob(attemptID int, attemptChan chan int, cancelChan
 				attemptChan <- (attemptID + 1)
 				return
 			}
+			log.Errorf("gt AlertingMaxAttempts, error: %v", evalContext.Error)
+			close(attemptChan)
+			return
 		}
 
 		// create new context with timeout for notifications


### PR DESCRIPTION
**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

/cc @zexi 
/area monitor


