### PR TITLE
fix: qemu-img create disk may fail to preallocation=metadata enable for large disk

### DIFF
--- a/pkg/util/qemuimg/init.go
+++ b/pkg/util/qemuimg/init.go
@@ -59,11 +59,11 @@ func QemuImgInit() error {
 
 func qcow2SparseOptions() []string {
 	if version.LE(qemuImgVersion, "1.1") {
-		return []string{"preallocation=metadata", "cluster_size=2M"}
+		return []string{"cluster_size=2M"}
 	} else if version.LE(qemuImgVersion, "1.7.1") {
-		return []string{"preallocation=metadata", "lazy_refcounts=on"}
+		return []string{"lazy_refcounts=on"}
 	} else if version.LE(qemuImgVersion, "2.2") {
-		return []string{"preallocation=metadata", "lazy_refcounts=on", "cluster_size=2M"}
+		return []string{"lazy_refcounts=on", "cluster_size=2M"}
 	} else {
 		return []string{}
 	}

--- a/pkg/util/qemuimg/qemuimg.go
+++ b/pkg/util/qemuimg/qemuimg.go
@@ -22,9 +22,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
@@ -35,7 +34,7 @@ import (
 )
 
 var (
-	ErrUnsupportedFormat = errors.New("unsupported format")
+	ErrUnsupportedFormat = errors.Error("unsupported format")
 )
 
 type TIONiceLevel int
@@ -461,6 +460,9 @@ func (img *SQemuImage) CreateQcow2(sizeMB int, compact bool, backPath string) er
 		}
 	} else if !compact {
 		sparseOpts := qcow2SparseOptions()
+		if sizeMB <= 1024*1024*4 {
+			options = append(options, "preallocation=metadata")
+		}
 		options = append(options, sparseOpts...)
 	}
 	return img.create(sizeMB, QCOW2, options)


### PR DESCRIPTION
error report: failed to flush the refcount block cache: File too large

**What this PR does / why we need it**:
fix: qemu-img may fail when creating large disk with prealocation=metadata on

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 