### PR TITLE
fix(region): display info.name for local cachedimage

### DIFF
--- a/pkg/compute/models/guest_queries.go
+++ b/pkg/compute/models/guest_queries.go
@@ -265,8 +265,9 @@ func fetchGuestDisksInfo(guestIds []string) map[string][]api.GuestDiskInfo {
 		}
 		ret[gds[i].GuestId] = append(ret[gds[i].GuestId], gds[i].GuestDiskInfo)
 	}
-	imageNames, err := db.FetchIdNameMap2(CachedimageManager, imageIds)
+	imageNames, err := CachedimageManager.FetchIdRealNameMap2(imageIds)
 	if err != nil {
+		log.Errorf("unable to FetchIdRealNameMap2: %v", err)
 		return ret
 	}
 	for guestId, infos := range ret {


### PR DESCRIPTION
**What this PR does / why we need it**:

The image name of the yunioncloud virtual machine should be the same as that of glance

- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zexi  @swordqiu 