### PR TITLE
Automated cherry pick of #11808: fix(region): avoid get openstack hostid panic

### DIFF
--- a/pkg/multicloud/openstack/region.go
+++ b/pkg/multicloud/openstack/region.go
@@ -206,6 +206,16 @@ func (region *SRegion) GetIVMById(id string) (cloudprovider.ICloudVM, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "GetInstance(%s)", id)
 	}
+	hosts, err := region.GetIHosts()
+	if err != nil {
+		return nil, err
+	}
+	for i := range hosts {
+		host := hosts[i].(*SHypervisor)
+		if instance.HypervisorHostname == host.HypervisorHostname {
+			instance.host = host
+		}
+	}
 	return instance, nil
 }
 


### PR DESCRIPTION
Cherry pick of #11808 on release/3.6.

#11808: fix(region): avoid get openstack hostid panic