### PR TITLE
Automated cherry pick of #12564: fix(region): init timerQueue correctly

### DIFF
--- a/pkg/compute/models/scheduled_tasks.go
+++ b/pkg/compute/models/scheduled_tasks.go
@@ -571,9 +571,12 @@ func (stm *SScheduledTaskManager) timeScope(median time.Time, interval time.Dura
 	}
 }
 
-var timerQueue = make(chan struct{}, cop.Options.ScheduledTaskQueueSize)
+var timerQueue chan struct{}
 
 func (stm *SScheduledTaskManager) Timer(ctx context.Context, userCred mcclient.TokenCredential, isStart bool) {
+	if timerQueue == nil {
+		timerQueue = make(chan struct{}, cop.Options.ScheduledTaskQueueSize)
+	}
 	// 60 is for fault tolerance
 	interval := 60 + 30
 	timeScope := stm.timeScope(time.Now(), time.Duration(interval)*time.Second)


### PR DESCRIPTION
Cherry pick of #12564 on release/3.8.

#12564: fix(region): init timerQueue correctly