### PR TITLE
Automated cherry pick of #12353: fix: webconsole close socket when read on error

### DIFF
--- a/pkg/webconsole/server/tty_server.go
+++ b/pkg/webconsole/server/tty_server.go
@@ -74,11 +74,13 @@ func initSocketHandler(so socketio.Socket, p *session.Pty) {
 				data, err := p.Read()
 				if err != nil {
 					log.Errorf("[%s] read data error: %v", so.Id(), err)
-					err = p.Stop()
+					/*err = p.Stop()
 					if err != nil {
 						log.Warningf("[%s] stop tty error: %v", so.Id(), err)
 					}
 					p.Session.Reconnect()
+					*/
+					cleanUp(so, p)
 				} else {
 					so.Emit(OUTPUT_EVENT, string(data))
 				}


### PR DESCRIPTION
Cherry pick of #12353 on release/3.8.

#12353: fix: webconsole close socket when read on error