### PR TITLE
Automated cherry pick of #12066: fix(climc): host-delete use batch delete function

### DIFF
--- a/cmd/climc/shell/compute/hosts.go
+++ b/cmd/climc/shell/compute/hosts.go
@@ -43,7 +43,7 @@ func init() {
 	cmd.Perform("start", &options.BaseIdOptions{})
 	cmd.Perform("stop", &options.BaseIdOptions{})
 	cmd.Perform("reset", &options.BaseIdOptions{})
-	cmd.Perform("delete", &options.BaseIdOptions{})
+	cmd.BatchDelete(&options.BaseIdsOptions{})
 	cmd.Perform("remove-all-netifs", &options.BaseIdOptions{})
 
 	cmd.BatchPerform("enable", &options.BaseIdsOptions{})


### PR DESCRIPTION
Cherry pick of #12066 on master.

#12066: fix(climc): host-delete use batch delete function