### PR TITLE
fix: glance depends s3fs

### DIFF
--- a/build/docker/Dockerfile.glance
+++ b/build/docker/Dockerfile.glance
@@ -2,5 +2,6 @@ FROM registry.cn-beijing.aliyuncs.com/yunionio/torrent:20210815.0
 
 MAINTAINER "Zexi Li <lizexi@yunionyun.com>"
 
+RUN apk add --no-cache s3fs-fuse --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 RUN mkdir -p /opt/yunion/bin
 ADD ./_output/alpine-build/bin/glance /opt/yunion/bin/glance

--- a/pkg/image/drivers/s3/minio.go
+++ b/pkg/image/drivers/s3/minio.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
@@ -57,9 +56,6 @@ func (c *S3Client) getBucket() (cloudprovider.ICloudBucket, error) {
 func Init(endpoint, accessKey, secretKey, bucket string, useSSL bool) error {
 	if client != nil {
 		return nil
-	}
-	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
-		endpoint = "http://" + endpoint
 	}
 	cfg := objectstore.NewObjectStoreClientConfig(endpoint, accessKey, secretKey)
 	minioClient, err := objectstore.NewObjectStoreClient(cfg)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fix removed s3fs in glance docker image

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 