### PR TITLE
fix(cloudcommon): update db_dispatcher set order by to sqlchemy.SQuery

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -708,12 +708,14 @@ func ListItems(manager IModelManager, ctx context.Context, userCred mcclient.Tok
 			// skip markerField in pagingConf
 			continue
 		}
-		colSpec := manager.TableSpec().ColumnSpec(orderByField)
-		if colSpec != nil {
-			if order == sqlchemy.SQL_ORDER_ASC {
-				q = q.Asc(orderByField)
-			} else {
-				q = q.Desc(orderByField)
+		for _, field := range q.QueryFields() {
+			if orderByField == field.Name() {
+				if order == sqlchemy.SQL_ORDER_ASC {
+					q = q.Asc(field)
+				} else {
+					q = q.Desc(field)
+				}
+				break
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. 支持对使用了聚合函数的field进行orderby 操作，如：sum(amount) as
   amount

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.8

/cc @zexi 
/cc @swordqiu 
/cc @ioito 
