### PR TITLE
fix(host): allow server directory a symbol link to directory in other location

### DIFF
--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -259,7 +259,7 @@ func (m *SGuestManager) IsGuestDir(f os.FileInfo) bool {
 	if !regutils.MatchUUID(f.Name()) {
 		return false
 	}
-	if !f.Mode().IsDir() {
+	if !f.Mode().IsDir() && f.Mode()&os.ModeSymlink == 0 {
 		return false
 	}
 	descFile := path.Join(m.ServersPath, f.Name(), "desc")


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allow server directory can be a symbol link to directory in another location

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
* release/3.7
* release/3.6

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
