### PR TITLE
fix: adjust the initialization order of init function contents

### DIFF
--- a/pkg/mcclient/modules/notify/mod_notification.go
+++ b/pkg/mcclient/modules/notify/mod_notification.go
@@ -99,9 +99,3 @@ func (manager *NotificationManager) Send(s *mcclient.ClientSession, msg SNotifyM
 	_, err := manager.Create(s, params)
 	return err
 }
-
-func init() {
-	Notifications = NotificationManager{
-		Notification,
-	}
-}

--- a/pkg/mcclient/modules/notify/mod_notify.go
+++ b/pkg/mcclient/modules/notify/mod_notify.go
@@ -90,4 +90,9 @@ func init() {
 		[]string{},
 	)
 	modules.Register(&NotifySubscriber)
+
+	// important: Notifications' init must be behind Notication's init
+	Notifications = NotificationManager{
+		Notification,
+	}
 }


### PR DESCRIPTION
改之前，mod_notification.go的init执行在mod_notify.go之前，但是mod_notification.go
init的初始化内容又依赖于mod_notify.go 所以现在合并一起

**What this PR does / why we need it**:
- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 