### PR TITLE
Automated cherry pick of #12359: kvm lb update lb listener redirect code fix

### DIFF
--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -373,6 +373,8 @@ func (self *SKVMRegionDriver) ValidateUpdateLoadbalancerListenerRuleData(ctx con
 	}
 	if lbr.RedirectCode > 0 {
 		redirectCodeV.Default(int64(lbr.RedirectCode))
+	} else {
+		redirectCodeV.Default(api.LB_REDIRECT_CODE_302)
 	}
 	if lbr.RedirectScheme != "" {
 		redirectSchemeV.Default(lbr.RedirectScheme)
@@ -590,6 +592,8 @@ func (self *SKVMRegionDriver) ValidateUpdateLoadbalancerListenerData(ctx context
 	}
 	if lblis.RedirectCode > 0 {
 		redirectCodeV.Default(int64(lblis.RedirectCode))
+	} else {
+		redirectCodeV.Default(api.LB_REDIRECT_CODE_302)
 	}
 	if lblis.RedirectScheme != "" {
 		redirectSchemeV.Default(lblis.RedirectScheme)

--- a/pkg/compute/regiondrivers/openstack.go
+++ b/pkg/compute/regiondrivers/openstack.go
@@ -969,6 +969,8 @@ func (self *SOpenStackRegionDriver) ValidateUpdateLoadbalancerListenerRuleData(c
 	}
 	if lbr.RedirectCode > 0 {
 		redirectCodeV.Default(int64(lbr.RedirectCode))
+	} else {
+		redirectCodeV.Default(api.LB_REDIRECT_CODE_302)
 	}
 	if lbr.RedirectScheme != "" {
 		redirectSchemeV.Default(lbr.RedirectScheme)


### PR DESCRIPTION
Cherry pick of #12359 on release/3.7.

#12359: kvm lb update lb listener redirect code fix