### PR TITLE
Automated cherry pick of #12577: fix(region): delete instance snapshot itself after deleting subsnapshots

### DIFF
--- a/pkg/compute/tasks/instance_snapshot_delete_task.go
+++ b/pkg/compute/tasks/instance_snapshot_delete_task.go
@@ -96,6 +96,11 @@ func (self *InstanceSnapshotDeleteTask) OnKvmSnapshotDeleteFailed(
 }
 
 func (self *InstanceSnapshotDeleteTask) OnInstanceSnapshotDelete(ctx context.Context, isp *models.SInstanceSnapshot, data jsonutils.JSONObject) {
+	err := isp.Delete(ctx, self.UserCred)
+	if err != nil {
+		self.taskFail(ctx, isp, jsonutils.NewString(err.Error()))
+		return
+	}
 	self.taskComplete(ctx, isp, data)
 
 }


### PR DESCRIPTION
Cherry pick of #12577 on release/3.7.

#12577: fix(region): delete instance snapshot itself after deleting subsnapshots