### PR TITLE
fix(monitor): monitor alert support multi robot

### DIFF
--- a/pkg/apis/monitor/commalert.go
+++ b/pkg/apis/monitor/commalert.go
@@ -56,6 +56,8 @@ type CommonAlertCreateInput struct {
 	Channel []string `json:"channel"`
 	// 通知接受者
 	Recipients []string `json:"recipients"`
+
+	RobotIds []string `json:"robot_ids"`
 	// 静默期
 	SilentPeriod string `json:"silent_period"`
 	// 报警类型
@@ -132,6 +134,7 @@ type CommonAlertDetails struct {
 	NotifierId    string   `json:"notifier_id"`
 	Channel       []string `json:"channel"`
 	Recipients    []string `json:"recipients"`
+	RobotIds      []string `json:"robot_ids"`
 	// 静默期
 	SilentPeriod string `json:"silent_period"`
 	Status       string `json:"status"`

--- a/pkg/apis/monitor/notification.go
+++ b/pkg/apis/monitor/notification.go
@@ -78,8 +78,9 @@ type NotificationListInput struct {
 }
 
 type NotificationSettingOneCloud struct {
-	Channel string   `json:"channel"`
-	UserIds []string `json:"user_ids"`
+	Channel  string   `json:"channel"`
+	UserIds  []string `json:"user_ids"`
+	RobotIds []string `json:"robot_ids"`
 }
 
 type SendWebhookSync struct {

--- a/pkg/monitor/models/nodealert.go
+++ b/pkg/monitor/models/nodealert.go
@@ -84,7 +84,7 @@ func (v1man *SV1AlertManager) CreateNotification(
 	channel string,
 	recipients string) (*SNotification, error) {
 	userIds := strings.Split(recipients, ",")
-	return NotificationManager.CreateOneCloudNotification(ctx, userCred, alertName, channel, userIds, "")
+	return NotificationManager.CreateOneCloudNotification(ctx, userCred, alertName, channel, userIds, nil, "")
 }
 
 func (man *SNodeAlertManager) ValidateCreateData(

--- a/pkg/monitor/models/notification.go
+++ b/pkg/monitor/models/notification.go
@@ -160,15 +160,11 @@ func (man *SNotificationManager) ListItemFilter(ctx context.Context, q *sqlchemy
 	return q, err
 }
 
-func (man *SNotificationManager) CreateOneCloudNotification(
-	ctx context.Context,
-	userCred mcclient.TokenCredential,
-	alertName string,
-	channel string,
-	userIds []string, silentPeriod string) (*SNotification, error) {
+func (man *SNotificationManager) CreateOneCloudNotification(ctx context.Context, userCred mcclient.TokenCredential, alertName string, channel string, userIds []string, robotIds []string, silentPeriod string) (*SNotification, error) {
 	settings := &monitor.NotificationSettingOneCloud{
-		Channel: channel,
-		UserIds: userIds,
+		Channel:  channel,
+		UserIds:  userIds,
+		RobotIds: robotIds,
 	}
 
 	newName, err := db.GenerateName(ctx, man, userCred, alertName)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. 机器人下放到域后监控报警支持

**Does this PR need to be backport to the previous release branch?**:
- release/3.8


/cc @zexi 
/area monitor
