### PR TITLE
Automated cherry pick of #12491: fix(region): set storage with snapshot id when change vm disk config

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2616,7 +2616,15 @@ func (self *SGuest) PerformChangeConfig(ctx context.Context, userCred mcclient.T
 		if err != nil {
 			return nil, httperrors.NewBadRequestError("Parse disk info error: %s", err)
 		}
-		if len(diskConf.Backend) == 0 {
+		if len(diskConf.SnapshotId) > 0 {
+			snapObj, err := SnapshotManager.FetchById(diskConf.SnapshotId)
+			if err != nil {
+				return nil, httperrors.NewResourceNotFoundError("snapshot %s not found", diskConf.SnapshotId)
+			}
+			snap := snapObj.(*SSnapshot)
+			diskConf.Storage = snap.StorageId
+		}
+		if len(diskConf.Backend) == 0 && len(diskConf.Storage) == 0 {
 			diskConf.Backend = self.getDefaultStorageType()
 		}
 		if diskConf.SizeMb > 0 {


### PR DESCRIPTION
Cherry pick of #12491 on release/3.7.

#12491: fix(region): set storage with snapshot id when change vm disk config