### PR TITLE
fix(region): replace vpc_delete with vpc_sync_delete when sycnRemoveVpc

### DIFF
--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -516,7 +516,7 @@ func (self *SVpc) syncRemoveCloudVpc(ctx context.Context, userCred mcclient.Toke
 		if err == nil {
 			notifyclient.EventNotify(ctx, userCred, notifyclient.SEventNotifyParam{
 				Obj:    self,
-				Action: notifyclient.ActionDelete,
+				Action: notifyclient.ActionSyncDelete,
 			})
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Smoke testing completed
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zexi @ioito 