### PR TITLE
Automated cherry pick of #12666: fix: fail to free reserved ip in non-owner project

### DIFF
--- a/pkg/mcclient/modules/mod_reservedips.go
+++ b/pkg/mcclient/modules/mod_reservedips.go
@@ -51,7 +51,11 @@ func (this *ReservedIPManager) DoBatchReleaseReservedIps(s *mcclient.ClientSessi
 	}
 
 	// filter ip and network pairs.
-	ipFilterOps := jsonutils.NewDict()
+	originFilter, _ := params.Get("query")
+	if originFilter == nil {
+		originFilter = jsonutils.NewDict()
+	}
+	ipFilterOps := originFilter.(*jsonutils.JSONDict)
 	arr := jsonutils.NewArray()
 	filterCondition := "ip_addr.in(" + strings.Join(ips, ",") + ")"
 	arr.Add(jsonutils.NewString(filterCondition))


### PR DESCRIPTION
Cherry pick of #12666 on release/3.7.

#12666: fix: fail to free reserved ip in non-owner project