### PR TITLE
Automated cherry pick of #12747: fix: vpcagent fail to refresh session token

### DIFF
--- a/pkg/apihelper/apihelper.go
+++ b/pkg/apihelper/apihelper.go
@@ -118,7 +118,7 @@ func (h *APIHelper) adminClientSession(ctx context.Context) *mcclient.ClientSess
 	if s != nil {
 		token := s.GetToken()
 		expires := token.GetExpires()
-		if time.Now().Add(time.Hour).After(expires) {
+		if time.Now().Add(time.Hour).Before(expires) {
 			return s
 		}
 	}


### PR DESCRIPTION
Cherry pick of #12747 on release/3.7.

#12747: fix: vpcagent fail to refresh session token