### PR TITLE
fix: qemu extra options support multiple values

### DIFF
--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -19,9 +19,11 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/apis"
 	"yunion.io/x/onecloud/pkg/apis/billing"
+	"yunion.io/x/onecloud/pkg/httperrors"
 )
 
 type ServerListInput struct {
@@ -699,4 +701,31 @@ type ServerChangeDiskStorageInternalInput struct {
 	ServerChangeDiskStorageInput
 	StorageId    string `json:"storage_id"`
 	TargetDiskId string `json:"target_disk_id"`
+}
+
+type ServerSetExtraOptionInput struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (o ServerSetExtraOptionInput) Validate() error {
+	if len(o.Key) == 0 {
+		return errors.Wrap(httperrors.ErrBadRequest, "empty key")
+	}
+	if len(o.Value) == 0 {
+		return errors.Wrap(httperrors.ErrBadRequest, "empty value")
+	}
+	return nil
+}
+
+type ServerDelExtraOptionInput struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (o ServerDelExtraOptionInput) Validate() error {
+	if len(o.Key) == 0 {
+		return errors.Wrap(httperrors.ErrBadRequest, "empty key")
+	}
+	return nil
 }

--- a/pkg/hostman/guestman/qemu-arm.go
+++ b/pkg/hostman/guestman/qemu-arm.go
@@ -303,10 +303,7 @@ function nic_mtu() {
 	}
 
 	cmd += fmt.Sprintf(" -pidfile %s", s.GetPidFilePath())
-	extraOptions, _ := s.Desc.GetMap("extra_options")
-	for k, v := range extraOptions {
-		cmd += fmt.Sprintf(" -%s %s", k, v.String())
-	}
+	cmd += s.extraOptions()
 
 	// cmd += s.getQgaDesc()
 	if fileutils2.Exists("/dev/random") {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: qemu extra options support multiple key-value pairs

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 
/area region host
/hold