### PR TITLE
Automated cherry pick of #13040: fix: hostinfo onfail should return immediately

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -158,7 +158,7 @@ type SHost struct {
 	HostType string `width:"36" charset:"ascii" nullable:"false" list:"domain" update:"domain" create:"domain_required"`
 
 	// host服务软件版本
-	Version string `width:"64" charset:"ascii" list:"domain" update:"domain" create:"domain_optional"`
+	Version string `width:"128" charset:"ascii" list:"domain" update:"domain" create:"domain_optional"`
 	// OVN软件版本
 	OvnVersion string `width:"64" charset:"ascii" list:"domain" update:"domain" create:"domain_optional"`
 


### PR DESCRIPTION
Cherry pick of #13040 on release/3.8.

#13040: fix: hostinfo onfail should return immediately