### PR TITLE
fix(monitor): monitor resource apiHelper fix

### DIFF
--- a/pkg/apihelper/interface.go
+++ b/pkg/apihelper/interface.go
@@ -15,6 +15,8 @@
 package apihelper
 
 import (
+	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	mcclient "yunion.io/x/onecloud/pkg/mcclient"
 	mcclient_modulebase "yunion.io/x/onecloud/pkg/mcclient/modulebase"
@@ -42,6 +44,14 @@ type IModelSet interface {
 
 type IModelSetEmulatedIncluder interface {
 	IncludeEmulated() bool
+}
+
+type IModelSetFilter interface {
+	ModelFilter() []string
+}
+
+type IModelListParam interface {
+	ModelParamFilter() jsonutils.JSONObject
 }
 
 func SyncModelSets(mssOld IModelSets, s *mcclient.ClientSession, opt *Options) (r ModelSetsUpdateResult, err error) {

--- a/pkg/apihelper/reflect.go
+++ b/pkg/apihelper/reflect.go
@@ -120,6 +120,10 @@ func GetModels(opts *GetModelsOptions) error {
 			"cloud_env=onpremise",
 		)
 	}
+	if inter, ok := opts.ModelSet.(IModelSetFilter); ok {
+		filter := inter.ModelFilter()
+		listOptions.Filter = append(listOptions.Filter, filter...)
+	}
 	if !minUpdatedAt.Equal(PseudoZeroTime) {
 		// Only fetching pending deletes when we are doing incremental fetch
 		listOptions.PendingDeleteAll = options.Bool(true)
@@ -128,6 +132,10 @@ func GetModels(opts *GetModelsOptions) error {
 	params, err := listOptions.Params()
 	if err != nil {
 		return fmt.Errorf("%s: making list params: %s", manKeyPlural, err)
+	}
+	if inter, ok := opts.ModelSet.(IModelListParam); ok {
+		filter := inter.ModelParamFilter()
+		params.Update(filter)
 	}
 	//XXX
 	//params.Set(api.LBAGENT_QUERY_ORIG_KEY, jsonutils.NewString(api.LBAGENT_QUERY_ORIG_VAL))

--- a/pkg/monitor/models/modelset.go
+++ b/pkg/monitor/models/modelset.go
@@ -15,6 +15,8 @@
 package models
 
 import (
+	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/apihelper"
 	"yunion.io/x/onecloud/pkg/apis/monitor"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
@@ -130,6 +132,10 @@ func (s Servers) NeedSync() bool {
 	return true
 }
 
+func (s Servers) ModelFilter() []string {
+	return []string{"hypervisor.notin(baremetal,container)"}
+}
+
 func (h Hosts) AddModel(i db.IModel) {
 	resource := i.(*Host)
 	h[resource.Id] = resource
@@ -153,6 +159,12 @@ func (h Hosts) GetResType() string {
 
 func (s Hosts) NeedSync() bool {
 	return true
+}
+
+func (s Hosts) ModelParamFilter() jsonutils.JSONObject {
+	param := jsonutils.NewDict()
+	param.Set("baremetal", jsonutils.NewBool(false))
+	return param
 }
 
 func (r Rds) ModelManager() modulebase.IBaseManager {

--- a/pkg/monitor/models/monitor_resource.go
+++ b/pkg/monitor/models/monitor_resource.go
@@ -122,6 +122,41 @@ func (manager *SMonitorResourceManager) GetMonitorResources(input monitor.Monito
 	return monitorResources, nil
 }
 
+type SdeleteRes struct {
+	resType string
+	notIn   []string
+	in      []string
+}
+
+func (manager *SMonitorResourceManager) DeleteMonitorResources(ctx context.Context, userCred mcclient.TokenCredential, input SdeleteRes) error {
+	monitorResources := make([]SMonitorResource, 0)
+	errs := make([]error, 0)
+	query := manager.Query()
+	if len(input.notIn) != 0 {
+		query.NotIn("res_id", input.notIn)
+	}
+	if len(input.in) != 0 {
+		query.In("res_id", input.in)
+	}
+	if len(input.resType) != 0 {
+		query.Equals("res_type", input.resType)
+	}
+	err := db.FetchModelObjects(manager, query, &monitorResources)
+	if err != nil {
+		return errors.Wrap(err, "SMonitorResourceManager FetchModelObjects when DeleteMonitorResources err")
+	}
+	for _, res := range monitorResources {
+		err := (&res).RealDelete(ctx, userCred)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "delete monitorResource:%s err", res.GetId()))
+		}
+	}
+	if len(errs) != 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
 func (manager *SMonitorResourceManager) GetMonitorResourceById(id string) (*SMonitorResource, error) {
 	iModel, err := db.FetchById(manager, id)
 	if err != nil {
@@ -423,6 +458,7 @@ func (manager *SMonitorResourceManager) SyncResources(ctx context.Context, mss *
 	userCred := auth.AdminCredential()
 	errs := make([]error, 0)
 	log.Infoln("start sync")
+	aliveIds := make([]string, 0)
 	for _, set := range mss.ModelSetList() {
 		setRv := reflect.ValueOf(set)
 		needSync, typ := manager.GetSetType(set)
@@ -442,6 +478,7 @@ func (manager *SMonitorResourceManager) SyncResources(ctx context.Context, mss *
 				return errors.Wrap(err, "GetMonitorResources err")
 			}
 			if mRv.IsValid() {
+				aliveIds = append(aliveIds, kRv.String())
 				obj := jsonutils.Marshal(mRv.Interface())
 				if len(res) == 0 {
 					// no find to create
@@ -473,6 +510,10 @@ func (manager *SMonitorResourceManager) SyncResources(ctx context.Context, mss *
 					errs = append(errs, errors.Wrapf(err, "delete monitorResource:%s err", res[0].GetId()))
 				}
 			}
+		}
+		err := manager.DeleteMonitorResources(ctx, userCred, SdeleteRes{notIn: aliveIds, resType: typ})
+		if err != nil {
+			return err
 		}
 	}
 	log.Infoln("SMonitorResourceManager SyncResources End")


### PR DESCRIPTION
**What this PR does / why we need it**:
1. apiHeleper 中增加interface，对应的ModelSet可以指定资源过滤参数
2. monitor删除过期的资源

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.8

/cc @zexi 
/area monitor

