### PR TITLE
fix(region): prevent the creation of redundant network segments when managing vmware

### DIFF
--- a/pkg/compute/tasks/cloud_account_sync_vmware_net.go
+++ b/pkg/compute/tasks/cloud_account_sync_vmware_net.go
@@ -230,6 +230,9 @@ func (self *CloudAccountSyncVMwareNetworkTask) createNetworks(ctx context.Contex
 	var err error
 	ret := make(map[string][]models.SVs2Wire)
 	for i := range capWires {
+		if len(capWires[i].GuestNetworks)+len(capWires[i].HostNetworks) == 0 {
+			continue
+		}
 		var wireId = capWires[i].WireId
 		if len(wireId) == 0 {
 			wireId, err = self.createWire(ctx, cloudaccount, api.DEFAULT_VPC_ID, zoneId, capWires[i].Name, capWires[i].Description)


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zexi 