### PR TITLE
fix: cloudevent not initialize cloudevents_tbl in clickhouse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -157,6 +157,6 @@ require (
 	yunion.io/x/ovsdb v0.0.0-20200526071744-27bf0940cbc7
 	yunion.io/x/pkg v0.0.0-20211116020154-6a76ba2f7e97
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
-	yunion.io/x/sqlchemy v0.0.0-20211209232407-29f10e47db1f
+	yunion.io/x/sqlchemy v0.0.0-20211212072622-e63b8097854a
 	yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce
 )

--- a/go.sum
+++ b/go.sum
@@ -955,7 +955,7 @@ yunion.io/x/pkg v0.0.0-20211116020154-6a76ba2f7e97 h1:lY+5NlWwO2aIkfNnVOGKHmZvMt
 yunion.io/x/pkg v0.0.0-20211116020154-6a76ba2f7e97/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
-yunion.io/x/sqlchemy v0.0.0-20211209232407-29f10e47db1f h1:zGenK5vnuqmT+372uGlNMMV/thy/WZwLW6j1dgMn2ww=
-yunion.io/x/sqlchemy v0.0.0-20211209232407-29f10e47db1f/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
+yunion.io/x/sqlchemy v0.0.0-20211212072622-e63b8097854a h1:2x6ee1ZTSEqrUpNWKByKP+BxejEYTYxx09pFmWems4A=
+yunion.io/x/sqlchemy v0.0.0-20211212072622-e63b8097854a/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce h1:kU8xE7O5uZ1GSJVMZHoJ+jrNL7csUQHYGyAPW9QfNpE=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=

--- a/pkg/cloudevent/service/handlers.go
+++ b/pkg/cloudevent/service/handlers.go
@@ -40,6 +40,8 @@ import (
 func InitHandlers(app *appsrv.Application) {
 	db.InitAllManagers()
 
+	models.InitCloudevent()
+
 	taskman.AddTaskHandler("v1", app)
 
 	for _, manager := range []db.IModelManager{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1223,7 +1223,7 @@ yunion.io/x/pkg/util/workqueue
 yunion.io/x/pkg/utils
 # yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 yunion.io/x/s3cli
-# yunion.io/x/sqlchemy v0.0.0-20211209232407-29f10e47db1f
+# yunion.io/x/sqlchemy v0.0.0-20211212072622-e63b8097854a
 yunion.io/x/sqlchemy
 yunion.io/x/sqlchemy/backends
 yunion.io/x/sqlchemy/backends/clickhouse

--- a/vendor/yunion.io/x/sqlchemy/backends/clickhouse/columninfo.go
+++ b/vendor/yunion.io/x/sqlchemy/backends/clickhouse/columninfo.go
@@ -77,6 +77,9 @@ func (info *sSqlColumnInfo) getTagmap() map[string]string {
 	}
 	defVal := info.getDefault()
 	if len(defVal) > 0 {
+		if info.getType() == "String" && defVal[0] == '\'' {
+			defVal = defVal[1 : len(defVal)-1]
+		}
 		tagmap[sqlchemy.TAG_DEFAULT] = defVal
 	}
 	return tagmap


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: cloudevents not initialize clickhouse table

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 