### PR TITLE
Automated cherry pick of #12335: fix(baremetal): adjust adaptec raid logical volume order

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -2448,9 +2448,7 @@ func (s *SBaremetalServer) DoDiskConfig(term *ssh.Client) error {
 		}
 	}
 
-	tool := disktool.NewSSHPartitionTool(term)
-	tool.FetchDiskConfs(baremetal.GetDiskConfigurations(layouts))
-	err = tool.RetrieveDiskInfo()
+	tool, err := disktool.NewSSHPartitionTool(term, layouts)
 	if err != nil {
 		return err
 	}
@@ -2529,11 +2527,9 @@ func (s *SBaremetalServer) DoPartitionDisk(term *ssh.Client) ([]*disktool.Partit
 		return nil, errors.Wrapf(err, "CalculateLayout")
 	}
 
-	tool := disktool.NewSSHPartitionTool(term)
-	tool.FetchDiskConfs(baremetal.GetDiskConfigurations(layouts))
-	err = tool.RetrieveDiskInfo()
+	tool, err := disktool.NewSSHPartitionTool(term, layouts)
 	if err != nil {
-		return nil, errors.Wrapf(err, "RetrieveDiskInfo")
+		return nil, errors.Wrapf(err, "NewSSHPartitionTool")
 	}
 
 	disks, _ := s.desc.GetArray("disks")
@@ -2606,9 +2602,7 @@ func (s *SBaremetalServer) DoRebuildRootDisk(term *ssh.Client) ([]*disktool.Part
 		return nil, err
 	}
 
-	tool := disktool.NewSSHPartitionTool(term)
-	tool.FetchDiskConfs(baremetal.GetDiskConfigurations(layouts))
-	err = tool.RetrieveDiskInfo()
+	tool, err := disktool.NewSSHPartitionTool(term, layouts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/baremetal/utils/disktool/disktool.go
+++ b/pkg/baremetal/utils/disktool/disktool.go
@@ -753,12 +753,21 @@ type SSHPartitionTool struct {
 	term *ssh.Client
 }
 
-func NewSSHPartitionTool(term *ssh.Client) *SSHPartitionTool {
+func newSSHPartitionTool(term *ssh.Client) *SSHPartitionTool {
 	tool := &SSHPartitionTool{
 		term: term,
 	}
 	tool.PartitionTool = NewPartitionTool(tool)
 	return tool
+}
+
+func NewSSHPartitionTool(term *ssh.Client, layouts []baremetal.Layout) (*SSHPartitionTool, error) {
+	tool := newSSHPartitionTool(term)
+	tool.FetchDiskConfs(baremetal.GetDiskConfigurations(layouts))
+	if err := tool.RetrieveDiskInfo(); err != nil {
+		return nil, errors.Wrapf(err, "RetrieveDiskInfo")
+	}
+	return tool, nil
 }
 
 func (tool *SSHPartitionTool) Run(cmds ...string) ([]string, error) {

--- a/pkg/baremetal/utils/raid/raid.go
+++ b/pkg/baremetal/utils/raid/raid.go
@@ -37,6 +37,7 @@ const (
 	MODULE_MPT2SAS  = "mpt2sas"
 	MODULE_MPT3SAS  = "mpt3sas"
 	MODULE_AACRAID  = "aacraid"
+	MODULE_SMARTPQI = "smartpqi"
 )
 
 const (

--- a/pkg/hostman/guestfs/sshpart/sshpart.go
+++ b/pkg/hostman/guestfs/sshpart/sshpart.go
@@ -572,9 +572,8 @@ func (p *SSHPartition) Zerofree() {
 }
 
 func MountSSHRootfs(term *ssh.Client, layouts []baremetal.Layout) (*SSHPartition, fsdriver.IRootFsDriver, error) {
-	tool := disktool.NewSSHPartitionTool(term)
-	tool.FetchDiskConfs(baremetal.GetDiskConfigurations(layouts))
-	if err := tool.RetrieveDiskInfo(); err != nil {
+	tool, err := disktool.NewSSHPartitionTool(term, layouts)
+	if err != nil {
 		return nil, nil, err
 	}
 	tool.RetrievePartitionInfo()


### PR DESCRIPTION
Cherry pick of #12335 on release/3.6.

#12335: fix(baremetal): adjust adaptec raid logical volume order