### PR TITLE
Automated cherry pick of #12747: fix: vpcagent fail to refresh session token

### DIFF
--- a/pkg/apihelper/apihelper.go
+++ b/pkg/apihelper/apihelper.go
@@ -118,7 +118,7 @@ func (h *APIHelper) adminClientSession(ctx context.Context) *mcclient.ClientSess
 	if s != nil {
 		token := s.GetToken()
 		expires := token.GetExpires()
-		if time.Now().Add(time.Hour).After(expires) {
+		if time.Now().Add(time.Hour).Before(expires) {
 			return s
 		}
 	}

--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -328,7 +328,8 @@ func (keeper *OVNNorthboundKeeper) ClaimNetwork(ctx context.Context, network *ag
 		} else {
 			dns, err := auth.GetDNSServers(opts.Region, "")
 			if err != nil {
-				log.Errorf("auth.GetDNSServers fail %s", err)
+				// ignore the error
+				// log.Errorf("auth.GetDNSServers fail %s", err)
 			} else {
 				dnsSrvs = strings.Join(dns, ",")
 			}
@@ -345,7 +346,8 @@ func (keeper *OVNNorthboundKeeper) ClaimNetwork(ctx context.Context, network *ag
 		} else {
 			ntp, err := auth.GetNTPServers(opts.Region, "")
 			if err != nil {
-				log.Errorf("auth.GetNTPServers fail %s", err)
+				// ignore
+				// log.Errorf("auth.GetNTPServers fail %s", err)
 			} else {
 				ntpSrvs = strings.Join(ntp, ",")
 			}


### PR DESCRIPTION
Cherry pick of #12747 on release/3.8.

#12747: fix: vpcagent fail to refresh session token