### PR TITLE
Automated cherry pick of #12740: fix: close it after using sql.Rows

### DIFF
--- a/pkg/monitor/models/monitor_resource.go
+++ b/pkg/monitor/models/monitor_resource.go
@@ -336,6 +336,7 @@ func (manager *SMonitorResourceManager) GetPropertyAlert(ctx context.Context, us
 		if err != nil {
 			return nil, errors.Wrap(err, "getMonitorResourceAlert query err")
 		}
+		defer rows.Close()
 		total := int64(0)
 		resTypeDict := jsonutils.NewDict()
 		for rows.Next() {

--- a/pkg/notify/models/notification.go
+++ b/pkg/notify/models/notification.go
@@ -551,10 +551,11 @@ func dataCleaning(tableName string) error {
 		monthsDaysAgo,
 	)
 	q := sqlchemy.NewRawQuery(sqlStr)
-	_, err := q.Rows()
+	rows, err := q.Rows()
 	if err != nil {
 		return errors.Wrapf(err, "unable to delete expired data in %q", tableName)
 	}
+	defer rows.Close()
 	log.Infof("delete expired data in %q successfully", tableName)
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #12740 on release/3.7.

#12740: fix: close it after using sql.Rows