### PR TITLE
Automated cherry pick of #12993: fix(region): replace vpc_delete with vpc_sync_delete when sycnRemoveVpc

### DIFF
--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -516,7 +516,7 @@ func (self *SVpc) syncRemoveCloudVpc(ctx context.Context, userCred mcclient.Toke
 		if err == nil {
 			notifyclient.EventNotify(ctx, userCred, notifyclient.SEventNotifyParam{
 				Obj:    self,
-				Action: notifyclient.ActionDelete,
+				Action: notifyclient.ActionSyncDelete,
 			})
 		}
 	}


### PR DESCRIPTION
Cherry pick of #12993 on release/3.8.

#12993: fix(region): replace vpc_delete with vpc_sync_delete when sycnRemoveVpc