### PR TITLE
fix: set qemu cpu sockets to 2 for x86 cpu

### DIFF
--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -513,7 +513,7 @@ function nic_mtu() {
 	cmd += fmt.Sprintf(" -machine %s,accel=%s", s.getMachine(), accel)
 	cmd += " -k en-us"
 	// #cmd += " -g 800x600"
-	cmd += fmt.Sprintf(" -smp %d,maxcpus=255", cpu)
+	cmd += fmt.Sprintf(" -smp cpus=%d,sockets=2,cores=64,maxcpus=128", cpu)
 	cmd += fmt.Sprintf(" -name %s", name)
 	// #cmd += fmt.Sprintf(" -uuid %s", self.desc["uuid"])
 	cmd += fmt.Sprintf(" -m %dM,slots=4,maxmem=524288M", mem)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: set default qemu cpu sockets to 2 for x86

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 
/area host