### PR TITLE
fix(webconsole): ISessionData convert to *session.RemoteConsoleInfo

### DIFF
--- a/pkg/webconsole/server/server.go
+++ b/pkg/webconsole/server/server.go
@@ -55,9 +55,9 @@ func (s *ConnectionServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	var srv http.Handler
 	protocol := sessionObj.GetProtocol()
-	info := sessionObj.ISessionData.(*session.RemoteConsoleInfo)
 	switch protocol {
 	case session.VNC, session.SPICE:
+		info := sessionObj.ISessionData.(*session.RemoteConsoleInfo)
 		if info.Hypervisor == api.HYPERVISOR_OPENSTACK {
 			srv, err = NewWebsocketProxyServer(sessionObj)
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area webconsole
/cc @ioito 
- release/3.8