### PR TITLE
Automated cherry pick of #12350: fix(region): network brand

### DIFF
--- a/pkg/compute/models/capabilities.go
+++ b/pkg/compute/models/capabilities.go
@@ -359,6 +359,8 @@ func getBrands(region *SCloudregion, zone *SZone, domainId string, capa *SCapabi
 		capa.LoadbalancerEngineBrands = append(capa.LoadbalancerEngineBrands, api.ONECLOUD_BRAND_ONECLOUD)
 	}
 
+	capa.NetworkManageBrands = append(capa.NetworkManageBrands, api.ONECLOUD_BRAND_ONECLOUD)
+
 	var appendBrand = func(enabled *[]string, disabled *[]string, readOnlyEnabled *[]string, readOnlyDisabled *[]string, brand, capability string, isEnable, readOnly bool) {
 		if readOnly {
 			if isEnable {


### PR DESCRIPTION
Cherry pick of #12350 on release/3.8.

#12350: fix(region): network brand