### PR TITLE
cn-southwest-2 default bgp type 5_sbgp

### DIFF
--- a/pkg/multicloud/huawei/region.go
+++ b/pkg/multicloud/huawei/region.go
@@ -579,6 +579,8 @@ func (self *SRegion) CreateEIP(eip *cloudprovider.SEip) (cloudprovider.ICloudEIP
 			eip.BGPType = "5_telcom"
 		case "cn-north-4", "ap-southeast-1", "ap-southeast-2", "eu-west-0":
 			eip.BGPType = "5_bgp"
+		case "cn-southwest-2":
+			eip.BGPType = "5_sbgp"
 		default:
 			eip.BGPType = "5_bgp"
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
* cn-southwest-2 default bgp type 5_sbgp

**Does this PR need to be backport to the previous release branch?**:
If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.8
- release/3.7

/area region
/cc @zexi 