### PR TITLE
feat(monitor): update monitor resource overview

### DIFF
--- a/pkg/apis/monitor/monitor_resource_alert.go
+++ b/pkg/apis/monitor/monitor_resource_alert.go
@@ -7,8 +7,9 @@ import (
 )
 
 type MonitorResourceJointListInput struct {
-	MonitorResourceId string `json:"monitor_resource_id"`
-	AlertId           string `json:"alert_id"`
+	MonitorResourceId string  `json:"monitor_resource_id"`
+	AlertId           string  `json:"alert_id"`
+	JointId           []int64 `json:"joint_id"`
 }
 
 type MonitorResourceJointCreateInput struct {

--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -516,6 +516,7 @@ func (c *QueryCondition) setResType() {
 	metricMeasurement, _ := models.MetricMeasurementManager.GetCache().Get(c.Query.Model.Measurement)
 	if metricMeasurement != nil {
 		resType = metricMeasurement.ResType
+		c.ResType = resType
 	}
 	if len(resType) != 0 && c.Query.Model.GroupBy[0].Params[0] != monitor.
 		MEASUREMENT_TAG_ID[resType] {

--- a/pkg/monitor/models/monitor_resource_alert.go
+++ b/pkg/monitor/models/monitor_resource_alert.go
@@ -59,7 +59,7 @@ func (manager *SMonitorResourceAlertManager) DetachJoint(ctx context.Context, us
 	}
 	errs := make([]error, 0)
 	for _, joint := range joints {
-		err := joint.Delete(ctx, userCred)
+		err := joint.Delete(ctx, nil)
 		if err != nil {
 			errs = append(errs, errors.Wrapf(err, "joint %s:%s ,%s:%s", manager.GetMasterFieldName(),
 				joint.MonitorResourceId, manager.GetSlaveFieldName(), joint.AlertId))
@@ -102,9 +102,12 @@ func (manager *SMonitorResourceAlertManager) GetJoinsByListInput(input monitor.M
 	if len(input.AlertId) != 0 {
 		query.Equals(manager.GetSlaveFieldName(), input.AlertId)
 	}
+	if len(input.JointId) != 0 {
+		query.In("row_id", input.JointId)
+	}
 	err := db.FetchModelObjects(manager, query, &joints)
 	if err != nil {
-		return nil, errors.Wrapf(err, "FetchModelObjects by GetJoinsByMasterId:%s err", input)
+		return nil, errors.Wrapf(err, "FetchModelObjects by GetJoinsByMasterId:%s err", input.MonitorResourceId)
 	}
 	return joints, nil
 }

--- a/pkg/monitor/models/monitor_resource_sync.go
+++ b/pkg/monitor/models/monitor_resource_sync.go
@@ -132,6 +132,7 @@ monLoop:
 					errs = append(errs, errors.Wrapf(err, "monitorResource:%s Update err", resource.Name))
 					continue monLoop
 				}
+				resource.UpdateAlertState()
 				if index == len(resources)-1 {
 					resources = resources[0:index]
 				} else {

--- a/pkg/monitor/tasks/detach_alertresource_task.go
+++ b/pkg/monitor/tasks/detach_alertresource_task.go
@@ -8,6 +8,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
+	"yunion.io/x/onecloud/pkg/apis/monitor"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/monitor/models"
@@ -33,6 +34,12 @@ func (self *DetachAlertResourceTask) OnInit(ctx context.Context, obj db.IStandal
 	err := models.GetAlertResourceManager().NotifyAlertResourceCount(ctx)
 	if err != nil {
 		log.Errorf("DetachAlertResourceTask NotifyAlertResourceCount error:%v", err)
+	}
+	// detach MonitorResourceJoint when alert disabel
+	err = models.MonitorResourceAlertManager.DetachJoint(ctx, self.GetUserCred(),
+		monitor.MonitorResourceJointListInput{AlertId: alert.GetId()})
+	if err != nil {
+		log.Errorf("DetachJoint when alert:%s disable err:%v", alert.GetName(), err)
 	}
 	logclient.AddActionLogWithStartable(self, alert, logclient.ACT_DETACH_ALERTRESOURCE, nil, self.UserCred, true)
 	self.SetStageComplete(ctx, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
1.调整监控总览-报警资源逻辑
启用禁用策略时对报警资源进行对应的挂载和解绑

**Does this PR need to be backport to the previous release branch?**:
- release/3.7

/cc @zexi 
/area monitor

