### PR TITLE
fix: inter-vm traffic limited by eip bandwidth limit

### DIFF
--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -551,7 +551,7 @@ func (keeper *OVNNorthboundKeeper) ClaimGuestnetwork(ctx context.Context, guestn
 				qosEipOut = &ovn_nb.QoS{
 					Priority:  3000,
 					Direction: "from-lport",
-					Match:     fmt.Sprintf("inport == %q", lportName),
+					Match:     fmt.Sprintf("inport == %q && ip4 && ip4.src == %s", vpcErpName(vpc.Id), guestnetwork.IpAddr),
 					Bandwidth: map[string]int64{
 						"rate":  kbps,
 						"burst": kbur,
@@ -635,7 +635,7 @@ func (keeper *OVNNorthboundKeeper) ClaimGuestnetwork(ctx context.Context, guestn
 		args = append(args, ovnCreateArgs(qosEipIn, "qosEipIn")...)
 		args = append(args, "--", "add", "Logical_Switch", vpcEipLsName(vpc.Id), "qos_rules", "@qosEipIn")
 		args = append(args, ovnCreateArgs(qosEipOut, "qosEipOut")...)
-		args = append(args, "--", "add", "Logical_Switch", netLsName(guestnetwork.NetworkId), "qos_rules", "@qosEipOut")
+		args = append(args, "--", "add", "Logical_Switch", vpcEipLsName(vpc.Id), "qos_rules", "@qosEipOut")
 	}
 	return keeper.cli.Must(ctx, "ClaimGuestnetwork", args)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: inter-vm traffic should not be limited by eip bandwidth limit


<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 