### PR TITLE
Automated cherry pick of #12906: fix(region): respect disk's snapshotId in disk_batch_create_task

### DIFF
--- a/pkg/compute/tasks/disk_batch_create_task.go
+++ b/pkg/compute/tasks/disk_batch_create_task.go
@@ -171,7 +171,7 @@ func (self *DiskBatchCreateTask) startCreateDisk(ctx context.Context, disk *mode
 	quotas.CancelPendingUsage(ctx, self.UserCred, &pendingUsage, &quotaStorage, true) // success
 	self.SetPendingUsage(&pendingUsage, 0)
 
-	disk.StartDiskCreateTask(ctx, self.GetUserCred(), false, "", self.GetTaskId())
+	disk.StartDiskCreateTask(ctx, self.GetUserCred(), false, disk.SnapshotId, self.GetTaskId())
 }
 
 func (self *DiskBatchCreateTask) OnScheduleComplete(ctx context.Context, items []db.IStandaloneModel, data *jsonutils.JSONDict) {


### PR DESCRIPTION
Cherry pick of #12906 on release/3.7.

#12906: fix(region): respect disk's snapshotId in disk_batch_create_task