### PR TITLE
Automated cherry pick of #12495: fix(cloudcommon): update db_dispatcher set order by to sqlchemy.SQuery

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -708,12 +708,14 @@ func ListItems(manager IModelManager, ctx context.Context, userCred mcclient.Tok
 			// skip markerField in pagingConf
 			continue
 		}
-		colSpec := manager.TableSpec().ColumnSpec(orderByField)
-		if colSpec != nil {
-			if order == sqlchemy.SQL_ORDER_ASC {
-				q = q.Asc(orderByField)
-			} else {
-				q = q.Desc(orderByField)
+		for _, field := range q.QueryFields() {
+			if orderByField == field.Name() {
+				if order == sqlchemy.SQL_ORDER_ASC {
+					q = q.Asc(field)
+				} else {
+					q = q.Desc(field)
+				}
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick of #12495 on release/3.8.

#12495: fix(cloudcommon): update db_dispatcher set order by to sqlchemy.SQuery