### PR TITLE
Automated cherry pick of #11823: fix(region): prohibit resizing the disk of a esxi vm with instance snapshots

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -862,6 +862,15 @@ func (disk *SDisk) PerformResize(ctx context.Context, userCred mcclient.TokenCre
 	if guest != nil {
 		return nil, httperrors.NewUnsupportOperationError("try use /servers/<%s>/resize-disk API", guest.Id)
 	}
+	if guest.Hypervisor == api.HYPERVISOR_ESXI {
+		c, err := guest.GetInstanceSnapshotCount()
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to GetInstanceSnapshotCount for guest %s", guest.GetName())
+		}
+		if c > 0 {
+			return nil, httperrors.NewUnsupportOperationError("the disk of a esxi virtual machine with instance snapshots does not support resizing")
+		}
+	}
 	sizeMb, err := input.SizeMb()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry pick of #11823 on release/3.7.

#11823: fix(region): prohibit resizing the disk of a esxi vm with instance snapshots