### PR TITLE
fix(baremetal): TaskWorkerCount options not init

### DIFF
--- a/pkg/baremetal/tasks/worker.go
+++ b/pkg/baremetal/tasks/worker.go
@@ -24,16 +24,16 @@ import (
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/appsrv"
+	"yunion.io/x/onecloud/pkg/baremetal/options"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 )
 
 var baremetalTaskWorkerMan *appsrv.SWorkerManager
 
-func init() {
-	baremetalTaskWorkerMan = appsrv.NewWorkerManager("BaremetalTaskWorkerManager", 4, 1024, false)
-}
-
 func GetWorkManager() *appsrv.SWorkerManager {
+	if baremetalTaskWorkerMan == nil {
+		baremetalTaskWorkerMan = appsrv.NewWorkerManager("BaremetalTaskWorkerManager", options.Options.TaskWorkerCount, 1024, false)
+	}
 	return baremetalTaskWorkerMan
 }
 
@@ -62,7 +62,7 @@ func ExecuteTask(task ITask, args interface{}) {
 		task: task,
 		args: args,
 	}
-	baremetalTaskWorkerMan.Run(t, nil, nil)
+	GetWorkManager().Run(t, nil, nil)
 }
 
 func executeTask(task ITask, args interface{}) {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- release/3.8
- release/3.7

/area baremetal
/cc @swordqiu 