### PR TITLE
Automated cherry pick of #13153: fix: windows server name cannot be longer than 15 chars

### DIFF
--- a/pkg/apis/compute/guest_const.go
+++ b/pkg/apis/compute/guest_const.go
@@ -325,3 +325,7 @@ func Hypervisors2HostTypes(hypervisors []string) []string {
 	}
 	return hostTypes
 }
+
+// windows allow a maximal length of 15
+// http://support.microsoft.com/kb/909264
+const MAX_WINDOWS_COMPUTER_NAME_LENGTH = 15

--- a/pkg/hostman/guestfs/fsdriver/windows.go
+++ b/pkg/hostman/guestfs/fsdriver/windows.go
@@ -26,6 +26,7 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/utils"
 
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 	deployapi "yunion.io/x/onecloud/pkg/hostman/hostdeployer/apis"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
@@ -222,6 +223,11 @@ func (w *SWindowsRootFs) DeployHostname(part IDiskPartition, hostname, domain st
 		"NV Domain":   domain,
 	} {
 		lines = append(lines, w.regAdd(TCPIP_PARAM_KEY, k, v, "REG_SZ"))
+	}
+	// windows allow a maximal length of 15
+	// http://support.microsoft.com/kb/909264
+	if len(hostname) > api.MAX_WINDOWS_COMPUTER_NAME_LENGTH {
+		hostname = hostname[:api.MAX_WINDOWS_COMPUTER_NAME_LENGTH]
 	}
 	lines = append(lines, w.regAdd(ACTIVE_COMPUTER_NAME_KEY, "ComputerName", hostname, "REG_SZ"))
 	lines = append(lines, w.regAdd(COMPUTER_NAME_KEY, "ComputerName", hostname, "REG_SZ"))


### PR DESCRIPTION
Cherry pick of #13153 on release/3.8.

#13153: fix: windows server name cannot be longer than 15 chars