### PR TITLE
fix(host-deployer): XFS uuid冲突 无法 mount

### DIFF
--- a/pkg/hostman/diskutils/fsutils/fsutils.go
+++ b/pkg/hostman/diskutils/fsutils/fsutils.go
@@ -28,6 +28,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
 
+	"yunion.io/x/onecloud/pkg/hostman/guestfs/kvmpart"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 	"yunion.io/x/onecloud/pkg/util/regutils2"
@@ -255,6 +256,11 @@ func ResizePartitionFs(fpath, fs string, raiseError bool) (error, bool) {
 			}
 		}
 		FsckXfsFs(fpath)
+		uuid := uuids["UUID"]
+		if len(uuid) > 0 {
+			kvmpart.LockXfsPartition(uuid)
+			defer kvmpart.UnlockXfsPartition(uuid)
+		}
 		cmds = [][]string{{"mkdir", "-p", tmpPoint},
 			{"mount", fpath, tmpPoint},
 			{"sleep", "2"},


### PR DESCRIPTION
这个PR修复XFS挂载磁盘 异常问题

1. ResizeFs 操作中 ResizePartitionFs 未对 xfs uuid 加锁
     导致挂载相同uuid 磁盘异异常
 - dmesg 显示
[86653.888361] XFS (nbd2p1): Filesystem has duplicate UUID f4553201-609a-4657-87aa-994cc6339f50 - can't mount

 - 批量创建虚拟机, 虚拟机磁盘为xfs, 多台虚拟机调度到同一宿主机时
   DeployGuestFs 无法 chroot password root

