### PR TITLE
fix(scheduler): correct sorting for HostPriorityList

### DIFF
--- a/pkg/scheduler/core/score/score.go
+++ b/pkg/scheduler/core/score/score.go
@@ -116,6 +116,10 @@ func NormalLess(b1, b2 *ScoreBucket) bool {
 	return b1.normalScore.Total() < b2.normalScore.Total()
 }
 
+func NormalEqual(b1, b2 *ScoreBucket) bool {
+	return b1.normalScore.Total() == b2.normalScore.Total()
+}
+
 func (b *ScoreBucket) debugString(kind string, vals map[string]int) string {
 	return fmt.Sprintf("%s: %v", kind, vals)
 }

--- a/pkg/scheduler/core/types.go
+++ b/pkg/scheduler/core/types.go
@@ -159,11 +159,6 @@ func (h HostPriorityList) Less(i, j int) bool {
 	s2 := h[j].Score.ScoreBucket
 	preferLess := score.PreferLess(s1, s2)
 	avoidLess := score.AvoidLess(s1, s2)
-	normalLess := score.NormalLess(s1, s2)
-
-	if !(preferLess || avoidLess || normalLess) {
-		return h[i].Host < h[j].Host
-	}
 
 	if preferLess {
 		return true
@@ -171,7 +166,10 @@ func (h HostPriorityList) Less(i, j int) bool {
 	if avoidLess {
 		return false
 	}
-	return normalLess
+	if score.NormalEqual(s1, s2) {
+		return h[i].Host < h[j].Host
+	}
+	return score.NormalLess(s1, s2)
 }
 
 func (h HostPriorityList) Swap(i, j int) {


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7
- release/3.6
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area scheduler
/cc @zexi @swordqiu 