### PR TITLE
Automated cherry pick of #12510: fix(baremetal): TaskWorkerCount options not init

### DIFF
--- a/pkg/baremetal/tasks/worker.go
+++ b/pkg/baremetal/tasks/worker.go
@@ -24,16 +24,16 @@ import (
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/appsrv"
+	"yunion.io/x/onecloud/pkg/baremetal/options"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 )
 
 var baremetalTaskWorkerMan *appsrv.SWorkerManager
 
-func init() {
-	baremetalTaskWorkerMan = appsrv.NewWorkerManager("BaremetalTaskWorkerManager", 4, 1024, false)
-}
-
 func GetWorkManager() *appsrv.SWorkerManager {
+	if baremetalTaskWorkerMan == nil {
+		baremetalTaskWorkerMan = appsrv.NewWorkerManager("BaremetalTaskWorkerManager", options.Options.TaskWorkerCount, 1024, false)
+	}
 	return baremetalTaskWorkerMan
 }
 
@@ -45,7 +45,7 @@ func OnStop() {
 }
 
 func ExecuteTask(task ITask, args interface{}) {
-	baremetalTaskWorkerMan.Run(func() {
+	GetWorkManager().Run(func() {
 		executeTask(task, args)
 	}, nil, nil)
 }


### PR DESCRIPTION
Cherry pick of #12510 on release/3.7.

#12510: fix(baremetal): TaskWorkerCount options not init