### PR TITLE
fix: enable kvm_pv_eoi by default

### DIFF
--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -514,8 +514,11 @@ function nic_mtu() {
 			cpuType = "Penryn,vendor=GenuineIntel"
 		} else if options.HostOptions.HostCpuPassthrough {
 			cpuType = "host"
+			// https://unix.stackexchange.com/questions/216925/nmi-received-for-unknown-reason-20-do-you-have-a-strange-power-saving-mode-ena
+			cpuType += ",+kvm_pv_eoi"
 		} else {
 			cpuType = "qemu64"
+			cpuType += ",+kvm_pv_eoi"
 			if sysutils.IsProcessorIntel() {
 				cpuType += ",+vmx"
 				cpuType += ",+ssse3,+sse4.1,+sse4.2,-x2apic,+aes,+avx"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: enable kvm_pv_eoi by default

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7
- release/3.6

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 