### PR TITLE
fix(devtool): change agent install metadata key

### DIFF
--- a/pkg/devtool/tasks/apply_script_task.go
+++ b/pkg/devtool/tasks/apply_script_task.go
@@ -171,7 +171,7 @@ func mapStringSlice(f func(string) string, a []string) []string {
 }
 
 const (
-	agentInstalledKey   = "sys:monitor_agent"
+	agentInstalledKey   = "__monitor_agent"
 	agentInstalledValue = "true"
 )
 


### PR DESCRIPTION
The tag beginning with sys will be overwritten by the cloud
- [x] Smoke testing completed
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area devtool
/cc @zexi 