### PR TITLE
Automated cherry pick of #12285: fix(region): export field duplicate vpc

### DIFF
--- a/pkg/compute/models/mount_targets.go
+++ b/pkg/compute/models/mount_targets.go
@@ -338,10 +338,6 @@ func (manager *SMountTargetManager) ListItemExportKeys(ctx context.Context,
 	if err != nil {
 		return nil, errors.Wrap(err, "SStatusStandaloneResourceBaseManager.ListItemExportKeys")
 	}
-	q, err = manager.SVpcResourceBaseManager.ListItemExportKeys(ctx, q, userCred, keys)
-	if err != nil {
-		return nil, errors.Wrapf(err, "SVpcResourceBaseManager.ListItemExportKeys")
-	}
 	q, err = manager.SNetworkResourceBaseManager.ListItemExportKeys(ctx, q, userCred, keys)
 	if err != nil {
 		return nil, errors.Wrapf(err, "SNetworkResourceBaseManager.ListItemExportKeys")


### PR DESCRIPTION
Cherry pick of #12285 on release/3.7.

#12285: fix(region): export field duplicate vpc