### PR TITLE
Automated cherry pick of #12835: fix(hostdeployer): Operate with the original name when vgrename fails

### DIFF
--- a/pkg/hostman/diskutils/nbd/lvmutils.go
+++ b/pkg/hostman/diskutils/nbd/lvmutils.go
@@ -157,10 +157,12 @@ func (p *SKVMGuestLVMPartition) SetupDevice() bool {
 	if len(p.vgid) == 0 {
 		return false
 	}
-	if !p.vgRename(p.vgid, p.vgname) {
-		return false
+	if p.vgRename(p.vgid, p.vgname) {
+		p.needChangeName = true
+	} else {
+		p.vgname = p.originVgname
+		p.needChangeName = false
 	}
-	p.needChangeName = true
 	if p.vgActivate(true) {
 		return true
 	}


### PR DESCRIPTION
Cherry pick of #12835 on release/3.8.

#12835: fix(hostdeployer): Operate with the original name when vgrename fails