### PR TITLE
fix: image service can start without valid track endpoints

### DIFF
--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -89,7 +89,7 @@ func StartService() {
 	trackers := torrent.GetTrackers()
 	if len(trackers) == 0 {
 		log.Errorf("no valid torrent-tracker")
-		return
+		// return
 	}
 
 	app := app_common.InitApp(baseOpts, true)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allow image to start without valid torrent tracker endpoints

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 