### PR TITLE
Automated cherry pick of #13113: fix: qemu-img convert may hang on aarach64

### DIFF
--- a/pkg/util/qemuimg/qemuimg.go
+++ b/pkg/util/qemuimg/qemuimg.go
@@ -221,6 +221,10 @@ func (img *SQemuImage) doConvert(name string, format TImageFormat, options []str
 	if compact {
 		cmdline = append(cmdline, "-c")
 	}
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1969848
+	// https://bugs.launchpad.net/qemu/+bug/1805256
+	// qemu-img convert may hang on aarch64, fix: add -m 1
+	cmdline = append(cmdline, "-m", "1")
 	cmdline = append(cmdline, "-f", img.Format.String(), "-O", format.String())
 	if len(password) > 0 {
 		if options == nil {


### PR DESCRIPTION
Cherry pick of #13113 on release/3.8.

#13113: fix: qemu-img convert may hang on aarach64