### PR TITLE
Automated cherry pick of #13089: fix(region): isolated device reserved memory default typo

### DIFF
--- a/pkg/compute/models/isolated_devices.go
+++ b/pkg/compute/models/isolated_devices.go
@@ -96,7 +96,7 @@ type SIsolatedDevice struct {
 	VendorDeviceId string `width:"16" charset:"ascii" nullable:"true" list:"domain" create:"domain_optional"`
 
 	// reserved memory size for isolated device
-	ReservedMemory int `nullable:"true" efault:"0" list:"domain" update:"domain" create:"domain_optional"`
+	ReservedMemory int `nullable:"true" default:"0" list:"domain" update:"domain" create:"domain_optional"`
 
 	// reserved cpu count for isolated device
 	ReservedCpu int `nullable:"true" default:"0" list:"domain" update:"domain" create:"domain_optional"`


### PR DESCRIPTION
Cherry pick of #13089 on release/3.8.

#13089: fix(region): isolated device reserved memory default typo