### PR TITLE
fix(monitor): project view hide cloudaccount resource

### DIFF
--- a/pkg/monitor/models/modelset.go
+++ b/pkg/monitor/models/modelset.go
@@ -26,6 +26,10 @@ import (
 	mcclient_modules "yunion.io/x/onecloud/pkg/mcclient/modules"
 )
 
+const (
+	INTERNAL_ID = "internal"
+)
+
 type IMonitorResModelSet interface {
 	apihelper.IModelSet
 	GetResType() string
@@ -253,6 +257,7 @@ func (a Accounts) NewModel() db.IModel {
 
 func (a Accounts) AddModel(i db.IModel) {
 	resource := i.(*SAccount)
+	resource.TenantId = INTERNAL_ID
 	a[resource.Id] = resource
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
监控页面云账号资源不在项目视图展示

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

/cc @zexi 
/area monitor
