### PR TITLE
fix: usb id in spice command args conflict with usb-xhci

### DIFF
--- a/pkg/hostman/guestman/qemu-arm.go
+++ b/pkg/hostman/guestman/qemu-arm.go
@@ -193,24 +193,7 @@ function nic_mtu() {
 	cmd += " -device virtio-gpu-pci,id=video0,max_outputs=1"
 
 	if s.IsVdiSpice() {
-		cmd += " -device qxl-vga,id=video0,ram_size=141557760,vram_size=141557760"
-		cmd += " -device intel-hda,id=sound0"
-		cmd += " -device hda-duplex,id=sound0-codec0,bus=sound0.0,cad=0"
-		cmd += fmt.Sprintf(" -spice port=%d,password=87654312,seamless-migration=on", 5900+vncPort)
-		// # ,streaming-video=all,playback-compression=on,jpeg-wan-compression=always,zlib-glz-wan-compression=always,image-compression=glz" % (5900+vnc_port)
-		cmd += fmt.Sprintf(" -device virtio-serial-pci,id=virtio-serial0,max_ports=16,bus=%s", s.GetPciBus())
-		cmd += " -chardev spicevmc,name=vdagent,id=vdagent"
-		cmd += " -device virtserialport,nr=1,bus=virtio-serial0.0,chardev=vdagent,name=com.redhat.spice.0"
-
-		// # usb redirect
-		cmd += " -device ich9-usb-ehci1,id=usb"
-		cmd += " -device ich9-usb-uhci1,masterbus=usb.0,firstport=0,multifunction=on"
-		cmd += " -device ich9-usb-uhci2,masterbus=usb.0,firstport=2"
-		cmd += " -device ich9-usb-uhci3,masterbus=usb.0,firstport=4"
-		cmd += " -chardev spicevmc,name=usbredir,id=usbredirchardev1"
-		cmd += " -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1"
-		cmd += " -chardev spicevmc,name=usbredir,id=usbredirchardev2"
-		cmd += " -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2"
+		cmd += s.generateSpiceArgs(vncPort)
 	} else {
 		cmd += fmt.Sprintf(" -vnc :%d", vncPort)
 		if options.HostOptions.SetVncPassword {
@@ -288,4 +271,27 @@ function nic_mtu() {
 	cmd += "fi\n"
 
 	return cmd, nil
+}
+
+func (s *SKVMGuestInstance) generateSpiceArgs(vncPort int64) string {
+	cmd := ""
+	cmd += " -device qxl-vga,id=video0,ram_size=141557760,vram_size=141557760"
+	cmd += " -device intel-hda,id=sound0"
+	cmd += " -device hda-duplex,id=sound0-codec0,bus=sound0.0,cad=0"
+	cmd += fmt.Sprintf(" -spice port=%d,password=87654312,seamless-migration=on", 5900+vncPort)
+	// # ,streaming-video=all,playback-compression=on,jpeg-wan-compression=always,zlib-glz-wan-compression=always,image-compression=glz" % (5900+vnc_port)
+	cmd += fmt.Sprintf(" -device virtio-serial-pci,id=virtio-serial0,max_ports=16,bus=%s", s.GetPciBus())
+	cmd += " -chardev spicevmc,name=vdagent,id=vdagent"
+	cmd += " -device virtserialport,nr=1,bus=virtio-serial0.0,chardev=vdagent,name=com.redhat.spice.0"
+
+	// # usb redirect
+	cmd += " -device ich9-usb-ehci1,id=usbspice"
+	cmd += " -device ich9-usb-uhci1,masterbus=usbspice.0,firstport=0,multifunction=on"
+	cmd += " -device ich9-usb-uhci2,masterbus=usbspice.0,firstport=2"
+	cmd += " -device ich9-usb-uhci3,masterbus=usbspice.0,firstport=4"
+	cmd += " -chardev spicevmc,name=usbredir,id=usbredirchardev1"
+	cmd += " -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1"
+	cmd += " -chardev spicevmc,name=usbredir,id=usbredirchardev2"
+	cmd += " -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2"
+	return cmd
 }

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -614,24 +614,7 @@ function nic_mtu() {
 	}
 
 	if s.IsVdiSpice() {
-		cmd += " -device qxl-vga,id=video0,ram_size=141557760,vram_size=141557760"
-		cmd += " -device intel-hda,id=sound0"
-		cmd += " -device hda-duplex,id=sound0-codec0,bus=sound0.0,cad=0"
-		cmd += fmt.Sprintf(" -spice port=%d,password=87654312,seamless-migration=on", 5900+vncPort)
-		// # ,streaming-video=all,playback-compression=on,jpeg-wan-compression=always,zlib-glz-wan-compression=always,image-compression=glz" % (5900+vnc_port)
-		cmd += fmt.Sprintf(" -device virtio-serial-pci,id=virtio-serial0,max_ports=16,bus=%s", s.GetPciBus())
-		cmd += " -chardev spicevmc,name=vdagent,id=vdagent"
-		cmd += " -device virtserialport,nr=1,bus=virtio-serial0.0,chardev=vdagent,name=com.redhat.spice.0"
-
-		// # usb redirect
-		cmd += " -device ich9-usb-ehci1,id=usb"
-		cmd += " -device ich9-usb-uhci1,masterbus=usb.0,firstport=0,multifunction=on"
-		cmd += " -device ich9-usb-uhci2,masterbus=usb.0,firstport=2"
-		cmd += " -device ich9-usb-uhci3,masterbus=usb.0,firstport=4"
-		cmd += " -chardev spicevmc,name=usbredir,id=usbredirchardev1"
-		cmd += " -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1"
-		cmd += " -chardev spicevmc,name=usbredir,id=usbredirchardev2"
-		cmd += " -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2"
+		cmd += s.generateSpiceArgs(vncPort)
 	} else {
 		if isolatedDevsParams != nil && len(isolatedDevsParams.Vga) > 0 {
 			cmd += isolatedDevsParams.Vga


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: spice use duplicate usb id

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 
