### PR TITLE
Automated cherry pick of #12978: fix(build): move librbd librados to baremetal-agent-base image

### DIFF
--- a/build/docker/Dockerfile.baremetal-agent
+++ b/build/docker/Dockerfile.baremetal-agent
@@ -1,12 +1,8 @@
-FROM registry.cn-beijing.aliyuncs.com/yunionio/baremetal-base:v0.3.3
+FROM registry.cn-beijing.aliyuncs.com/yunionio/baremetal-base:v0.3.3-2
 
 MAINTAINER "Zexi Li <lizexi@yunionyun.com>"
 
 RUN mkdir -p /opt/yunion/bin
 
-#ADD ./_output/bin/baremetal-agent /opt/yunion/bin/baremetal-agent
-#ADD ./_output/bin/.baremetal-agent.bin /opt/yunion/bin/.baremetal-agent.bin
-#ADD ./_output/bin/bundles/baremetal-agent /opt/yunion/bin/bundles/baremetal-agent
-RUN apk add librados librbd
 ENV TZ UTC
 ADD ./_output/alpine-build/bin/baremetal-agent /opt/yunion/bin/baremetal-agent

--- a/build/docker/Dockerfile.baremetal-base
+++ b/build/docker/Dockerfile.baremetal-base
@@ -2,14 +2,14 @@ FROM --platform=linux/amd64 registry.cn-beijing.aliyuncs.com/yunionio/centos-bui
 RUN yum install -y https://iso.yunion.cn/vm-images/baremetal-pxerom-1.1.0-21092209.x86_64.rpm
 #RUN yum install -y http://192.168.23.50:8083/baremetal-pxerom-1.1.0-21092209.x86_64.rpm
 
-FROM registry.cn-beijing.aliyuncs.com/yunionio/onecloud-base:v0.3.5
+FROM registry.cn-beijing.aliyuncs.com/yunionio/onecloud-base:v0.3-3.13.5
 
 MAINTAINER "Yaoqi Wan <wanyaoqi@yunionyun.com>"
 
 RUN mkdir -p /opt/yunion/bin
 
 RUN apk update && \
-    apk add --no-cache ipmitool ethtool tzdata ca-certificates cdrkit coreutils && \
+    apk add --no-cache ipmitool ethtool tzdata ca-certificates cdrkit coreutils librados librbd && \
     rm -rf /var/cache/apk/*
 
 RUN mkdir -p /opt/cloud/yunion/baremetal

--- a/build/docker/Dockerfile.onecloud-base
+++ b/build/docker/Dockerfile.onecloud-base
@@ -7,6 +7,8 @@ ENV TZ UTC
 
 RUN mkdir -p /opt/yunion/bin
 
+RUN sed -i 's!https://dl-cdn.alpinelinux.org/!https://mirrors.ustc.edu.cn/!g' /etc/apk/repositories
+
 RUN apk update && \
     apk add --no-cache tzdata curl busybox-extras tcpdump strace ca-certificates && \
     rm -rf /var/cache/apk/*

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -7,7 +7,7 @@ debian10-base:
 	docker buildx build --platform linux/arm64,linux/amd64 --push \
 		-t registry.cn-beijing.aliyuncs.com/yunionio/debian10-base:1.0 -f ./Dockerfile.debian-base .
 
-ONECLOUD_BASE_VERSION = v0.3.5-1
+ONECLOUD_BASE_VERSION = v0.3-3.13.5
 
 onecloud-base:
 	$(DOCKER_BUILDX)/onecloud-base:$(ONECLOUD_BASE_VERSION) -f ./Dockerfile.onecloud-base .
@@ -27,7 +27,7 @@ WEBCONSOLE_BASE_VERSION = v0.2-1
 webconsole-base:
 	$(DOCKER_BUILDX)/webconsole-base:$(WEBCONSOLE_BASE_VERSION) -f ./Dockerfile.webconsole-base .
 
-BAREMETAL_BASE_VERSION = v0.3.3
+BAREMETAL_BASE_VERSION = v0.3.3-2
 
 baremetal-base:
 	$(DOCKER_BUILDX)/baremetal-base:$(BAREMETAL_BASE_VERSION) -f ./Dockerfile.baremetal-base .


### PR DESCRIPTION
Cherry pick of #12978 on release/3.8.

#12978: fix(build): move librbd librados to baremetal-agent-base image