### PR TITLE
fix(monitor):  alert policy use ownerId when update

### DIFF
--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -920,7 +920,8 @@ func (alert *SCommonAlert) ValidateUpdateData(
 			return data, errors.Wrap(err, "metric_query Unmarshal error")
 		}
 		scope, _ := data.GetString("scope")
-		err = CommonAlertManager.ValidateMetricQuery(metricQuery, scope, userCred)
+		ownerId := CommonAlertManager.GetOwnerId(ctx, userCred, data)
+		err = CommonAlertManager.ValidateMetricQuery(metricQuery, scope, ownerId)
 		if err != nil {
 			return data, errors.Wrap(err, "metric query error")
 		}
@@ -949,6 +950,14 @@ func (alert *SCommonAlert) ValidateUpdateData(
 		data.Update(jsonutils.Marshal(updataInput))
 	}
 	return data, nil
+}
+
+func (manager *SCommonAlertManager) GetOwnerId(ctx context.Context, userCred mcclient.TokenCredential, data jsonutils.JSONObject) mcclient.IIdentityProvider {
+	ownId, _ := CommonAlertManager.FetchOwnerId(ctx, data)
+	if ownId == nil {
+		ownId = userCred
+	}
+	return ownId
 }
 
 func (alert *SCommonAlert) PostUpdate(


### PR DESCRIPTION
**What this PR does / why we need it**:
1.根据参数中的project和domain属性调用FetchOwnerId方法，然后确定报警策略归属并进行监控查询过滤

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

/cc @zexi 
/area monitor

