### PR TITLE
Automated cherry pick of #11610: fix: host detach wire not update netinterface

### DIFF
--- a/pkg/apigateway/handler/resource.go
+++ b/pkg/apigateway/handler/resource.go
@@ -805,7 +805,7 @@ func (f *ResourceHandlers) detachHandle(ctx context.Context, w http.ResponseWrit
 	jmod, e := modulebase.GetJointModule2(session, module, module2)
 	var obj jsonutils.JSONObject
 	if e == nil { // joint detach
-		obj, e = jmod.Detach(session, req.ResID(), req.ResID2(), nil)
+		obj, e = jmod.Detach(session, req.ResID(), req.ResID2(), req.Query())
 	} else {
 		obj, e = module2.DeleteInContextWithParam(session, req.ResID2(), req.Query(), req.Body(), module, req.ResID())
 	}

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -4424,6 +4424,9 @@ func (self *SHost) PerformDisableNetif(ctx context.Context, userCred mcclient.To
 	return nil, nil
 }
 
+/*
+ * Disable a net interface, remove IP address if assigned
+ */
 func (self *SHost) DisableNetif(ctx context.Context, userCred mcclient.TokenCredential, netif *SNetInterface, reserve bool) error {
 	bn := netif.GetBaremetalNetwork()
 	var ipAddr string

--- a/pkg/compute/models/netinterfaces.go
+++ b/pkg/compute/models/netinterfaces.go
@@ -78,6 +78,14 @@ func (manager *SNetInterfaceManager) FetchByMac(mac string) (*SNetInterface, err
 	return netif.(*SNetInterface), nil
 }
 
+func (netif *SNetInterface) UnsetWire() error {
+	_, err := db.Update(netif, func() error {
+		netif.WireId = ""
+		return nil
+	})
+	return err
+}
+
 func (netif *SNetInterface) GetWire() *SWire {
 	if len(netif.WireId) > 0 {
 		wireModel, _ := WireManager.FetchById(netif.WireId)


### PR DESCRIPTION
Cherry pick of #11610 on release/3.6.

#11610: fix: host detach wire not update netinterface