### PR TITLE
Automated cherry pick of #11554: fix: add cloudroot as system account, so as not using normal user id

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/interface.go
+++ b/pkg/hostman/guestfs/fsdriver/interface.go
@@ -34,7 +34,7 @@ type IDiskPartition interface {
 	Exists(sPath string, caseInsensitive bool) bool
 	Chown(sPath string, uid, gid int, caseInsensitive bool) error
 	Chmod(sPath string, mode uint32, caseInsensitive bool) error
-	UserAdd(user, homeDir string, caseInsensitive bool) error
+	UserAdd(user, homeDir string, caseInsensitive bool, isSys bool) error
 	Stat(sPath string, caseInsensitive bool) os.FileInfo
 	Symlink(src, dst string, caseInsensitive bool) error
 

--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -95,7 +95,7 @@ func (l *sLinuxRootFs) DeployHosts(rootFs IDiskPartition, hostname, domain strin
 
 func (l *sLinuxRootFs) GetLoginAccount(rootFs IDiskPartition, sUser string, defaultRootUser bool, windowsDefaultAdminUser bool) (string, error) {
 	if len(sUser) > 0 {
-		if err := rootFs.UserAdd(sUser, "", false); err != nil && !strings.Contains(err.Error(), "already exists") {
+		if err := rootFs.UserAdd(sUser, "", false, false); err != nil && !strings.Contains(err.Error(), "already exists") {
 			return "", fmt.Errorf("UserAdd %s: %v", sUser, err)
 		}
 		if err := l.EnableUserSudo(rootFs, sUser); err != nil {
@@ -156,7 +156,7 @@ func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *deployap
 	}
 	var yunionroot = YUNIONROOT_USER
 	rootdir := path.Join(cloudrootDirectory, yunionroot)
-	if err := rootFs.UserAdd(yunionroot, cloudrootDirectory, false); err != nil && !strings.Contains(err.Error(), "already exists") {
+	if err := rootFs.UserAdd(yunionroot, cloudrootDirectory, false, true); err != nil && !strings.Contains(err.Error(), "already exists") {
 		log.Errorf("UserAdd %s: %v", yunionroot, err)
 	}
 	err := DeployAuthorizedKeys(rootFs, rootdir, pubkeys, true)

--- a/pkg/hostman/guestfs/kvmpart/localfs.go
+++ b/pkg/hostman/guestfs/kvmpart/localfs.go
@@ -222,11 +222,14 @@ func (f *SLocalGuestFS) Chmod(sPath string, mode uint32, caseInsensitive bool) e
 	return nil
 }
 
-func (f *SLocalGuestFS) UserAdd(user, homeDir string, caseInsensitive bool) error {
+func (f *SLocalGuestFS) UserAdd(user, homeDir string, caseInsensitive bool, isSys bool) error {
 	if err := f.Mkdir(homeDir, 0755, false); err != nil {
 		return errors.Wrap(err, "Mkdir")
 	}
 	cmd := []string{"chroot", f.mountPath, "useradd", "-m", "-s", "/bin/bash", user}
+	if isSys {
+		cmd = append(cmd, "-r")
+	}
 	if len(homeDir) > 0 {
 		cmd = append(cmd, "-d", path.Join(homeDir, user))
 	}

--- a/pkg/hostman/guestfs/sshpart/sshpart.go
+++ b/pkg/hostman/guestfs/sshpart/sshpart.go
@@ -395,8 +395,11 @@ func (p *SSHPartition) Remove(sPath string, caseInsensitive bool) {
 	}
 }
 
-func (p *SSHPartition) UserAdd(user, homeDir string, caseInsensitive bool) error {
+func (p *SSHPartition) UserAdd(user, homeDir string, caseInsensitive bool, isSys bool) error {
 	cmd := fmt.Sprintf("/usr/sbin/chroot %s /usr/sbin/useradd -m -s /bin/bash %s", p.mountPath, user)
+	if isSys {
+		cmd += " -r"
+	}
 	if len(homeDir) > 0 {
 		cmd += fmt.Sprintf(" -d %s", path.Join(homeDir, user))
 	}


### PR DESCRIPTION
Cherry pick of #11554 on release/3.7.

#11554: fix: add cloudroot as system account, so as not using normal user id