### PR TITLE
Automated cherry pick of #13071: fix(region): keystone default policy

### DIFF
--- a/pkg/keystone/locale/predefined_policies.go
+++ b/pkg/keystone/locale/predefined_policies.go
@@ -138,6 +138,10 @@ var (
 					"unifiedmonitors": {
 						"perform",
 					},
+					"monitorresourcealerts": {
+						"list",
+						"get",
+					},
 				},
 				"log": {
 					"actions": {


### PR DESCRIPTION
Cherry pick of #13071 on release/3.8.

#13071: fix(region): keystone default policy