### PR TITLE
Automated cherry pick of #12822: fix: image service can start without valid track endpoints

### DIFF
--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -90,7 +90,7 @@ func StartService() {
 	trackers := torrent.GetTrackers()
 	if len(trackers) == 0 {
 		log.Errorf("no valid torrent-tracker")
-		return
+		// return
 	}
 
 	app := app_common.InitApp(baseOpts, true)


### PR DESCRIPTION
Cherry pick of #12822 on release/3.8.

#12822: fix: image service can start without valid track endpoints