### PR TITLE
fix: webconsole close socket when read on error

### DIFF
--- a/pkg/webconsole/server/tty_server.go
+++ b/pkg/webconsole/server/tty_server.go
@@ -74,11 +74,13 @@ func initSocketHandler(so socketio.Socket, p *session.Pty) {
 				data, err := p.Read()
 				if err != nil {
 					log.Errorf("[%s] read data error: %v", so.Id(), err)
-					err = p.Stop()
+					/*err = p.Stop()
 					if err != nil {
 						log.Warningf("[%s] stop tty error: %v", so.Id(), err)
 					}
 					p.Session.Reconnect()
+					*/
+					cleanUp(so, p)
 				} else {
 					so.Emit(OUTPUT_EVENT, string(data))
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: webconsole close socket when reading on error

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 
/area webconsole