### PR TITLE
Automated cherry pick of #11539: fix: do not use ntfsresize to resize NTFS partition

### DIFF
--- a/pkg/hostman/diskutils/fsutils/fsutils.go
+++ b/pkg/hostman/diskutils/fsutils/fsutils.go
@@ -264,7 +264,10 @@ func ResizePartitionFs(fpath, fs string, raiseError bool) (error, bool) {
 			{"sleep", "2"},
 			{"rm", "-fr", tmpPoint}}
 	} else if fs == "ntfs" {
-		cmds = [][]string{{"ntfsresize", "-c", fpath}, {"ntfsresize", "-P", "-f", fpath}}
+		// the following cmds may cause disk damage on Windows 10 with new version of NTFS
+		// comment out the following codes only impact Windows 2003
+		// as windows 2003 deprecated, so choose to sacrifies windows 2003
+		// cmds = [][]string{{"ntfsresize", "-c", fpath}, {"ntfsresize", "-P", "-f", fpath}}
 	}
 
 	if len(cmds) > 0 {


### PR DESCRIPTION
Cherry pick of #11539 on release/3.6.

#11539: fix: do not use ntfsresize to resize NTFS partition