### PR TITLE
fix(climc): host-ssh use privateKey when ciphertext too short

### DIFF
--- a/cmd/climc/shell/compute/hosts.go
+++ b/cmd/climc/shell/compute/hosts.go
@@ -528,7 +528,7 @@ func init() {
 		i, e := modules.Hosts.GetLoginInfo(s, srvid, nil)
 		privateKey := ""
 		if e != nil {
-			if httputils.ErrorCode(e) == 404 {
+			if httputils.ErrorCode(e) == 404 || e.Error() == "ciphertext too short" {
 				var err error
 				privateKey, err = modules.Sshkeypairs.FetchPrivateKeyBySession(context.Background(), s)
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- release/3.8

/cc @swordqiu 
/area climc