### PR TITLE
fix: simplify SQL for distinct field query of tenant or domain names

### DIFF
--- a/pkg/cloudcommon/db/domain.go
+++ b/pkg/cloudcommon/db/domain.go
@@ -91,7 +91,7 @@ func ValidateCreateDomainId(domainId string) error {
 func (manager *SDomainizedResourceBaseManager) QueryDistinctExtraField(q *sqlchemy.SQuery, field string) (*sqlchemy.SQuery, error) {
 	switch field {
 	case "domain":
-		tenantCacheQuery := TenantCacheManager.GetDomainQuery("name", "id").SubQuery()
+		tenantCacheQuery := TenantCacheManager.getTable() // GetDomainQuery("name", "id").SubQuery()
 		q = q.AppendField(tenantCacheQuery.Field("name", "domain")).Distinct()
 		q = q.Join(tenantCacheQuery, sqlchemy.Equals(q.Field("domain_id"), tenantCacheQuery.Field("id")))
 		return q, nil

--- a/pkg/cloudcommon/db/project.go
+++ b/pkg/cloudcommon/db/project.go
@@ -77,7 +77,7 @@ func (manager *SProjectizedResourceBaseManager) FetchOwnerId(ctx context.Context
 func (manager *SProjectizedResourceBaseManager) QueryDistinctExtraField(q *sqlchemy.SQuery, field string) (*sqlchemy.SQuery, error) {
 	switch field {
 	case "tenant":
-		tenantCacheQuery := TenantCacheManager.GetTenantQuery("name", "id").Distinct().SubQuery()
+		tenantCacheQuery := TenantCacheManager.getTable() // GetTenantQuery("name", "id").Distinct().SubQuery()
 		q.AppendField(tenantCacheQuery.Field("name", "tenant")).Distinct()
 		q = q.Join(tenantCacheQuery, sqlchemy.Equals(q.Field("tenant_id"), tenantCacheQuery.Field("id")))
 		return q, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: simplify SQL for distinct field query of tenant or domain name

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 