### PR TITLE
Automated cherry pick of #11746: fix: purge splitable logs for cloudevents and logger

### DIFF
--- a/cmd/climc/shell/cloudevent/cloudevents.go
+++ b/cmd/climc/shell/cloudevent/cloudevents.go
@@ -40,4 +40,18 @@ func init() {
 		printList(result, modules.Cloudevents.GetColumns(s))
 		return nil
 	})
+
+	type CloudeventLogsPurgeOptions struct {
+	}
+	R(&CloudeventLogsPurgeOptions{}, "cloud-event-purge", "Purge obsolete cloud event logs", func(s *mcclient.ClientSession, opts *CloudeventLogsPurgeOptions) error {
+		_, err := modules.Cloudevents.PerformClassAction(s, "purge-splitable", nil)
+		if err != nil {
+			return err
+		}
+		_, err = modules.CloudeventLogs.PerformClassAction(s, "purge-splitable", nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 }

--- a/pkg/mcclient/modules/mod_actions.go
+++ b/pkg/mcclient/modules/mod_actions.go
@@ -17,7 +17,8 @@ package modules
 import "yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 var (
-	Actions modulebase.ResourceManager
+	Actions    modulebase.ResourceManager
+	ActionLogs modulebase.ResourceManager
 )
 
 func init() {
@@ -25,4 +26,8 @@ func init() {
 		[]string{"id", "start_time", "service", "ops_time", "obj_id", "obj_type", "obj_name", "user", "user_id", "tenant", "tenant_id", "owner_tenant_id", "action", "success", "notes"},
 		[]string{})
 	register(&Actions)
+
+	ActionLogs = NewActionManager("event", "events",
+		[]string{"id", "ops_time", "obj_id", "obj_type", "obj_name", "user", "user_id", "tenant", "tenant_id", "owner_tenant_id", "action", "notes"},
+		[]string{})
 }

--- a/pkg/mcclient/modules/mod_cloudevents.go
+++ b/pkg/mcclient/modules/mod_cloudevents.go
@@ -17,7 +17,8 @@ package modules
 import "yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 var (
-	Cloudevents modulebase.ResourceManager
+	Cloudevents    modulebase.ResourceManager
+	CloudeventLogs modulebase.ResourceManager
 )
 
 func init() {
@@ -27,4 +28,9 @@ func init() {
 		[]string{})
 
 	register(&Cloudevents)
+
+	CloudeventLogs = NewCloudeventManager("event", "events",
+		[]string{"id", "ops_time", "obj_id", "obj_type", "obj_name", "user", "user_id", "tenant", "tenant_id", "owner_tenant_id", "action", "notes"},
+		[]string{})
+
 }


### PR DESCRIPTION
Cherry pick of #11746 on release/3.7.

#11746: fix: purge splitable logs for cloudevents and logger