### PR TITLE
Automated cherry pick of #12333: fix(monitor): shield list support alert_name and res_name like query

### DIFF
--- a/pkg/apis/monitor/commalert.go
+++ b/pkg/apis/monitor/commalert.go
@@ -103,6 +103,7 @@ type CommonAlertListInput struct {
 	Level   string   `json:"level"`
 	ResType []string `json:"res_type"`
 	UsedBy  string   `json:"used_by"`
+	Name    string   `json:"name"`
 }
 
 type CommonAlertUpdateInput struct {

--- a/pkg/apis/monitor/monitor_resource_alert.go
+++ b/pkg/apis/monitor/monitor_resource_alert.go
@@ -31,6 +31,7 @@ type MonitorResourceJointListInput struct {
 	SendState         string  `json:"send_state"`
 	ResType           string  `json:"res_type"`
 	ResName           string  `json:"res_name"`
+	AlertName         string  `json:"alert_name"`
 }
 
 type MonitorResourceJointCreateInput struct {

--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -426,6 +426,9 @@ func (man *SCommonAlertManager) FieldListFilter(q *sqlchemy.SQuery, input monito
 	if len(input.Level) > 0 {
 		q.Equals("level", input.Level)
 	}
+	if len(input.Name) != 0 {
+		q.Contains("name", input.Name)
+	}
 }
 
 func (manager *SCommonAlertManager) GetExportExtraKeys(ctx context.Context, keys stringutils2.SSortedStrings, rowMap map[string]string) *jsonutils.JSONDict {

--- a/pkg/monitor/models/monitor_resource.go
+++ b/pkg/monitor/models/monitor_resource.go
@@ -193,7 +193,7 @@ func (manager *SMonitorResourceManager) FieldListFilter(q *sqlchemy.SQuery, quer
 		q.In("res_id", query.ResId)
 	}
 	if len(query.ResName) != 0 {
-		q.Equals("name", query.ResName)
+		q.Contains("name", query.ResName)
 	}
 	return q
 }

--- a/pkg/monitor/models/monitor_resource_alert.go
+++ b/pkg/monitor/models/monitor_resource_alert.go
@@ -180,6 +180,11 @@ func (m *SMonitorResourceAlertManager) ListItemFilter(ctx context.Context, q *sq
 		}
 		q.Filter(sqlchemy.In(q.Field("monitor_resource_id"), resQ.SubQuery()))
 	}
+	if len(input.AlertName) != 0 {
+		alertQuery := CommonAlertManager.Query("id")
+		CommonAlertManager.FieldListFilter(alertQuery, monitor.CommonAlertListInput{Name: input.AlertName})
+		q.Filter(sqlchemy.In(q.Field(m.GetSlaveFieldName()), alertQuery.SubQuery()))
+	}
 
 	return q, nil
 }


### PR DESCRIPTION
Cherry pick of #12333 on release/3.8.

#12333: fix(monitor): shield list support alert_name and res_name like query