### PR TITLE
Automated cherry pick of #12258: fix: verify token with expired_at field instead of depending on options.TokenExpirationSeconds

### DIFF
--- a/cmd/cryptool/shell/fernet.go
+++ b/cmd/cryptool/shell/fernet.go
@@ -16,7 +16,6 @@ package shell
 
 import (
 	"fmt"
-	"time"
 
 	"yunion.io/x/pkg/util/timeutils"
 
@@ -110,7 +109,7 @@ func init() {
 		}
 		fmt.Println("primary key hash:", fm.PrimaryKeyHash())
 
-		ret := fm.Decrypt([]byte(args.MSG), time.Hour*-1)
+		ret := fm.Decrypt([]byte(args.MSG))
 		if len(ret) == 0 {
 			return fmt.Errorf("invalid message")
 		}

--- a/pkg/keystone/models/credentials.go
+++ b/pkg/keystone/models/credentials.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
@@ -214,7 +213,7 @@ func credentialExtra(cred *SCredential, out api.CredentialDetails) api.Credentia
 }
 
 func (self *SCredential) getBlob() []byte {
-	return keys.CredentialKeyManager.Decrypt([]byte(self.EncryptedBlob), time.Duration(-1))
+	return keys.CredentialKeyManager.Decrypt([]byte(self.EncryptedBlob))
 }
 
 func (self *SCredential) GetAccessKeySecret() (*api.SAccessKeySecretBlob, error) {

--- a/pkg/keystone/tokens/token_test.go
+++ b/pkg/keystone/tokens/token_test.go
@@ -54,7 +54,7 @@ func TestSAuthToken_Encode(t *testing.T) {
 			t.Fatalf("SFernetKeyManager encrypt fail %s", err)
 		}
 
-		dtm := fm.Decrypt(ft, time.Hour)
+		dtm := fm.Decrypt(ft)
 		token2 := SAuthToken{}
 		err = token2.Decode(dtm)
 		if err != nil {

--- a/pkg/util/fernetool/fernet.go
+++ b/pkg/util/fernetool/fernet.go
@@ -82,7 +82,11 @@ func (m *SFernetKeyManager) LoadKeys(path string) error {
 	return nil
 }
 
-func (m *SFernetKeyManager) Decrypt(tok []byte, ttl time.Duration) []byte {
+func (m *SFernetKeyManager) Decrypt(tok []byte) []byte {
+	return m.VerifyAndDecrypt(tok, 0)
+}
+
+func (m *SFernetKeyManager) VerifyAndDecrypt(tok []byte, ttl time.Duration) []byte {
 	modReturned := len(tok) % 4
 	if modReturned > 0 {
 		for i := 0; i < 4-modReturned; i += 1 {

--- a/pkg/util/fernetool/fernet_test.go
+++ b/pkg/util/fernetool/fernet_test.go
@@ -17,7 +17,6 @@ package fernetool
 import (
 	"crypto/rand"
 	"testing"
-	"time"
 )
 
 func TestFernetKeys(t *testing.T) {
@@ -36,7 +35,7 @@ func TestFernetKeys(t *testing.T) {
 		if err != nil {
 			t.Fatalf("fail to encrypt %s", err)
 		}
-		omsg := m.Decrypt(msg, time.Hour)
+		omsg := m.Decrypt(msg)
 		if len(omsg) != msgLen {
 			t.Fatalf("descrupt fail %s", err)
 		}


### PR DESCRIPTION
Cherry pick of #12258 on release/3.8.

#12258: fix: verify token with expired_at field instead of depending on options.TokenExpirationSeconds