### PR TITLE
fix: host tune system set default arp gc threshold

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -416,7 +416,7 @@ func (h *SHostInfo) prepareEnv() error {
 	}
 
 	h.PreventArpFlux()
-	h.TuneSystem()
+	h.tuneSystem()
 	return nil
 }
 
@@ -601,10 +601,13 @@ func (h *SHostInfo) PreventArpFlux() {
 
 // Any system wide optimizations
 // set swappiness=0 to avoid swap
-func (h *SHostInfo) TuneSystem() {
+func (h *SHostInfo) tuneSystem() {
 	kv := map[string]string{
 		"/proc/sys/vm/swappiness":                        "0",
 		"/proc/sys/net/ipv4/tcp_mtu_probing":             "2",
+		"/proc/sys/net/ipv4/neigh/default/gc_thresh1":    "1024",
+		"/proc/sys/net/ipv4/neigh/default/gc_thresh2":    "4096",
+		"/proc/sys/net/ipv4/neigh/default/gc_thresh3":    "8192",
 		"/sys/module/kvm/parameters/ignore_msrs":         "1",
 		"/sys/module/kvm/parameters/report_ignored_msrs": "0",
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: host tune system set default ARP gc threshold 

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.7

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 