### PR TITLE
Automated cherry pick of #11622: fix(region): set DefaultSysDiskBackend as empty for esxi guest

### DIFF
--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -94,7 +94,7 @@ func (self *SESXiGuestDriver) GetComputeQuotaKeys(scope rbacutils.TRbacScope, ow
 }
 
 func (self *SESXiGuestDriver) GetDefaultSysDiskBackend() string {
-	return api.STORAGE_LOCAL
+	return ""
 }
 
 func (self *SESXiGuestDriver) ChooseHostStorage(host *models.SHost, guest *models.SGuest, diskConfig *api.DiskConfig, storageIds []string) (*models.SStorage, error) {


### PR DESCRIPTION
Cherry pick of #11622 on release/3.7.

#11622: fix(region): set DefaultSysDiskBackend as empty for esxi guest