### PR TITLE
Automated cherry pick of #13076: fix(region): wire topology name

### DIFF
--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -1542,6 +1542,7 @@ func (self *SWire) GetDetailsTopology(ctx context.Context, userCred mcclient.Tok
 		hns := hosts[i].GetBaremetalnetworks()
 		host := api.HostTopologyOutput{
 			Name:       hosts[i].Name,
+			Id:         hosts[i].Id,
 			Status:     hosts[i].Status,
 			HostStatus: hosts[i].HostStatus,
 			HostType:   hosts[i].HostType,
@@ -1573,7 +1574,7 @@ func (self *SWire) GetDetailsTopology(ctx context.Context, userCred mcclient.Tok
 
 		netAddrs := make([]api.SNetworkUsedAddress, 0)
 
-		q := networks[j].getUsedAddressQuery(userCred, rbacutils.ScopeDomain, false)
+		q := networks[j].getUsedAddressQuery(userCred, rbacutils.ScopeSystem, false)
 		err = q.All(&netAddrs)
 		if err != nil {
 			return nil, errors.Wrapf(err, "q.All")


### PR DESCRIPTION
Cherry pick of #13076 on release/3.8.

#13076: fix(region): wire topology name