### PR TITLE
Automated cherry pick of #11509: fix: get datacenter of host via GetDatacenter

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -1398,15 +1398,19 @@ func (host *SHost) fetchDatastores() error {
 		return nil
 	}
 
+	dc, err := host.GetDatacenter()
+	if err != nil {
+		return err
+	}
 	dss := host.getHostSystem().Datastore
 	var datastores []mo.Datastore
-	err := host.manager.references2Objects(dss, DATASTORE_PROPS, &datastores)
+	err = host.manager.references2Objects(dss, DATASTORE_PROPS, &datastores)
 	if err != nil {
 		return err
 	}
 	host.datastores = make([]cloudprovider.ICloudStorage, 0)
 	for i := 0; i < len(datastores); i += 1 {
-		ds := NewDatastore(host.manager, &datastores[i], host.datacenter)
+		ds := NewDatastore(host.manager, &datastores[i], dc)
 		dsId := ds.GetGlobalId()
 		if len(dsId) > 0 {
 			host.datastores = append(host.datastores, ds)


### PR DESCRIPTION
Cherry pick of #11509 on release/3.6.

#11509: fix: get datacenter of host via GetDatacenter