### PR TITLE
fix(region): create wire input bw deprecated

### DIFF
--- a/pkg/apis/compute/wire.go
+++ b/pkg/apis/compute/wire.go
@@ -23,6 +23,9 @@ type WireCreateInput struct {
 	// default: 0
 	Bandwidth int `json:"bandwidth"`
 
+	// Deprecated
+	Bw int `json:"bw" yunion-deprecated-by:"bandwidth"`
+
 	// mtu
 	// minimum: 0
 	// maximum: 1000000


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix below issue:

```bash
$ climc wire-create my-zone-1 my-wire-1 10000
{"error":{"class":"InputParameterError","code":400,"details":"bandwidth: missing input field","request":{"body":{"wire":{"bw":10000,"mtu":0,"name":"my-wire-1","vpc":"default","zone":"my-zone-1"}},"headers":{"Content-Length":"83","Content-Type":"application/json","User-Agent":"yunioncloud-go/201708","X-Auth-Token":"*"},"method":"POST","url":"https://192.168.121.21:30888/wires"}}}

```

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- release/3.8
/area region

/cc @swordqiu @ioito 