### PR TITLE
Automated cherry pick of #12935: fix(host): more readable error info of GetWireOfIp

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1265,7 +1265,7 @@ func (h *SHostInfo) uploadNetworkInfo() {
 
 				wireInfo, err := hostutils.GetWireOfIp(context.Background(), kwargs)
 				if err != nil {
-					h.onFail(err)
+					h.onFail(errors.Wrapf(err, "GetWireOfIp args: %s", kwargs.String()))
 				} else {
 					nic.Network, _ = wireInfo.GetString("name")
 					h.doUploadNicInfo(nic)


### PR DESCRIPTION
Cherry pick of #12935 on release/3.7.

#12935: fix(host): more readable error info of GetWireOfIp