### PR TITLE
Automated cherry pick of #12434: feature: add global mac prefix option

### DIFF
--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -212,7 +212,7 @@ func (manager *SGuestnetworkManager) GenerateMac(netId string, suggestion string
 				log.Errorf("generate random mac failed: %s", err)
 				continue
 			}
-			mac = fmt.Sprintf("00:22:%02x:%02x:%02x:%02x", b[0], b[1], b[2], b[3])
+			mac = fmt.Sprintf("%s:%02x:%02x:%02x:%02x", options.Options.GlobalMacPrefix, b[0], b[1], b[2], b[3])
 		}
 		q := manager.Query().Equals("mac_addr", mac)
 		if len(netId) > 0 {

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -175,6 +175,8 @@ type ComputeOptions struct {
 
 	ProhibitRefreshingCloudImage bool `help:"Prohibit refreshing cloud image"`
 
+	GlobalMacPrefix string `help:"Global prefix of MAC address, default to 00:22" default:"00:22"`
+
 	esxi.EsxiOptions
 }
 


### PR DESCRIPTION
Cherry pick of #12434 on release/3.8.

#12434: feature: add global mac prefix option