### PR TITLE
Automated cherry pick of #12925: fix: lbagent pull resources of OneCloud only

### DIFF
--- a/pkg/lbagent/models/reflect.go
+++ b/pkg/lbagent/models/reflect.go
@@ -110,6 +110,7 @@ func GetModels(opts *GetModelsOptions) error {
 		},
 		OrderBy:   []string{"updated_at", "id"},
 		Order:     "asc",
+		Provider:  []string{"OneCloud"},
 		IsManaged: &isManaged,
 		Limit:     options.Int(opts.BatchListSize),
 		Offset:    options.Int(0),


### PR DESCRIPTION
Cherry pick of #12925 on release/3.6.

#12925: fix: lbagent pull resources of OneCloud only