### PR TITLE
Automated cherry pick of #13047: fix(region): vpc topology data fix

### DIFF
--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -252,7 +252,7 @@ func (wire *SWire) GetHostwires() ([]SHostwire, error) {
 }
 
 func (self *SWire) GetHosts() ([]SHost, error) {
-	networks := NetworkManager.Query().SubQuery()
+	networks := NetworkManager.Query().Equals("wire_id", self.Id).SubQuery()
 	hns := HostnetworkManager.Query("baremetal_id")
 	sq := hns.Join(networks, sqlchemy.Equals(hns.Field("network_id"), networks.Field("id"))).SubQuery()
 	q := HostManager.Query().In("id", sq)


### PR DESCRIPTION
Cherry pick of #13047 on release/3.8.

#13047: fix(region): vpc topology data fix