### PR TITLE
Automated cherry pick of #12370: fix(climc): host-ssh use privateKey when ciphertext too short

### DIFF
--- a/cmd/climc/shell/compute/hosts.go
+++ b/cmd/climc/shell/compute/hosts.go
@@ -528,7 +528,7 @@ func init() {
 		i, e := modules.Hosts.GetLoginInfo(s, srvid, nil)
 		privateKey := ""
 		if e != nil {
-			if httputils.ErrorCode(e) == 404 {
+			if httputils.ErrorCode(e) == 404 || e.Error() == "ciphertext too short" {
 				var err error
 				privateKey, err = modules.Sshkeypairs.FetchPrivateKeyBySession(context.Background(), s)
 				if err != nil {


### PR DESCRIPTION
Cherry pick of #12370 on release/3.8.

#12370: fix(climc): host-ssh use privateKey when ciphertext too short