### PR TITLE
fix: do not use ntfsresize to resize NTFS partition

### DIFF
--- a/pkg/hostman/diskutils/fsutils/fsutils.go
+++ b/pkg/hostman/diskutils/fsutils/fsutils.go
@@ -264,7 +264,10 @@ func ResizePartitionFs(fpath, fs string, raiseError bool) (error, bool) {
 			{"sleep", "2"},
 			{"rm", "-fr", tmpPoint}}
 	} else if fs == "ntfs" {
-		cmds = [][]string{{"ntfsresize", "-c", fpath}, {"ntfsresize", "-P", "-f", fpath}}
+		// the following cmds may cause disk damage on Windows 10 with new version of NTFS
+		// comment out the following codes only impact Windows 2003
+		// as windows 2003 deprecated, so choose to sacrifies windows 2003
+		// cmds = [][]string{{"ntfsresize", "-c", fpath}, {"ntfsresize", "-P", "-f", fpath}}
 	}
 
 	if len(cmds) > 0 {


### PR DESCRIPTION
This makes resizing windows 2003 ntfs partition non-functional

**What this PR does / why we need it**:
fix: do not use ntfsresize to resize NTFS partition

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
