### PR TITLE
Automated cherry pick of #12126: fix(region): apsara default region

### DIFF
--- a/pkg/mcclient/options/cloudaccounts.go
+++ b/pkg/mcclient/options/cloudaccounts.go
@@ -774,6 +774,7 @@ func (opts *SVMwareCloudAccountPrepareNetsOptions) Params() (jsonutils.JSONObjec
 type SApsaraCloudAccountCreateOptions struct {
 	SCloudAccountCreateBaseOptions
 	cloudprovider.SApsaraEndpoints
+	Endpoint string
 	SAccessKeyCredential
 }
 


### PR DESCRIPTION
Cherry pick of #12126 on release/3.6.

#12126: fix(region): apsara default region