### PR TITLE
fix: delayed probing GPU on host init and add disable_gpu option

### DIFF
--- a/pkg/hostman/isolated_device/isolated_device.go
+++ b/pkg/hostman/isolated_device/isolated_device.go
@@ -96,17 +96,22 @@ type IsolatedDeviceManager struct {
 	DetachedDevices []*CloudDeviceInfo
 }
 
-func NewManager(host IHost) (*IsolatedDeviceManager, error) {
+func NewManager(host IHost) *IsolatedDeviceManager {
 	man := &IsolatedDeviceManager{
 		host:            host,
 		Devices:         make([]IDevice, 0),
 		DetachedDevices: make([]*CloudDeviceInfo, 0),
 	}
-	err := man.fillPCIDevices()
-	return man, err
+	// Do probe laster - Qiu Jian
+	// err := man.fillPCIDevices()
+	return man
 }
 
-func (man *IsolatedDeviceManager) fillPCIDevices() error {
+func (man *IsolatedDeviceManager) ProbePCIDevices() error {
+	if len(man.Devices) > 0 {
+		// already probed, skip
+		return nil
+	}
 	// only support gpu by now
 	gpus, err := getPassthroughGPUS()
 	if err != nil {

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -143,7 +143,9 @@ type SHostOptions struct {
 	DisableProbeKubelet bool   `help:"Disable probe kubelet config" default:"false"`
 	KubeletRunDirectory string `help:"Kubelet config file path" default:"/var/lib/kubelet"`
 
-	DisableKVM bool `help:"force disable KVM" default:"false"`
+	DisableKVM bool `help:"force disable KVM" default:"false" json:"disable_kvm"`
+
+	DisableGPU bool `help:"force disable GPU" default:"false" json:"disable_gpu"`
 }
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: 1. delayed probing of GPU devices on host init 2. add disable_gpu option

<!-- 
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7
- release/3.6

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 
/area host