### PR TITLE
Fix for Notify Config and Robot

### DIFF
--- a/pkg/apis/notify/config.go
+++ b/pkg/apis/notify/config.go
@@ -80,9 +80,13 @@ type ConfigValidateOutput struct {
 }
 
 type ConfigManagerGetTypesInput struct {
-	// description: domain where in config
-	// example: default
-	Domain string `json:"domain"`
+	// description: View the available notification channels for the domains with these DomainIds
+	// required: true
+	DomainIds []string `json:"domain_ids"`
+	// description: Operation of reduce
+	// required: false
+	// enum: union,merge
+	Operation string `json:"operation"`
 }
 
 type ConfigManagerGetTypesOutput struct {

--- a/pkg/mcclient/modules/mod_notify.go
+++ b/pkg/mcclient/modules/mod_notify.go
@@ -35,7 +35,7 @@ func init() {
 	NotifyReceiver = NewNotifyv2Manager(
 		"receiver",
 		"receivers",
-		[]string{"ID", "Name", "Email", "International_Mobile", "Enabled_Contact_Types", "Verified_Infos"},
+		[]string{"ID", "Name", "Domain_Id", "Project_Domain", "Email", "International_Mobile", "Enabled_Contact_Types", "Verified_Infos"},
 		[]string{},
 	)
 	register(&NotifyReceiver)

--- a/pkg/mcclient/options/notify/receiver.go
+++ b/pkg/mcclient/options/notify/receiver.go
@@ -125,7 +125,8 @@ func (ri *ReceiverIntellijGetOptions) Params() (jsonutils.JSONObject, error) {
 }
 
 type ReceiverGetTypeOptions struct {
-	Domain string `help:"Domain under where available contact methods"`
+	DomainIds []string `help:"View the available notification channels for the domains with these DomainIds"`
+	Operation string   `help:"Operation of reduce" choices:"merge|union"`
 }
 
 func (rg *ReceiverGetTypeOptions) Params() (jsonutils.JSONObject, error) {

--- a/pkg/notify/models/config.go
+++ b/pkg/notify/models/config.go
@@ -470,6 +470,28 @@ func (self *SConfigManager) InitializeData() error {
 		"admin_tenant_name": options.Options.AdminProject,
 	})
 	err = self.TableSpec().InsertOrUpdate(context.TODO(), config)
+
+	// init config name
+	q = self.Query().IsNullOrEmpty("name")
+	enConfigs := make([]SConfig, 0)
+	err = db.FetchModelObjects(self, q, &enConfigs)
+	if err != nil {
+		return errors.Wrap(err, "unable to get configs with empty name")
+	}
+	for i := range enConfigs {
+		c := &enConfigs[i]
+		name, err := db.GenerateAlterName(c, enConfigs[i].Type)
+		if err != nil {
+			return errors.Wrap(err, "unable to generate alter name")
+		}
+		_, err = db.Update(c, func() error {
+			c.Name = name
+			return nil
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to update name")
+		}
+	}
 	return nil
 }
 

--- a/pkg/notify/models/config.go
+++ b/pkg/notify/models/config.go
@@ -63,7 +63,7 @@ type SConfig struct {
 	db.SStandaloneResourceBase
 	db.SDomainizedResourceBase
 
-	Type        string               `width:"15" nullable:"false" create:"required" get:"domain" list:"domain"`
+	Type        string               `width:"15" nullable:"false" create:"required" get:"domain" list:"domain" index:"true"`
 	Content     jsonutils.JSONObject `nullable:"false" create:"required" update:"domain" get:"domain" list:"domain"`
 	Attribution string               `width:"8" nullable:"false" default:"system" get:"domain" list:"domain" create:"optional"`
 }
@@ -232,6 +232,16 @@ func sortContactType(ctypes []string) []string {
 		}
 	}
 	return ret
+}
+
+func (cm *SConfigManager) contactTypesQuery(domainId string) *sqlchemy.SQuery {
+	q := cm.Query("type").Distinct()
+	if domainId == "" {
+		q = q.Equals("attribution", api.CONFIG_ATTRIBUTION_SYSTEM)
+	} else {
+		q = q.Filter(sqlchemy.OR(sqlchemy.AND(sqlchemy.Equals(q.Field("attribution"), api.CONFIG_ATTRIBUTION_DOMAIN), sqlchemy.Equals(q.Field("domain_id"), domainId)), sqlchemy.Equals(q.Field("attribution"), api.CONFIG_ATTRIBUTION_SYSTEM)))
+	}
+	return q
 }
 
 func (cm *SConfigManager) availableContactTypes(domainId string) ([]string, error) {

--- a/pkg/notify/models/robot.go
+++ b/pkg/notify/models/robot.go
@@ -65,7 +65,7 @@ func (rm *SRobotManager) InitializeData() error {
 	if len(configs) == 0 {
 		return nil
 	}
-	robots := make([]SRobot, len(configs))
+	robots := make([]SRobot, 0, len(configs))
 	for i := range configs {
 		webhook, _ := configs[i].Content.GetString("webhook")
 		robot := SRobot{
@@ -96,6 +96,8 @@ func (rm *SRobotManager) InitializeData() error {
 				robots = append(robots, robotn)
 			}
 			robot.Address = addresses[0]
+		default:
+			continue
 		}
 		robots = append(robots, robot)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

- feat(notify): Gets the available notification types for the receiver
- fix(notify): init robot correctly from old data
- fix(notify): init config name

- [x] Smoke testing completed

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area notify
/cc @zexi 