### PR TITLE
Automated cherry pick of #13158: fix(region): kvm vm no need remote update

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1660,7 +1660,7 @@ func (manager *SGuestManager) validateEip(userCred mcclient.TokenCredential, inp
 
 func (self *SGuest) PostUpdate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) {
 	self.SVirtualResourceBase.PostUpdate(ctx, userCred, query, data)
-	if data.Contains("name") || data.Contains("__meta__") {
+	if len(self.ExternalId) > 0 && (data.Contains("name") || data.Contains("__meta__")) {
 		err := self.StartRemoteUpdateTask(ctx, userCred, false, "")
 		if err != nil {
 			log.Errorf("StartRemoteUpdateTask fail: %s", err)


### PR DESCRIPTION
Cherry pick of #13158 on release/3.8.

#13158: fix(region): kvm vm no need remote update