### PR TITLE
fix(region): filter deleted storages

### DIFF
--- a/pkg/compute/models/storagecaches.go
+++ b/pkg/compute/models/storagecaches.go
@@ -84,7 +84,8 @@ func (self *SStoragecache) getValidStorages() []SStorage {
 	q := StorageManager.Query()
 	q = q.Equals("storagecache_id", self.Id).
 		Filter(sqlchemy.In(q.Field("status"), []string{api.STORAGE_ENABLED, api.STORAGE_ONLINE})).
-		Filter(sqlchemy.IsTrue(q.Field("enabled")))
+		Filter(sqlchemy.IsTrue(q.Field("enabled"))).
+		Filter(sqlchemy.IsFalse(q.Field("deleted")))
 	err := db.FetchModelObjects(StorageManager, q, &storages)
 	if err != nil {
 		return nil


### PR DESCRIPTION
In some situation, getValidStorages return deleted storage and the zone was deleted from
remote(openstack or others).

**What this PR does / why we need it**:
Filter deleted storags.
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
