### PR TITLE
fix: close it after using sql.Rows

### DIFF
--- a/pkg/monitor/models/monitor_resource.go
+++ b/pkg/monitor/models/monitor_resource.go
@@ -358,6 +358,7 @@ func (manager *SMonitorResourceManager) GetPropertyAlert(ctx context.Context, us
 		if err != nil {
 			return nil, errors.Wrap(err, "getMonitorResourceAlert query err")
 		}
+		defer rows.Close()
 		total := int64(0)
 		resTypeDict := jsonutils.NewDict()
 		for rows.Next() {

--- a/pkg/notify/models/notification.go
+++ b/pkg/notify/models/notification.go
@@ -656,10 +656,11 @@ func dataCleaning(tableName string) error {
 		monthsDaysAgo,
 	)
 	q := sqlchemy.NewRawQuery(sqlStr)
-	_, err := q.Rows()
+	rows, err := q.Rows()
 	if err != nil {
 		return errors.Wrapf(err, "unable to delete expired data in %q", tableName)
 	}
+	defer rows.Close()
 	log.Infof("delete expired data in %q successfully", tableName)
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito @swordqiu 