### PR TITLE
Automated cherry pick of #12020: feat(cloudcommon): move ignore_nonrunning_guests option to common

### DIFF
--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -109,6 +109,7 @@ var (
 			"customized_private_prefixes",
 			"global_http_proxy",
 			"global_https_proxy",
+			"ignore_nonrunning_guests",
 		},
 	}
 

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -102,6 +102,8 @@ type BaseOptions struct {
 
 	GlobalHTTPProxy  string `help:"Global http proxy"`
 	GlobalHTTPSProxy string `help:"Global https proxy"`
+
+	IgnoreNonrunningGuests bool `default:"true" help:"Count memory for running guests only when do scheduling. Ignore memory allocation for non-running guests"`
 }
 
 const (

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -27,7 +27,6 @@ type ComputeOptions struct {
 	DNSDomain    string   `help:"Domain suffix for virtual servers"`
 	DNSResolvers []string `help:"Upstream DNS resolvers"`
 
-	IgnoreNonrunningGuests        bool    `default:"true" help:"Count memory for running guests only when do scheduling. Ignore memory allocation for non-running guests"`
 	DefaultCPUOvercommitBound     float32 `default:"8.0" help:"Default cpu overcommit bound for host, default to 8"`
 	DefaultMemoryOvercommitBound  float32 `default:"1.0" help:"Default memory overcommit bound for host, default to 1"`
 	DefaultStorageOvercommitBound float32 `default:"1.0" help:"Default storage overcommit bound for storage, default to 1"`


### PR DESCRIPTION
Cherry pick of #12020 on release/3.8.

#12020: feat(cloudcommon): move ignore_nonrunning_guests option to common