### PR TITLE
Automated cherry pick of #11806: fix(region): display info.name for local cachedimage

### DIFF
--- a/pkg/compute/models/guestdisks.go
+++ b/pkg/compute/models/guestdisks.go
@@ -274,7 +274,13 @@ func (self *SGuestdisk) GetDetailedInfo() api.GuestDiskInfo {
 		cachedImageObj, _ := CachedimageManager.FetchById(imageId)
 		if cachedImageObj != nil {
 			cachedImage := cachedImageObj.(*SCachedimage)
-			desc.Image = cachedImage.GetName()
+			imageName := cachedImage.GetName()
+			if len(cachedImage.ExternalId) == 0 {
+				if name, _ := cachedImage.Info.GetString("name"); len(name) > 0 {
+					imageName = name
+				}
+			}
+			desc.Image = imageName
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #11806 on release/3.7.

#11806: fix(region): display info.name for local cachedimage