### PR TITLE
Automated cherry pick of #11454: fix(monitor): exit monitor engine in time when happen err

### DIFF
--- a/pkg/monitor/alerting/engine.go
+++ b/pkg/monitor/alerting/engine.go
@@ -211,6 +211,9 @@ func (e *AlertEngine) processJob(attemptID int, attemptChan chan int, cancelChan
 				attemptChan <- (attemptID + 1)
 				return
 			}
+			log.Errorf("gt AlertingMaxAttempts, error: %v", evalContext.Error)
+			close(attemptChan)
+			return
 		}
 
 		// create new context with timeout for notifications


### PR DESCRIPTION
Cherry pick of #11454 on release/3.6.

#11454: fix(monitor): exit monitor engine in time when happen err