### PR TITLE
Automated cherry pick of #12202: feat(climc): SSH Login with cloudroot (add new parameter --use-cloudroot in server-ssh)

### DIFF
--- a/pkg/mcclient/modules/mod_sshkeypairs.go
+++ b/pkg/mcclient/modules/mod_sshkeypairs.go
@@ -48,6 +48,11 @@ func (this *SSshkeypairManager) List(s *mcclient.ClientSession, params jsonutils
 
 func (this *SSshkeypairManager) FetchPrivateKey(ctx context.Context, userCred mcclient.TokenCredential) (string, error) {
 	s := auth.GetSession(ctx, userCred, "", "")
+	return this.FetchPrivateKeyBySession(ctx, s)
+}
+
+func (this *SSshkeypairManager) FetchPrivateKeyBySession(ctx context.Context, s *mcclient.ClientSession) (string, error) {
+	userCred := s.GetToken()
 	jd := jsonutils.NewDict()
 	var jr jsonutils.JSONObject
 	if userCred.HasSystemAdminPrivilege() {

--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -99,10 +99,11 @@ type ServerLoginInfoOptions struct {
 
 type ServerSSHLoginOptions struct {
 	ServerLoginInfoOptions
-	Host     string `help:"IP address or hostname of the server"`
-	Port     int    `help:"SSH service port" default:"22"`
-	User     string `help:"SSH login user"`
-	Password string `help:"SSH password"`
+	Host         string `help:"IP address or hostname of the server"`
+	Port         int    `help:"SSH service port" default:"22"`
+	User         string `help:"SSH login user"`
+	Password     string `help:"SSH password"`
+	UseCloudroot bool   `help:"SSH login with cloudroot"`
 }
 
 type ServerConvertToKvmOptions struct {


### PR DESCRIPTION
Cherry pick of #12202 on release/3.8.

#12202: feat(climc): SSH Login with cloudroot (add new parameter --use-cloudroot in server-ssh)