### PR TITLE
Automated cherry pick of #12705: gcp lb sync address bugfix

### DIFF
--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -1177,6 +1177,7 @@ func (lb *SLoadbalancer) SyncWithCloudLoadbalancer(ctx context.Context, userCred
 
 	diff, err := db.Update(lb, func() error {
 		lb.Address = extLb.GetAddress()
+		lb.AddressType = extLb.GetAddressType()
 		lb.Status = extLb.GetStatus()
 		// lb.Name = extLb.GetName()
 		lb.LoadbalancerSpec = extLb.GetLoadbalancerSpec()


### PR DESCRIPTION
Cherry pick of #12705 on release/3.8.

#12705: gcp lb sync address bugfix