### PR TITLE
Automated cherry pick of #12491: fix(region): set storage with snapshot id when change vm disk config

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2545,7 +2545,15 @@ func (self *SGuest) PerformChangeConfig(ctx context.Context, userCred mcclient.T
 	var diskIdx = 1
 	for i := range input.Disks {
 		disk := input.Disks[i]
-		if len(disk.Backend) == 0 {
+		if len(disk.SnapshotId) > 0 {
+			snapObj, err := SnapshotManager.FetchById(disk.SnapshotId)
+			if err != nil {
+				return nil, httperrors.NewResourceNotFoundError("snapshot %s not found", disk.SnapshotId)
+			}
+			snap := snapObj.(*SSnapshot)
+			disk.Storage = snap.StorageId
+		}
+		if len(disk.Backend) == 0 && len(disk.Storage) == 0 {
 			disk.Backend = self.getDefaultStorageType()
 		}
 		if disk.SizeMb > 0 {


### PR DESCRIPTION
Cherry pick of #12491 on release/3.8.

#12491: fix(region): set storage with snapshot id when change vm disk config