### PR TITLE
Automated cherry pick of #11741: fix(region): prevent the creation of redundant network segments when managing vmware

### DIFF
--- a/pkg/compute/tasks/cloud_account_sync_vmware_net.go
+++ b/pkg/compute/tasks/cloud_account_sync_vmware_net.go
@@ -216,6 +216,9 @@ func (self *CloudAccountSyncVMwareNetworkTask) createNetworks(ctx context.Contex
 	var err error
 	ret := make(map[string][]models.SVs2Wire)
 	for i := range capWires {
+		if len(capWires[i].GuestNetworks)+len(capWires[i].HostNetworks) == 0 {
+			continue
+		}
 		var wireId = capWires[i].WireId
 		if len(wireId) == 0 {
 			wireId, err = self.createWire(ctx, cloudaccount, api.DEFAULT_VPC_ID, zoneId, capWires[i].Name, capWires[i].Description)


### PR DESCRIPTION
Cherry pick of #11741 on release/3.7.

#11741: fix(region): prevent the creation of redundant network segments when managing vmware