### PR TITLE
Automated cherry pick of #12030: fix(keystone): appsrv listen multi port failed cause of race condition

### DIFF
--- a/pkg/appsrv/appsrv.go
+++ b/pkg/appsrv/appsrv.go
@@ -65,6 +65,7 @@ type Application struct {
 	isExiting       bool
 	idleConnsClosed chan struct{}
 	httpServer      *http.Server
+	slaveHttpServer *http.Server
 }
 
 const (
@@ -464,15 +465,16 @@ func (app *Application) ListenAndServeWithoutCleanup(addr, certFile, keyFile str
 }
 
 func (app *Application) ListenAndServeTLSWithCleanup2(addr string, certFile, keyFile string, onStop func(), isMaster bool) {
+	httpSrv := app.initServer(addr)
 	if isMaster {
 		app.addDefaultHandlers()
 		AddPProfHandler(app)
-	}
-	app.httpServer = app.initServer(addr)
-	if isMaster {
+		app.httpServer = httpSrv
 		app.registerCleanShutdown(app.httpServer, onStop)
+	} else {
+		app.slaveHttpServer = httpSrv
 	}
-	app.listenAndServeInternal(app.httpServer, certFile, keyFile)
+	app.listenAndServeInternal(httpSrv, certFile, keyFile)
 	if isMaster {
 		app.waitCleanShutdown()
 	}

--- a/pkg/cloudcommon/app/app.go
+++ b/pkg/cloudcommon/app/app.go
@@ -53,7 +53,7 @@ func ServeForeverExtended(app *appsrv.Application, options *common_options.BaseO
 	if options.EnableSsl {
 		proto = "https"
 	}
-	log.Infof("Start listen on %s://%s", proto, addr)
+	log.Infof("Start listen on %s://%s, isMaster: %v", proto, addr, isMaster)
 	var certfile string
 	var sslfile string
 	if options.EnableSsl {


### PR DESCRIPTION
Cherry pick of #12030 on release/3.6.

#12030: fix(keystone): appsrv listen multi port failed cause of race condition