### PR TITLE
Automated cherry pick of #12243: fix(region): consider the network of the entire VPC when merging networks

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -2489,7 +2489,10 @@ func (self *SNetwork) CheckInvalidToMerge(ctx context.Context, net *SNetwork, al
 
 	var wireNets []SNetwork
 	if allNets == nil {
-		q := NetworkManager.Query().Equals("wire_id", self.WireId).NotEquals("id", self.Id).NotEquals("id", net.Id)
+		wireSubq := WireManager.Query("vpc_id").Equals("id", self.WireId).SubQuery()
+		wiresQ := WireManager.Query("id")
+		wiresSubQ := wiresQ.Join(wireSubq, sqlchemy.Equals(wiresQ.Field("vpc_id"), wireSubq.Field("vpc_id"))).SubQuery()
+		q := NetworkManager.Query().In("wire_id", wiresSubQ).NotEquals("id", self.Id).NotEquals("id", net.Id)
 		err := db.FetchModelObjects(NetworkManager, q, &wireNets)
 		if err != nil && errors.Cause(err) != sql.ErrNoRows {
 			return "", "", errors.Wrap(err, "Query nets of same wire")

--- a/pkg/compute/tasks/networks_under_wire_merge_task.go
+++ b/pkg/compute/tasks/networks_under_wire_merge_task.go
@@ -91,7 +91,7 @@ func (self *NetworksUnderWireMergeTask) OnInit(ctx context.Context, obj db.IStan
 				wireNets = append(wireNets, nets[i].SNetwork)
 			}
 		}
-		ok, err := self.mergeNetwork(ctx, nets[i].SNetwork, nets[i+1].SNetwork, wireNets)
+		ok, err := self.mergeNetwork(ctx, nets[i].SNetwork, nets[i+1].SNetwork, nil)
 		if err != nil {
 			self.taskFailed(ctx, w, fmt.Sprintf("unable to merge network %q to %q", nets[i].GetId(), nets[i+1].GetId()), err)
 			return
@@ -100,7 +100,7 @@ func (self *NetworksUnderWireMergeTask) OnInit(ctx context.Context, obj db.IStan
 			continue
 		}
 		// Try to merge in the opposite direction
-		ok, err = self.mergeNetwork(ctx, nets[i+1].SNetwork, nets[i].SNetwork, wireNets)
+		ok, err = self.mergeNetwork(ctx, nets[i+1].SNetwork, nets[i].SNetwork, nil)
 		if err != nil {
 			self.taskFailed(ctx, w, fmt.Sprintf("unable to merge network %q to %q", nets[i+1].GetId(), nets[i].GetId()), err)
 			return


### PR DESCRIPTION
Cherry pick of #12243 on release/3.7.

#12243: fix(region): consider the network of the entire VPC when merging networks