### PR TITLE
feature: add global mac prefix option

### DIFF
--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -212,7 +212,7 @@ func (manager *SGuestnetworkManager) GenerateMac(netId string, suggestion string
 				log.Errorf("generate random mac failed: %s", err)
 				continue
 			}
-			mac = fmt.Sprintf("00:22:%02x:%02x:%02x:%02x", b[0], b[1], b[2], b[3])
+			mac = fmt.Sprintf("%s:%02x:%02x:%02x:%02x", options.Options.GlobalMacPrefix, b[0], b[1], b[2], b[3])
 		}
 		q := manager.Query().Equals("mac_addr", mac)
 		if len(netId) > 0 {

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -175,6 +175,8 @@ type ComputeOptions struct {
 
 	ProhibitRefreshingCloudImage bool `help:"Prohibit refreshing cloud image"`
 
+	GlobalMacPrefix string `help:"Global prefix of MAC address, default to 00:22" default:"00:22"`
+
 	esxi.EsxiOptions
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
feature: add global mac prefix option, by default, the option is 00:22

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 
/area region