### PR TITLE
fix(region): sync storage before syncing host in syncOnPremiseCloudProviderInfo

### DIFF
--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -655,9 +655,12 @@ func (self *SStorage) SyncStatusWithHosts() {
 	}
 }
 
-func (manager *SStorageManager) getStoragesByZoneId(zoneId string, provider *SCloudprovider) ([]SStorage, error) {
+func (manager *SStorageManager) getStoragesByZone(zone *SZone, provider *SCloudprovider) ([]SStorage, error) {
 	storages := make([]SStorage, 0)
-	q := manager.Query().Equals("zone_id", zoneId)
+	q := manager.Query()
+	if zone != nil {
+		q = q.Equals("zone_id", zone.Id)
+	}
 	if provider != nil {
 		q = q.Equals("manager_id", provider.Id)
 	}
@@ -698,7 +701,7 @@ func (manager *SStorageManager) SyncStorages(ctx context.Context, userCred mccli
 		return nil, nil, syncResult
 	}
 
-	dbStorages, err := manager.getStoragesByZoneId(zone.Id, provider)
+	dbStorages, err := manager.getStoragesByZone(zone, provider)
 	if err != nil {
 		syncResult.Error(err)
 		return nil, nil, syncResult


### PR DESCRIPTION
**What this PR does / why we need it**:
场景：重新构建了某个存储，相当于把之前某个存储上的所有虚拟机迁移到一个新的存储上。

因为没有syncStorage，所以在同步syncHostStorge的时候无法disconnect host
和 没有的storage，这是因为storage上还有host的虚拟机。syncHostStorages
会失败，storageCache 也就不会同步，上面的icloudImage也不会同步。

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @ioito @swordqiu 