### PR TITLE
fix(monitor): fix monitor resourece update 

### DIFF
--- a/pkg/monitor/models/monitor_resource_sync.go
+++ b/pkg/monitor/models/monitor_resource_sync.go
@@ -125,6 +125,7 @@ monLoop:
 					continue monLoop
 				}
 				_, err = db.Update(resource, func() error {
+					res.(*jsonutils.JSONDict).Remove("id")
 					res.Unmarshal(resource)
 					return nil
 				})


### PR DESCRIPTION
**What this PR does / why we need it**:
1.通过region返回的obj更新监控资源时 remove掉id信息

**Does this PR need to be backport to the previous release branch?**:
- release/3.7

/cc @zexi 
/area monitor


