### PR TITLE
fix(region): set DefaultSysDiskBackend as empty for esxi guest

### DIFF
--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -94,7 +94,7 @@ func (self *SESXiGuestDriver) GetComputeQuotaKeys(scope rbacutils.TRbacScope, ow
 }
 
 func (self *SESXiGuestDriver) GetDefaultSysDiskBackend() string {
-	return api.STORAGE_LOCAL
+	return ""
 }
 
 func (self *SESXiGuestDriver) ChooseHostStorage(host *models.SHost, guest *models.SGuest, diskConfig *api.DiskConfig, storageIds []string) (*models.SStorage, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

fix #4667

- [x] Smoke testing completed
- [x] Unit test written
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zexi @ioito 