### PR TITLE
fix(hostdeployer): Operate with the original name when vgrename fails

### DIFF
--- a/pkg/hostman/diskutils/nbd/lvmutils.go
+++ b/pkg/hostman/diskutils/nbd/lvmutils.go
@@ -157,10 +157,12 @@ func (p *SKVMGuestLVMPartition) SetupDevice() bool {
 	if len(p.vgid) == 0 {
 		return false
 	}
-	if !p.vgRename(p.vgid, p.vgname) {
-		return false
+	if p.vgRename(p.vgid, p.vgname) {
+		p.needChangeName = true
+	} else {
+		p.vgname = p.originVgname
+		p.needChangeName = false
 	}
-	p.needChangeName = true
 	if p.vgActivate(true) {
 		return true
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area hostdeployer
/cc @swordqiu @zexi 