### PR TITLE
Automated cherry pick of #12090: fix(climc-base): update tag to 20210901

### DIFF
--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -17,7 +17,7 @@ ANSIBLESERVER_BASE = v1.0.5
 ansibleserver-base:
 	$(DOCKER_BUILDX)/ansibleserver-base:$(ANSIBLESERVER_BASE) -f ./Dockerfile.ansibleserver-base .
 
-CLIMC_BASE_VERSION = 20210817
+CLIMC_BASE_VERSION = 20210901
 
 climc-base:
 	docker buildx build --platform linux/arm64,linux/amd64 --push \


### PR DESCRIPTION
Cherry pick of #12090 on release/3.7.

#12090: fix(climc-base): update tag to 20210901