### PR TITLE
fix: add ceph-common to climc image, so as to make rbcli work

### DIFF
--- a/build/docker/Dockerfile.climc
+++ b/build/docker/Dockerfile.climc
@@ -1,4 +1,4 @@
-FROM registry.cn-beijing.aliyuncs.com/yunionio/climc-base:20210817
+FROM registry.cn-beijing.aliyuncs.com/yunionio/climc-base:20210901
 
 ADD ./build/climc/root/opt /opt
 

--- a/build/docker/Dockerfile.climc-base
+++ b/build/docker/Dockerfile.climc-base
@@ -8,7 +8,7 @@ RUN mkdir -p /opt/yunion/bin
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >>/etc/apk/repositories
 
-RUN apk add --no-cache bash bash-completion tzdata ca-certificates vim ipmitool kubectl && \
+RUN apk add --no-cache bash bash-completion tzdata ca-certificates vim ipmitool kubectl ceph-common && \
     rm -rf /var/cache/apk/*
 
 RUN cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add ceph-common to climc base image to make rbdcli work

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
