### PR TITLE
Automated cherry pick of #13200: fix(common): ListItemFilter func exec in the end

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -265,10 +265,6 @@ func listItemQueryFiltersRaw(manager IModelManager,
 		q = manager.FilterBySystemAttributes(q, userCred, query, queryScope)
 		q = manager.FilterByHiddenSystemAttributes(q, userCred, query, queryScope)
 	}
-	q, err = ListItemFilter(manager, ctx, q, userCred, query)
-	if err != nil {
-		return nil, err
-	}
 	if query.Contains("export_keys") {
 		exportKeys, _ := query.GetString("export_keys")
 		keys := stringutils2.NewSortedStrings(strings.Split(exportKeys, ","))
@@ -305,6 +301,10 @@ func listItemQueryFiltersRaw(manager IModelManager,
 		if err != nil {
 			return nil, err
 		}
+	}
+	q, err = ListItemFilter(manager, ctx, q, userCred, query)
+	if err != nil {
+		return nil, err
 	}
 	return q, nil
 }


### PR DESCRIPTION
Cherry pick of #13200 on release/3.8.

#13200: fix(common): ListItemFilter func exec in the end