### PR TITLE
Automated cherry pick of #13213: fix(region): create wire input bw deprecated

### DIFF
--- a/pkg/apis/compute/wire.go
+++ b/pkg/apis/compute/wire.go
@@ -23,6 +23,9 @@ type WireCreateInput struct {
 	// default: 0
 	Bandwidth int `json:"bandwidth"`
 
+	// Deprecated
+	Bw int `json:"bw" yunion-deprecated-by:"bandwidth"`
+
 	// mtu
 	// minimum: 0
 	// maximum: 1000000


### PR DESCRIPTION
Cherry pick of #13213 on release/3.8.

#13213: fix(region): create wire input bw deprecated