### PR TITLE
Automated cherry pick of #11960: fix(region): adjust the query range corresponding to the alarm strategy

### DIFF
--- a/pkg/compute/models/scaling_trigger.go
+++ b/pkg/compute/models/scaling_trigger.go
@@ -341,7 +341,7 @@ func (sa *SScalingAlarm) generateAlertConfig(sp *SScalingPolicy) (*monitor.Alert
 	case api.OPERATOR_GT:
 		cond = cond.GT(sa.Value)
 	}
-	q := cond.Query().From(fmt.Sprintf("%ds", sa.Cycle))
+	q := cond.Query().From("1h")
 	sel := q.Selects().Select(indicatorMap[sa.Indicator].Field)
 	switch sa.Wrapper {
 	case api.WRAPPER_AVER:


### PR DESCRIPTION
Cherry pick of #11960 on release/3.6.

#11960: fix(region): adjust the query range corresponding to the alarm strategy