### PR TITLE
Automated cherry pick of #11274: fix(region): disable public cloud ip pre allocate

### DIFF
--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -112,7 +112,7 @@ type ComputeOptions struct {
 	ConvertEsxiDefaultTemplate       string `help:"ESXI baremetal convert option"`
 	ConvertKubeletDockerVolumeSize   string `default:"256g" help:"Docker volume size"`
 
-	EnablePreAllocateIpAddr bool `help:"Enable private and public cloud private ip pre allocate, default true" default:"true"`
+	EnablePreAllocateIpAddr bool `help:"Enable private and public cloud private ip pre allocate, default false" default:"false"`
 
 	DefaultImageCacheDir string `default:"image_cache"`
 


### PR DESCRIPTION
Cherry pick of #11274 on release/3.6.

#11274: fix(region): disable public cloud ip pre allocate