### PR TITLE
Automated cherry pick of #12561: fix: delayed probing GPU on host init and add disable_gpu option

### DIFF
--- a/pkg/hostman/isolated_device/isolated_device.go
+++ b/pkg/hostman/isolated_device/isolated_device.go
@@ -96,17 +96,22 @@ type IsolatedDeviceManager struct {
 	DetachedDevices []*CloudDeviceInfo
 }
 
-func NewManager(host IHost) (*IsolatedDeviceManager, error) {
+func NewManager(host IHost) *IsolatedDeviceManager {
 	man := &IsolatedDeviceManager{
 		host:            host,
 		Devices:         make([]IDevice, 0),
 		DetachedDevices: make([]*CloudDeviceInfo, 0),
 	}
-	err := man.fillPCIDevices()
-	return man, err
+	// Do probe laster - Qiu Jian
+	// err := man.fillPCIDevices()
+	return man
 }
 
-func (man *IsolatedDeviceManager) fillPCIDevices() error {
+func (man *IsolatedDeviceManager) ProbePCIDevices() error {
+	if len(man.Devices) > 0 {
+		// already probed, skip
+		return nil
+	}
 	// only support gpu by now
 	gpus, err := getPassthroughGPUS()
 	if err != nil {

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -142,6 +142,8 @@ type SHostOptions struct {
 
 	DisableProbeKubelet bool   `help:"Disable probe kubelet config" default:"false"`
 	KubeletRunDirectory string `help:"Kubelet config file path" default:"/var/lib/kubelet"`
+
+	DisableGPU bool `help:"force disable GPU" default:"false" json:"disable_gpu"`
 }
 
 var (


### PR DESCRIPTION
Cherry pick of #12561 on release/3.7.

#12561: fix: delayed probing GPU on host init and add disable_gpu option