### PR TITLE
Automated cherry pick of #12679: fix(region): tag sync

### DIFF
--- a/pkg/compute/models/waf_instances.go
+++ b/pkg/compute/models/waf_instances.go
@@ -332,7 +332,6 @@ func (self *SCloudregion) SyncWafInstances(ctx context.Context, userCred mcclien
 			result.UpdateError(err)
 			continue
 		}
-		syncMetadata(ctx, userCred, &commondb[i], commonext[i])
 		localWafs = append(localWafs, commondb[i])
 		remoteWafs = append(remoteWafs, commonext[i])
 		result.Update()
@@ -344,7 +343,6 @@ func (self *SCloudregion) SyncWafInstances(ctx context.Context, userCred mcclien
 			result.AddError(err)
 			continue
 		}
-		syncMetadata(ctx, userCred, newWaf, added[i])
 		localWafs = append(localWafs, *newWaf)
 		remoteWafs = append(remoteWafs, added[i])
 		result.Add()
@@ -433,6 +431,7 @@ func (self *SWafInstance) SyncWithCloudWafInstance(ctx context.Context, userCred
 			Action: notifyclient.ActionSyncUpdate,
 		})
 	}
+	syncMetadata(ctx, userCred, self, ext)
 	return err
 }
 
@@ -461,6 +460,7 @@ func (self *SCloudregion) newFromCloudWafInstance(ctx context.Context, userCred 
 	if err != nil {
 		return nil, err
 	}
+	syncMetadata(ctx, userCred, waf, ext)
 	notifyclient.EventNotify(ctx, userCred, notifyclient.SEventNotifyParam{
 		Obj:    waf,
 		Action: notifyclient.ActionSyncCreate,

--- a/pkg/multicloud/azure/web_app.go
+++ b/pkg/multicloud/azure/web_app.go
@@ -27,6 +27,7 @@ import (
 )
 
 type SAppSite struct {
+	multicloud.SResourceBase
 	multicloud.AzureTags
 	region         *SRegion
 	appServicePlan *SAppServicePlan
@@ -215,8 +216,6 @@ func (as *SAppSite) GetProjectId() string {
 }
 
 type SApp struct {
-	multicloud.SResourceBase
-	multicloud.AzureTags
 	SAppSite
 }
 


### PR DESCRIPTION
Cherry pick of #12679 on release/3.8.

#12679: fix(region): tag sync