### PR TITLE
Automated cherry pick of #12432: fix: set qemu cpu sockets to 2 for x86 cpu

### DIFF
--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -513,7 +513,7 @@ function nic_mtu() {
 	cmd += fmt.Sprintf(" -machine %s,accel=%s", s.getMachine(), accel)
 	cmd += " -k en-us"
 	// #cmd += " -g 800x600"
-	cmd += fmt.Sprintf(" -smp %d,maxcpus=255", cpu)
+	cmd += fmt.Sprintf(" -smp cpus=%d,sockets=2,cores=64,maxcpus=128", cpu)
 	cmd += fmt.Sprintf(" -name %s", name)
 	// #cmd += fmt.Sprintf(" -uuid %s", self.desc["uuid"])
 	cmd += fmt.Sprintf(" -m %dM,slots=4,maxmem=524288M", mem)


### PR DESCRIPTION
Cherry pick of #12432 on release/3.8.

#12432: fix: set qemu cpu sockets to 2 for x86 cpu