### PR TITLE
Automated cherry pick of #11951: fix(host-deployer): XFS uuid冲突 无法 mount

### DIFF
--- a/pkg/hostman/diskutils/fsutils/fsutils.go
+++ b/pkg/hostman/diskutils/fsutils/fsutils.go
@@ -28,6 +28,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
 
+	"yunion.io/x/onecloud/pkg/hostman/guestfs/kvmpart"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 	"yunion.io/x/onecloud/pkg/util/regutils2"
@@ -255,6 +256,11 @@ func ResizePartitionFs(fpath, fs string, raiseError bool) (error, bool) {
 			}
 		}
 		FsckXfsFs(fpath)
+		uuid := uuids["UUID"]
+		if len(uuid) > 0 {
+			kvmpart.LockXfsPartition(uuid)
+			defer kvmpart.UnlockXfsPartition(uuid)
+		}
 		cmds = [][]string{{"mkdir", "-p", tmpPoint},
 			{"mount", fpath, tmpPoint},
 			{"sleep", "2"},


### PR DESCRIPTION
Cherry pick of #11951 on release/3.6.

#11951: fix(host-deployer): XFS uuid冲突 无法 mount