### PR TITLE
fix(region): init timerQueue correctly

### DIFF
--- a/pkg/compute/models/scheduled_tasks.go
+++ b/pkg/compute/models/scheduled_tasks.go
@@ -571,9 +571,12 @@ func (stm *SScheduledTaskManager) timeScope(median time.Time, interval time.Dura
 	}
 }
 
-var timerQueue = make(chan struct{}, cop.Options.ScheduledTaskQueueSize)
+var timerQueue chan struct{}
 
 func (stm *SScheduledTaskManager) Timer(ctx context.Context, userCred mcclient.TokenCredential, isStart bool) {
+	if timerQueue == nil {
+		timerQueue = make(chan struct{}, cop.Options.ScheduledTaskQueueSize)
+	}
 	// 60 is for fault tolerance
 	interval := 60 + 30
 	timeScope := stm.timeScope(time.Now(), time.Duration(interval)*time.Second)


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- realease/3.8
- realease/3.7
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zexi 