### PR TITLE
fix: lbagent pull resources of OneCloud only

### DIFF
--- a/pkg/lbagent/models/reflect.go
+++ b/pkg/lbagent/models/reflect.go
@@ -110,6 +110,7 @@ func GetModels(opts *GetModelsOptions) error {
 		},
 		OrderBy:   []string{"updated_at", "id"},
 		Order:     "asc",
+		Provider:  []string{"OneCloud"},
 		IsManaged: &isManaged,
 		Limit:     options.Int(opts.BatchListSize),
 		Offset:    options.Int(0),


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: lbagent pull resources of OneCloud only


<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7
- release/3.6

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 