### PR TITLE
Automated cherry pick of #12083: fix: add ceph-common to climc image, so as to make rbcli work

### DIFF
--- a/build/docker/Dockerfile.climc
+++ b/build/docker/Dockerfile.climc
@@ -1,4 +1,4 @@
-FROM registry.cn-beijing.aliyuncs.com/yunionio/climc-base:20210817
+FROM registry.cn-beijing.aliyuncs.com/yunionio/climc-base:20210901
 
 ADD ./build/climc/root/opt /opt
 

--- a/build/docker/Dockerfile.climc-base
+++ b/build/docker/Dockerfile.climc-base
@@ -8,7 +8,7 @@ RUN mkdir -p /opt/yunion/bin
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >>/etc/apk/repositories
 
-RUN apk add --no-cache bash bash-completion tzdata ca-certificates vim ipmitool kubectl && \
+RUN apk add --no-cache bash bash-completion tzdata ca-certificates vim ipmitool kubectl ceph-common && \
     rm -rf /var/cache/apk/*
 
 RUN cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime


### PR DESCRIPTION
Cherry pick of #12083 on release/3.8.

#12083: fix: add ceph-common to climc image, so as to make rbcli work