### PR TITLE
Automated cherry pick of #11518: fix(host): allow server directory a symbol link to directory in other location

### DIFF
--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -255,7 +255,7 @@ func (m *SGuestManager) IsGuestDir(f os.FileInfo) bool {
 	if !regutils.MatchUUID(f.Name()) {
 		return false
 	}
-	if !f.Mode().IsDir() {
+	if !f.Mode().IsDir() && f.Mode()&os.ModeSymlink == 0 {
 		return false
 	}
 	descFile := path.Join(m.ServersPath, f.Name(), "desc")


### PR DESCRIPTION
Cherry pick of #11518 on release/3.6.

#11518: fix(host): allow server directory a symbol link to directory in other location