### PR TITLE
Automated cherry pick of #12477: fix(baremetal): rebuild root calculate root disk partitions incorrect

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -185,6 +185,7 @@ func (m *SBaremetalManager) CleanBaremetal(bmId string) {
 func (m *SBaremetalManager) updateBaremetal(session *mcclient.ClientSession, bmId string) (jsonutils.JSONObject, error) {
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.JSONTrue, "is_baremetal")
+	params.Add(jsonutils.JSONTrue, "not_sync_config")
 	obj, err := modules.Hosts.Put(session, bmId, params)
 	if err != nil {
 		return nil, err
@@ -2658,7 +2659,13 @@ func (s *SBaremetalServer) DoRebuildRootDisk(term *ssh.Client) ([]*disktool.Part
 
 func (s *SBaremetalServer) SyncPartitionSize(term *ssh.Client, parts []*disktool.Partition) ([]jsonutils.JSONObject, error) {
 	disks, _ := s.desc.GetArray("disks")
+
+	// calculate root partitions count
 	rootPartsCnt := len(parts) - len(disks) + 1
+	if len(parts) < len(disks) {
+		// HACK: rebuild root disk
+		rootPartsCnt = len(parts)
+	}
 	rootParts := parts[0:rootPartsCnt]
 	dataParts := parts[rootPartsCnt:]
 	idx := 0

--- a/pkg/baremetal/tasks/worker.go
+++ b/pkg/baremetal/tasks/worker.go
@@ -24,14 +24,13 @@ import (
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/appsrv"
-	"yunion.io/x/onecloud/pkg/baremetal/options"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 )
 
 var baremetalTaskWorkerMan *appsrv.SWorkerManager
 
 func init() {
-	baremetalTaskWorkerMan = appsrv.NewWorkerManager("BaremetalTaskWorkerManager", options.Options.TaskWorkerCount, 1024, false)
+	baremetalTaskWorkerMan = appsrv.NewWorkerManager("BaremetalTaskWorkerManager", 4, 1024, false)
 }
 
 func GetWorkManager() *appsrv.SWorkerManager {

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3548,8 +3548,12 @@ func (self *SHost) PostUpdate(ctx context.Context, userCred mcclient.TokenCreden
 		}
 	}
 
-	if err := self.startSyncConfig(ctx, userCred, "", true); err != nil {
-		log.Errorf("start sync host %q config after updated", self.GetName())
+	notSyncConf, _ := data.Bool("not_sync_config")
+
+	if !notSyncConf {
+		if err := self.startSyncConfig(ctx, userCred, "", true); err != nil {
+			log.Errorf("start sync host %q config after updated", self.GetName())
+		}
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #12477 on release/3.8.

#12477: fix(baremetal): rebuild root calculate root disk partitions incorrect