### PR TITLE
Automated cherry pick of #13171: fix: ceph clone image across pool should use pool of target image

### DIFF
--- a/pkg/util/cephutils/ceph.go
+++ b/pkg/util/cephutils/ceph.go
@@ -533,6 +533,10 @@ func (self *SImage) Clone(ctx context.Context, pool, name string) error {
 	}
 
 	_pool := self.client.pool
+
+	// use current pool
+	self.client.SetPool(pool)
+	// recover previous pool
 	defer self.client.SetPool(_pool)
 
 	img, err := self.client.GetImage(name)


### PR DESCRIPTION
Cherry pick of #13171 on release/3.9.

#13171: fix: ceph clone image across pool should use pool of target image