### PR TITLE
Automated cherry pick of #12030: fix(keystone): appsrv listen multi port failed cause of race condition

### DIFF
--- a/pkg/cloudcommon/app/app.go
+++ b/pkg/cloudcommon/app/app.go
@@ -53,7 +53,7 @@ func ServeForeverExtended(app *appsrv.Application, options *common_options.BaseO
 	if options.EnableSsl {
 		proto = "https"
 	}
-	log.Infof("Start listen on %s://%s", proto, addr)
+	log.Infof("Start listen on %s://%s, isMaster: %v", proto, addr, isMaster)
 	var certfile string
 	var sslfile string
 	if options.EnableSsl {


### PR DESCRIPTION
Cherry pick of #12030 on release/3.8.

#12030: fix(keystone): appsrv listen multi port failed cause of race condition