### PR TITLE
fix: ceph clone image across pool should use pool of target image

### DIFF
--- a/pkg/util/cephutils/ceph.go
+++ b/pkg/util/cephutils/ceph.go
@@ -533,6 +533,10 @@ func (self *SImage) Clone(ctx context.Context, pool, name string) error {
 	}
 
 	_pool := self.client.pool
+
+	// use current pool
+	self.client.SetPool(pool)
+	// recover previous pool
 	defer self.client.SetPool(_pool)
 
 	img, err := self.client.GetImage(name)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: ceph clone image across pool should use pool of target image
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi @ioito 
