### PR TITLE
fix(monitor): fix resource details can't show monitor metric

### DIFF
--- a/pkg/monitor/models/unifiedmonitor.go
+++ b/pkg/monitor/models/unifiedmonitor.go
@@ -421,9 +421,6 @@ func checkQueryGroupBy(query *monitor.AlertQuery, inputQuery *monitor.MetricInpu
 	if len(query.Model.GroupBy) != 0 {
 		return
 	}
-	if inputQuery.Unit {
-		return
-	}
 	if query.Model.Database == monitor.METRIC_DATABASE_METER && inputQuery.Unit {
 		return
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
修复资源详情页无法展示对应监控数据的问题

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

/cc @zexi 
/area monitor
