### PR TITLE
Automated cherry pick of #13050: fix(region): aws security group name generate

### DIFF
--- a/pkg/compute/regiondrivers/aws.go
+++ b/pkg/compute/regiondrivers/aws.go
@@ -54,7 +54,7 @@ func init() {
 }
 
 func (self *SAwsRegionDriver) IsAllowSecurityGroupNameRepeat() bool {
-	return true
+	return false
 }
 
 func (self *SAwsRegionDriver) GenerateSecurityGroupName(name string) string {


### PR DESCRIPTION
Cherry pick of #13050 on release/3.8.

#13050: fix(region): aws security group name generate