### PR TITLE
fix(ansibleserver): update file-repo from v0.3.3 to v0.3.4

### DIFF
--- a/build/docker/Dockerfile.ansibleserver
+++ b/build/docker/Dockerfile.ansibleserver
@@ -1,7 +1,7 @@
 FROM registry.cn-beijing.aliyuncs.com/yunionio/ansibleserver-base:v1.0.5
 
 # install playbook and telegraf install pkg
-COPY --from=registry.cn-beijing.aliyuncs.com/yunionio/file-repo:v0.3.3 /opt/yunion/playbook /opt/yunion/playbook
-COPY --from=registry.cn-beijing.aliyuncs.com/yunionio/file-repo:v0.3.3 /opt/yunion/ansible-install-pkg /opt/yunion/ansible-install-pkg
+COPY --from=registry.cn-beijing.aliyuncs.com/yunionio/file-repo:v0.3.4 /opt/yunion/playbook /opt/yunion/playbook
+COPY --from=registry.cn-beijing.aliyuncs.com/yunionio/file-repo:v0.3.4 /opt/yunion/ansible-install-pkg /opt/yunion/ansible-install-pkg
 
 ADD ./_output/alpine-build/bin/ansibleserver /opt/yunion/bin/ansibleserver


### PR DESCRIPTION


**What this PR does / why we need it**:
1. When checking telegraf, it is compatible with higher version Debian
2. Debian compatible when getting the installation package name
3. compatible with UOS

Please check https://github.com/yunionio/ansible-telegraf/commit/01a066c5cb7fb95f04200c325011f408cb73521c for details
- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area ansibleserver
/cc @zexi 