### PR TITLE
fix(common): ListItemFilter func exec in the end

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -264,10 +264,6 @@ func listItemQueryFiltersRaw(manager IModelManager,
 		q = manager.FilterBySystemAttributes(q, userCred, query, queryScope)
 		q = manager.FilterByHiddenSystemAttributes(q, userCred, query, queryScope)
 	}
-	q, err = ListItemFilter(manager, ctx, q, userCred, query)
-	if err != nil {
-		return nil, err
-	}
 	if query.Contains("export_keys") {
 		exportKeys, _ := query.GetString("export_keys")
 		keys := stringutils2.NewSortedStrings(strings.Split(exportKeys, ","))
@@ -304,6 +300,10 @@ func listItemQueryFiltersRaw(manager IModelManager,
 		if err != nil {
 			return nil, err
 		}
+	}
+	q, err = ListItemFilter(manager, ctx, q, userCred, query)
+	if err != nil {
+		return nil, err
 	}
 	return q, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
1.ListItemFilter 中如果有group by 操作(meter服务),如果使用框架解析filter参数，
会把filter 解析加入到 having结构中。

**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.9

/cc @zexi 
