### PR TITLE
Automated cherry pick of #11761: fix: avoid double counting when compute networks nic count

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -187,6 +187,7 @@ func (nm *SNetworkManager) jointNetworkCount(manager db.IModelManager, netIds []
 		q = filter(q)
 	}
 	q = q.AppendField(sqlchemy.COUNT("count"))
+	q = q.GroupBy("network_id")
 	return q
 }
 


### PR DESCRIPTION
Cherry pick of #11761 on release/3.7.

#11761: fix: avoid double counting when compute networks nic count