### PR TITLE
Filter wires and networks from host_type of host

### DIFF
--- a/pkg/apis/compute/network.go
+++ b/pkg/apis/compute/network.go
@@ -126,6 +126,8 @@ type NetworkListInput struct {
 
 	// filter by BGP types
 	BgpType []string `json:"bgp_type"`
+
+	HostType string `json:"host_type"`
 }
 
 type NetworkResourceInfoBase struct {

--- a/pkg/apis/compute/wire.go
+++ b/pkg/apis/compute/wire.go
@@ -90,7 +90,8 @@ type WireListInput struct {
 
 	HostResourceInput
 
-	Bandwidth *int `json:"bandwidth"`
+	Bandwidth *int   `json:"bandwidth"`
+	HostType  string `json:"host_type"`
 }
 
 type WireMergeInput struct {

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -2060,15 +2060,49 @@ func (manager *SNetworkManager) ListItemFilter(
 	}
 
 	hostStr := input.HostId
-	if len(hostStr) > 0 {
-		hostObj, err := HostManager.FetchByIdOrName(userCred, hostStr)
-		if err != nil {
-			return nil, httperrors.NewResourceNotFoundError2(HostManager.Keyword(), hostStr)
+	if len(hostStr)+len(input.HostType) > 0 {
+		type sSimpleHost struct {
+			Id         string
+			OvnVersion string
 		}
-		host := hostObj.(*SHost)
-		sq := HostwireManager.Query("wire_id").Equals("host_id", hostObj.GetId())
-		if len(host.OvnVersion) > 0 {
-			wireQuery := WireManager.Query("id").IsNotNull("vpc_id")
+		hq := HostManager.Query("id", "ovn_version")
+		switch {
+		case len(hostStr) > 0 && len(input.HostType) > 0:
+			hq = hq.Filter(sqlchemy.OR(
+				sqlchemy.Equals(hq.Field("id"), hostStr),
+				sqlchemy.Equals(hq.Field("host_type"), input.HostType),
+			))
+		case len(hostStr) > 0:
+			hq = hq.Equals("id", hostStr)
+		case len(input.HostType) > 0:
+			hq = hq.Equals("host_type", input.HostType)
+		}
+		shs := make([]sSimpleHost, 0)
+		err := hq.All(&shs)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to filter all host from id and host type")
+		}
+		hostids := make([]string, len(shs))
+		var ovnVersion bool
+		for i := range shs {
+			hostids[i] = shs[i].Id
+			if len(shs[i].OvnVersion) > 0 {
+				ovnVersion = true
+			}
+		}
+		sq := HostwireManager.Query("wire_id")
+		switch len(hostids) {
+		case 0:
+			// hack for empty hostwire
+			sq = sq.IsTrue("deleted")
+		case 1:
+			sq = sq.Equals("host_id", hostids[0])
+		default:
+			sq = sq.In("host_id", hostids)
+		}
+		if ovnVersion {
+			vpcSub := VpcManager.Query("id").Equals("cloudregion_id", "default").NotEquals("id", api.DEFAULT_VPC_ID).SubQuery()
+			wireQuery := WireManager.Query("id").In("vpc_id", vpcSub)
 			q = q.Filter(sqlchemy.OR(
 				sqlchemy.In(q.Field("wire_id"), wireQuery.SubQuery()),
 				sqlchemy.In(q.Field("wire_id"), sq.SubQuery())),

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -1306,6 +1306,12 @@ func (manager *SWireManager) ListItemFilter(
 		sq := HostwireManager.Query("wire_id").Equals("host_id", hostObj.GetId())
 		q = q.Filter(sqlchemy.In(q.Field("id"), sq.SubQuery()))
 	}
+	if len(query.HostType) > 0 {
+		hs := HostManager.Query("id").Equals("host_type", query.HostType).SubQuery()
+		sq := HostwireManager.Query("wire_id")
+		sq = sq.Join(hs, sqlchemy.Equals(sq.Field("host_id"), hs.Field("id")))
+		q = q.Filter(sqlchemy.In(q.Field("id"), sq.SubQuery()))
+	}
 
 	if query.Bandwidth != nil {
 		q = q.Equals("bandwidth", *query.Bandwidth)

--- a/pkg/mcclient/options/network.go
+++ b/pkg/mcclient/options/network.go
@@ -44,7 +44,8 @@ type NetworkListOptions struct {
 	GuestIpStart []string `help:"search by guest_ip_start"`
 	GuestIpEnd   []string `help:"search by guest_ip_end"`
 
-	BgpType []string `help:"filter by bgp_type"`
+	BgpType  []string `help:"filter by bgp_type"`
+	HostType string   `help:"filter by host_type"`
 }
 
 func (opts *NetworkListOptions) GetContextId() string {

--- a/pkg/mcclient/options/wire.go
+++ b/pkg/mcclient/options/wire.go
@@ -21,10 +21,11 @@ type WireListOptions struct {
 
 	Bandwidth *int `help:"List wires by bandwidth"`
 
-	Region string `help:"List wires in region"`
-	Zone   string `help:"list wires in zone" json:"-"`
-	Vpc    string `help:"List wires in vpc"`
-	Host   string `help:"List wires attached to a host"`
+	Region   string `help:"List wires in region"`
+	Zone     string `help:"list wires in zone" json:"-"`
+	Vpc      string `help:"List wires in vpc"`
+	Host     string `help:"List wires attached to a host"`
+	HostType string `help:"List wires attached to host with HostType"`
 }
 
 func (wo *WireListOptions) GetContextId() string {


### PR DESCRIPTION
**What this PR does / why we need it**:

能够明显解决的一个问题是，创建虚拟机时可以过滤区分vmware的网络和yunioncloud的网络。

- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zexi @ioito @swordqiu 