### PR TITLE
Automated cherry pick of #12971: fix(region): security group cache filter

### DIFF
--- a/pkg/compute/models/secgroupcache.go
+++ b/pkg/compute/models/secgroupcache.go
@@ -126,10 +126,6 @@ func (manager *SSecurityGroupCacheManager) ListItemFilter(
 	if err != nil {
 		return nil, errors.Wrap(err, "SCloudregionResourceBaseManager.ListItemFilter")
 	}
-	q, err = manager.SVpcResourceBaseManager.ListItemFilter(ctx, q, userCred, query.VpcFilterListInput)
-	if err != nil {
-		return nil, errors.Wrap(err, "SVpcResourceBaseManager.ListItemFilter")
-	}
 	q, err = manager.SSecurityGroupResourceBaseManager.ListItemFilter(ctx, q, userCred, query.SecgroupFilterListInput)
 	if err != nil {
 		return nil, errors.Wrap(err, "SSecurityGroupResourceBaseManager.ListItemFilter")


### PR DESCRIPTION
Cherry pick of #12971 on release/3.8.

#12971: fix(region): security group cache filter