### PR TITLE
fix(region): adjust the query range corresponding to the alarm strategy

### DIFF
--- a/pkg/compute/models/scaling_trigger.go
+++ b/pkg/compute/models/scaling_trigger.go
@@ -341,7 +341,7 @@ func (sa *SScalingAlarm) generateAlertConfig(sp *SScalingPolicy) (*monitor.Alert
 	case api.OPERATOR_GT:
 		cond = cond.GT(sa.Value)
 	}
-	q := cond.Query().From(fmt.Sprintf("%ds", sa.Cycle))
+	q := cond.Query().From("1h")
 	sel := q.Selects().Select(indicatorMap[sa.Indicator].Field)
 	switch sa.Wrapper {
 	case api.WRAPPER_AVER:


### PR DESCRIPTION
**What this PR does / why we need it**:

The data in the cycle range may not be available yet, and the data in the last hour can be queried fixedly

- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zhasm @zexi 