### PR TITLE
Automated cherry pick of #13165: fix(region): reset status to block_stream after restarting network

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2291,6 +2291,9 @@ func (self *SGuest) PerformChangeIpaddr(ctx context.Context, userCred mcclient.T
 	if self.Hypervisor == api.HYPERVISOR_KVM && restartNetwork && (self.Status == api.VM_RUNNING || self.Status == api.VM_BLOCK_STREAM) {
 		taskData.Set("restart_network", jsonutils.JSONTrue)
 		taskData.Set("prev_ip", jsonutils.NewString(gn.IpAddr))
+		if self.Status == api.VM_BLOCK_STREAM {
+			taskData.Set("in_block_stream", jsonutils.JSONTrue)
+		}
 		self.SetStatus(userCred, api.VM_RESTART_NETWORK, "restart network")
 	}
 	return nil, self.startSyncTask(ctx, userCred, true, "", taskData)

--- a/pkg/compute/tasks/guest_sync_task.go
+++ b/pkg/compute/tasks/guest_sync_task.go
@@ -64,7 +64,7 @@ func (self *GuestSyncConfTask) OnSyncComplete(ctx context.Context, obj db.IStand
 			self.SetStageComplete(ctx, nil)
 			return
 		}
-		if guest.Status == api.VM_BLOCK_STREAM {
+		if inBlockStream := jsonutils.QueryBoolean(self.Params, "in_block_stream", false); inBlockStream {
 			guest.StartRestartNetworkTask(ctx, self.UserCred, "", prevIp, true)
 		} else {
 			guest.StartRestartNetworkTask(ctx, self.UserCred, "", prevIp, false)


### PR DESCRIPTION
Cherry pick of #13165 on release/3.8.

#13165: fix(region): reset status to block_stream after restarting network