### PR TITLE
fix: usages should be filtered by policy tags

### DIFF
--- a/pkg/cloudcommon/db/fetch.go
+++ b/pkg/cloudcommon/db/fetch.go
@@ -309,7 +309,14 @@ type IScopedResourceManager interface {
 	FetchOwnerId(ctx context.Context, data jsonutils.JSONObject) (mcclient.IIdentityProvider, error)
 }
 
-func FetchCheckQueryOwnerScope(ctx context.Context, userCred mcclient.TokenCredential, data jsonutils.JSONObject, manager IScopedResourceManager, action string, doCheckRbac bool) (mcclient.IIdentityProvider, rbacutils.TRbacScope, error, rbacutils.SPolicyResult) {
+func FetchCheckQueryOwnerScope(
+	ctx context.Context,
+	userCred mcclient.TokenCredential,
+	data jsonutils.JSONObject,
+	manager IScopedResourceManager,
+	action string,
+	doCheckRbac bool,
+) (mcclient.IIdentityProvider, rbacutils.TRbacScope, error, rbacutils.SPolicyResult) {
 	var scope rbacutils.TRbacScope
 
 	var allowScope rbacutils.TRbacScope

--- a/pkg/cloudcommon/db/metadataresource.go
+++ b/pkg/cloudcommon/db/metadataresource.go
@@ -24,11 +24,36 @@ import (
 	"yunion.io/x/onecloud/pkg/apis"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 	"yunion.io/x/onecloud/pkg/util/tagutils"
 )
 
 type SMetadataResourceBaseModelManager struct{}
+
+func ObjectIdQueryWithPolicyResult(q *sqlchemy.SQuery, manager IModelManager, result rbacutils.SPolicyResult) *sqlchemy.SQuery {
+	scope := manager.ResourceScope()
+	if scope == rbacutils.ScopeDomain || scope == rbacutils.ScopeProject {
+		if !result.DomainTags.IsEmpty() {
+			tagFilters := tagutils.STagFilters{}
+			tagFilters.AddFilters(result.DomainTags)
+			q = ObjectIdQueryWithTagFilters(q, "domain_id", "domain", tagFilters)
+		}
+	}
+	if scope == rbacutils.ScopeProject {
+		if !result.ProjectTags.IsEmpty() {
+			tagFilters := tagutils.STagFilters{}
+			tagFilters.AddFilters(result.ProjectTags)
+			q = ObjectIdQueryWithTagFilters(q, "tenant_id", "project", tagFilters)
+		}
+	}
+	if !result.ProjectTags.IsEmpty() {
+		tagFilters := tagutils.STagFilters{}
+		tagFilters.AddFilters(result.ObjectTags)
+		q = ObjectIdQueryWithTagFilters(q, "id", manager.Keyword(), tagFilters)
+	}
+	return q
+}
 
 func ObjectIdQueryWithTagFilters(q *sqlchemy.SQuery, idField string, modelName string, filters tagutils.STagFilters) *sqlchemy.SQuery {
 	log.Debugf("Filters: %s", jsonutils.Marshal(filters))

--- a/pkg/compute/models/elasticcache_instances.go
+++ b/pkg/compute/models/elasticcache_instances.go
@@ -1688,8 +1688,10 @@ func (man *SElasticcacheManager) TotalCount(
 	ownerId mcclient.IIdentityProvider,
 	rangeObjs []db.IStandaloneModel,
 	providers []string, brands []string, cloudEnv string,
+	policyResult rbacutils.SPolicyResult,
 ) (int, error) {
 	q := man.Query()
+	q = db.ObjectIdQueryWithPolicyResult(q, man, policyResult)
 	vpcs := VpcManager.Query().SubQuery()
 	q = q.Join(vpcs, sqlchemy.Equals(q.Field("vpc_id"), vpcs.Field("id")))
 	q = scopeOwnerIdFilter(q, scope, ownerId)

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2535,6 +2535,7 @@ func (manager *SHostManager) totalCountQ(
 	resourceTypes []string,
 	providers []string, brands []string, cloudEnv string,
 	enabled, isBaremetal tristate.TriState,
+	policyResult rbacutils.SPolicyResult,
 ) *sqlchemy.SQuery {
 	hosts := manager.Query().SubQuery()
 	q := hosts.Query(
@@ -2575,6 +2576,9 @@ func (manager *SHostManager) totalCountQ(
 			))
 		}
 	}
+
+	q = db.ObjectIdQueryWithPolicyResult(q, HostManager, policyResult)
+
 	isolatedDevices := IsolatedDeviceManager.Query().SubQuery()
 	iq := isolatedDevices.Query(
 		isolatedDevices.Field("host_id"),
@@ -2703,6 +2707,7 @@ func (manager *SHostManager) TotalCount(
 	resourceTypes []string,
 	providers []string, brands []string, cloudEnv string,
 	enabled, isBaremetal tristate.TriState,
+	policyResult rbacutils.SPolicyResult,
 ) HostsCountStat {
 	return manager.calculateCount(
 		manager.totalCountQ(
@@ -2718,6 +2723,7 @@ func (manager *SHostManager) TotalCount(
 			cloudEnv,
 			enabled,
 			isBaremetal,
+			policyResult,
 		),
 	)
 }

--- a/pkg/compute/models/infrasquota.go
+++ b/pkg/compute/models/infrasquota.go
@@ -142,7 +142,7 @@ func (self *SInfrasQuota) FetchUsage(ctx context.Context) error {
 		brands = []string{regionKeys.Brand}
 	}
 
-	hostStat := HostManager.TotalCount(ownerId, scope, rangeObjs, "", "", nil, nil, providers, brands, regionKeys.CloudEnv, tristate.None, tristate.None)
+	hostStat := HostManager.TotalCount(ownerId, scope, rangeObjs, "", "", nil, nil, providers, brands, regionKeys.CloudEnv, tristate.None, tristate.None, rbacutils.SPolicyResult{})
 	self.Host = int(hostStat.Count)
 	self.Vpc = VpcManager.totalCount(ownerId, scope, rangeObjs, providers, brands, regionKeys.CloudEnv)
 

--- a/pkg/compute/models/instance_snapshots.go
+++ b/pkg/compute/models/instance_snapshots.go
@@ -469,7 +469,7 @@ func (self *SInstanceSnapshot) GetUsages() []db.IUsage {
 	}
 }
 
-func TotalInstanceSnapshotCount(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, rangeObjs []db.IStandaloneModel, providers []string, brands []string, cloudEnv string) (int, error) {
+func TotalInstanceSnapshotCount(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, rangeObjs []db.IStandaloneModel, providers []string, brands []string, cloudEnv string, policyResult rbacutils.SPolicyResult) (int, error) {
 	q := InstanceSnapshotManager.Query()
 
 	switch scope {
@@ -479,6 +479,8 @@ func TotalInstanceSnapshotCount(scope rbacutils.TRbacScope, ownerId mcclient.IId
 	case rbacutils.ScopeProject:
 		q = q.Equals("tenant_id", ownerId.GetProjectId())
 	}
+
+	q = db.ObjectIdQueryWithPolicyResult(q, InstanceSnapshotManager, policyResult)
 
 	q = RangeObjectsFilter(q, rangeObjs, q.Field("cloudregion_id"), nil, q.Field("manager_id"), nil, nil)
 	q = CloudProviderFilter(q, q.Field("manager_id"), providers, brands, cloudEnv)

--- a/pkg/compute/models/isolated_devices.go
+++ b/pkg/compute/models/isolated_devices.go
@@ -532,13 +532,16 @@ func (manager *SIsolatedDeviceManager) totalCountQ(
 	resourceTypes []string,
 	providers []string, brands []string, cloudEnv string,
 	rangeObjs []db.IStandaloneModel,
+	policyResult rbacutils.SPolicyResult,
 ) *sqlchemy.SQuery {
-	hosts := HostManager.Query().SubQuery()
+	hq := HostManager.Query()
+	if scope == rbacutils.ScopeDomain {
+		hq = hq.Filter(sqlchemy.Equals(hq.Field("domain_id"), ownerId.GetProjectDomainId()))
+	}
+	hq = db.ObjectIdQueryWithPolicyResult(hq, HostManager, policyResult)
+	hosts := hq.SubQuery()
 	devs := manager.Query().SubQuery()
 	q := devs.Query().Join(hosts, sqlchemy.Equals(devs.Field("host_id"), hosts.Field("id")))
-	if scope == rbacutils.ScopeDomain {
-		q = q.Filter(sqlchemy.Equals(hosts.Field("domain_id"), ownerId.GetProjectDomainId()))
-	}
 	q = q.Filter(sqlchemy.IsTrue(hosts.Field("enabled")))
 	if len(devType) != 0 {
 		q = q.Filter(sqlchemy.In(devs.Field("dev_type"), devType))
@@ -561,6 +564,7 @@ func (manager *SIsolatedDeviceManager) totalCount(
 	brands []string,
 	cloudEnv string,
 	rangeObjs []db.IStandaloneModel,
+	policyResult rbacutils.SPolicyResult,
 ) (int, error) {
 	return manager.totalCountQ(
 		scope,
@@ -572,6 +576,7 @@ func (manager *SIsolatedDeviceManager) totalCount(
 		brands,
 		cloudEnv,
 		rangeObjs,
+		policyResult,
 	).CountWithError()
 }
 
@@ -584,19 +589,20 @@ func (manager *SIsolatedDeviceManager) TotalCount(
 	brands []string,
 	cloudEnv string,
 	rangeObjs []db.IStandaloneModel,
+	policyResult rbacutils.SPolicyResult,
 ) (IsolatedDeviceCountStat, error) {
 	stat := IsolatedDeviceCountStat{}
 	devCnt, err := manager.totalCount(
 		scope, ownerId, nil, hostType, resourceTypes,
 		providers, brands, cloudEnv,
-		rangeObjs)
+		rangeObjs, policyResult)
 	if err != nil {
 		return stat, err
 	}
 	gpuCnt, err := manager.totalCount(
 		scope, ownerId, VALID_GPU_TYPES, hostType, resourceTypes,
 		providers, brands, cloudEnv,
-		rangeObjs)
+		rangeObjs, policyResult)
 	if err != nil {
 		return stat, err
 	}

--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -1324,8 +1324,10 @@ func (man *SLoadbalancerManager) TotalCount(
 	ownerId mcclient.IIdentityProvider,
 	rangeObjs []db.IStandaloneModel,
 	providers []string, brands []string, cloudEnv string,
+	policyResult rbacutils.SPolicyResult,
 ) (int, error) {
 	q := man.Query()
+	q = db.ObjectIdQueryWithPolicyResult(q, man, policyResult)
 	q = scopeOwnerIdFilter(q, scope, ownerId)
 	q = CloudProviderFilter(q, q.Field("manager_id"), providers, brands, cloudEnv)
 	q = RangeObjectsFilter(q, rangeObjs, nil, q.Field("zone_id"), q.Field("manager_id"), nil, nil)

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -883,6 +883,7 @@ func (manager *SNetworkManager) totalPortCountQ(
 	brands []string,
 	cloudEnv string,
 	rangeObjs []db.IStandaloneModel,
+	policyResult rbacutils.SPolicyResult,
 ) *sqlchemy.SQuery {
 	q := manager.allNetworksQ(providers, brands, cloudEnv, rangeObjs)
 	switch scope {
@@ -892,6 +893,7 @@ func (manager *SNetworkManager) totalPortCountQ(
 	case rbacutils.ScopeProject:
 		q = q.Equals("tenant_id", userCred.GetProjectId())
 	}
+	q = db.ObjectIdQueryWithPolicyResult(q, manager, policyResult)
 	return manager.Query().In("id", q.Distinct().SubQuery())
 }
 
@@ -905,6 +907,7 @@ func (manager *SNetworkManager) TotalPortCount(
 	userCred mcclient.IIdentityProvider,
 	providers []string, brands []string, cloudEnv string,
 	rangeObjs []db.IStandaloneModel,
+	policyResult rbacutils.SPolicyResult,
 ) map[string]NetworkPortStat {
 	nets := make([]SNetwork, 0)
 	err := manager.totalPortCountQ(
@@ -912,6 +915,7 @@ func (manager *SNetworkManager) TotalPortCount(
 		userCred,
 		providers, brands, cloudEnv,
 		rangeObjs,
+		policyResult,
 	).All(&nets)
 	if err != nil {
 		log.Errorf("TotalPortCount: %v", err)

--- a/pkg/compute/models/quotas.go
+++ b/pkg/compute/models/quotas.go
@@ -188,7 +188,7 @@ func (self *SQuota) FetchUsage(ctx context.Context) error {
 
 	diskSize := totalDiskSize(scope, ownerId, tristate.None, tristate.None, false, false, rangeObjs, providers, brands, keys.CloudEnv, hypervisors)
 
-	guest := usageTotalGuestResouceCount(scope, ownerId, rangeObjs, nil, hypervisors, false, false, nil, nil, providers, brands, keys.CloudEnv, nil)
+	guest := usageTotalGuestResouceCount(scope, ownerId, rangeObjs, nil, hypervisors, false, false, nil, nil, providers, brands, keys.CloudEnv, nil, rbacutils.SPolicyResult{})
 
 	self.Count = guest.TotalGuestCount
 	self.Cpu = guest.TotalCpuCount

--- a/pkg/compute/models/regionquota.go
+++ b/pkg/compute/models/regionquota.go
@@ -184,7 +184,7 @@ func (self *SRegionQuota) FetchUsage(ctx context.Context) error {
 
 	lbnic, _ := totalLBNicCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv)
 
-	eipUsage := ElasticipManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv)
+	eipUsage := ElasticipManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv, rbacutils.SPolicyResult{})
 
 	self.Eip = eipUsage.Total()
 	self.Port = net.InternalNicCount + net.InternalVirtualNicCount + lbnic
@@ -192,24 +192,24 @@ func (self *SRegionQuota) FetchUsage(ctx context.Context) error {
 	// self.Bw = net.InternalBandwidth
 	// self.Ebw = net.ExternalBandwidth
 
-	snapshotCount, _ := TotalSnapshotCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv)
+	snapshotCount, _ := TotalSnapshotCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv, rbacutils.SPolicyResult{})
 	self.Snapshot = snapshotCount
 
-	instanceSnapshotCount, _ := TotalInstanceSnapshotCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv)
+	instanceSnapshotCount, _ := TotalInstanceSnapshotCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv, rbacutils.SPolicyResult{})
 	self.InstanceSnapshot = instanceSnapshotCount
 
-	bucketUsage := BucketManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv)
+	bucketUsage := BucketManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv, rbacutils.SPolicyResult{})
 	self.Bucket = bucketUsage.Buckets
 	self.ObjectGB = int(bucketUsage.Bytes / 1000 / 1000 / 1000)
 	self.ObjectCnt = bucketUsage.Objects
 
-	rdsUsage, _ := DBInstanceManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv)
+	rdsUsage, _ := DBInstanceManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv, rbacutils.SPolicyResult{})
 	self.Rds = rdsUsage.TotalRdsCount
-	self.Cache, _ = ElasticcacheManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv)
-	mongodbUsage, _ := MongoDBManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv)
+	self.Cache, _ = ElasticcacheManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv, rbacutils.SPolicyResult{})
+	mongodbUsage, _ := MongoDBManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv, rbacutils.SPolicyResult{})
 	self.Mongodb = mongodbUsage.TotalMongodbCount
 
-	self.Loadbalancer, _ = LoadbalancerManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv)
+	self.Loadbalancer, _ = LoadbalancerManager.TotalCount(scope, ownerId, rangeObjs, providers, brands, regionKeys.CloudEnv, rbacutils.SPolicyResult{})
 
 	return nil
 }

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -795,7 +795,7 @@ func (self *SSnapshotManager) DeleteDiskSnapshots(ctx context.Context, userCred 
 	return nil
 }
 
-func TotalSnapshotCount(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, rangeObjs []db.IStandaloneModel, providers []string, brands []string, cloudEnv string) (int, error) {
+func TotalSnapshotCount(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, rangeObjs []db.IStandaloneModel, providers []string, brands []string, cloudEnv string, policyResult rbacutils.SPolicyResult) (int, error) {
 	q := SnapshotManager.Query()
 
 	switch scope {
@@ -805,6 +805,8 @@ func TotalSnapshotCount(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityPr
 	case rbacutils.ScopeProject:
 		q = q.Equals("tenant_id", ownerId.GetProjectId())
 	}
+
+	q = db.ObjectIdQueryWithPolicyResult(q, SnapshotManager, policyResult)
 
 	q = RangeObjectsFilter(q, rangeObjs, q.Field("cloudregion_id"), nil, q.Field("manager_id"), nil, nil)
 	q = CloudProviderFilter(q, q.Field("manager_id"), providers, brands, cloudEnv)

--- a/pkg/image/models/image_guest.go
+++ b/pkg/image/models/image_guest.go
@@ -610,9 +610,9 @@ func (manager *SGuestImageManager) QueryDistinctExtraField(q *sqlchemy.SQuery, f
 	return q, httperrors.ErrNotFound
 }
 
-func (manager *SGuestImageManager) Usage(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, prefix string) map[string]int64 {
+func (manager *SGuestImageManager) Usage(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, prefix string, policyResult rbacutils.SPolicyResult) map[string]int64 {
 	usages := make(map[string]int64)
-	count := ImageManager.count(scope, ownerId, api.IMAGE_STATUS_ACTIVE, tristate.False, false, tristate.True)
+	count := ImageManager.count(scope, ownerId, api.IMAGE_STATUS_ACTIVE, tristate.False, false, tristate.True, policyResult)
 	expandUsageCount(usages, prefix, "guest_image", "", count)
 	sq := manager.Query()
 	switch scope {

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -892,8 +892,9 @@ type SImageUsage struct {
 	Size  int64
 }
 
-func (manager *SImageManager) count(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, status string, isISO tristate.TriState, pendingDelete bool, guestImage tristate.TriState) map[string]SImageUsage {
+func (manager *SImageManager) count(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, status string, isISO tristate.TriState, pendingDelete bool, guestImage tristate.TriState, policyResult rbacutils.SPolicyResult) map[string]SImageUsage {
 	sq := manager.Query("id")
+	sq = db.ObjectIdQueryWithPolicyResult(sq, manager, policyResult)
 	switch scope {
 	case rbacutils.ScopeSystem:
 		// do nothing
@@ -969,19 +970,19 @@ func expandUsageCount(usages map[string]int64, prefix, imgType, state string, co
 	}
 }
 
-func (manager *SImageManager) Usage(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, prefix string) map[string]int64 {
+func (manager *SImageManager) Usage(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, prefix string, policyResult rbacutils.SPolicyResult) map[string]int64 {
 	usages := make(map[string]int64)
-	count := manager.count(scope, ownerId, api.IMAGE_STATUS_ACTIVE, tristate.False, false, tristate.False)
+	count := manager.count(scope, ownerId, api.IMAGE_STATUS_ACTIVE, tristate.False, false, tristate.False, policyResult)
 	expandUsageCount(usages, prefix, "img", "", count)
-	count = manager.count(scope, ownerId, api.IMAGE_STATUS_ACTIVE, tristate.True, false, tristate.False)
+	count = manager.count(scope, ownerId, api.IMAGE_STATUS_ACTIVE, tristate.True, false, tristate.False, policyResult)
 	expandUsageCount(usages, prefix, string(qemuimg.ISO), "", count)
-	count = manager.count(scope, ownerId, api.IMAGE_STATUS_ACTIVE, tristate.None, false, tristate.False)
+	count = manager.count(scope, ownerId, api.IMAGE_STATUS_ACTIVE, tristate.None, false, tristate.False, policyResult)
 	expandUsageCount(usages, prefix, "imgiso", "", count)
-	count = manager.count(scope, ownerId, "", tristate.False, true, tristate.False)
+	count = manager.count(scope, ownerId, "", tristate.False, true, tristate.False, policyResult)
 	expandUsageCount(usages, prefix, "img", "pending_delete", count)
-	count = manager.count(scope, ownerId, "", tristate.True, true, tristate.False)
+	count = manager.count(scope, ownerId, "", tristate.True, true, tristate.False, policyResult)
 	expandUsageCount(usages, prefix, string(qemuimg.ISO), "pending_delete", count)
-	count = manager.count(scope, ownerId, "", tristate.None, true, tristate.False)
+	count = manager.count(scope, ownerId, "", tristate.None, true, tristate.False, policyResult)
 	expandUsageCount(usages, prefix, "imgiso", "pending_delete", count)
 	return usages
 }

--- a/pkg/image/models/quotas.go
+++ b/pkg/image/models/quotas.go
@@ -135,7 +135,7 @@ func (self *SQuota) FetchUsage(ctx context.Context) error {
 		isISO = tristate.None
 	}
 
-	count := ImageManager.count(scope, ownerId, "", isISO, false, tristate.None)
+	count := ImageManager.count(scope, ownerId, "", isISO, false, tristate.None, rbacutils.SPolicyResult{})
 	self.Image = int(count["total"].Count)
 	return nil
 }

--- a/pkg/image/usages/handler.go
+++ b/pkg/image/usages/handler.go
@@ -39,7 +39,7 @@ func ReportGeneralUsage(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	_, query, _ := appsrv.FetchEnv(ctx, w, r)
 	userCred := auth.FetchUserCredential(ctx, policy.FilterPolicyCredential)
 
-	ownerId, scope, err, _ := db.FetchUsageOwnerScope(ctx, userCred, query)
+	ownerId, scope, err, result := db.FetchUsageOwnerScope(ctx, userCred, query)
 	if err != nil {
 		httperrors.GeneralServerError(ctx, w, err)
 		return
@@ -47,23 +47,23 @@ func ReportGeneralUsage(ctx context.Context, w http.ResponseWriter, r *http.Requ
 
 	usages := jsonutils.NewDict()
 	if scope == rbacutils.ScopeSystem {
-		adminUsage := models.ImageManager.Usage(rbacutils.ScopeSystem, ownerId, "all")
+		adminUsage := models.ImageManager.Usage(rbacutils.ScopeSystem, ownerId, "all", result)
 		usages.Update(jsonutils.Marshal(adminUsage))
-		adminUsage = models.GuestImageManager.Usage(rbacutils.ScopeSystem, ownerId, "all")
+		adminUsage = models.GuestImageManager.Usage(rbacutils.ScopeSystem, ownerId, "all", result)
 		usages.Update(jsonutils.Marshal(adminUsage))
 	}
 
 	if scope.HigherEqual(rbacutils.ScopeDomain) {
-		domainUsage := models.ImageManager.Usage(rbacutils.ScopeDomain, ownerId, "domain")
+		domainUsage := models.ImageManager.Usage(rbacutils.ScopeDomain, ownerId, "domain", result)
 		usages.Update(jsonutils.Marshal(domainUsage))
-		domainUsage = models.GuestImageManager.Usage(rbacutils.ScopeDomain, ownerId, "domain")
+		domainUsage = models.GuestImageManager.Usage(rbacutils.ScopeDomain, ownerId, "domain", result)
 		usages.Update(jsonutils.Marshal(domainUsage))
 	}
 
 	if scope.HigherEqual(rbacutils.ScopeProject) {
-		projectUsage := models.ImageManager.Usage(rbacutils.ScopeProject, ownerId, "")
+		projectUsage := models.ImageManager.Usage(rbacutils.ScopeProject, ownerId, "", result)
 		usages.Update(jsonutils.Marshal(projectUsage))
-		projectUsage = models.GuestImageManager.Usage(rbacutils.ScopeProject, ownerId, "")
+		projectUsage = models.GuestImageManager.Usage(rbacutils.ScopeProject, ownerId, "", result)
 		usages.Update(jsonutils.Marshal(projectUsage))
 	}
 

--- a/pkg/keystone/models/usages.go
+++ b/pkg/keystone/models/usages.go
@@ -16,27 +16,41 @@ package models
 
 import (
 	api "yunion.io/x/onecloud/pkg/apis/identity"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
 )
 
-func Usage() map[string]int {
+func Usage(result rbacutils.SPolicyResult) map[string]int {
 	results := make(map[string]int)
 
-	domCnt, _ := DomainManager.Query().IsTrue("is_domain").NotEquals("id", api.KeystoneDomainRoot).CountWithError()
+	dq := DomainManager.Query()
+	dq = db.ObjectIdQueryWithPolicyResult(dq, DomainManager, result)
+	domCnt, _ := dq.IsTrue("is_domain").NotEquals("id", api.KeystoneDomainRoot).CountWithError()
 	results["domains"] = domCnt
 
-	projCnt, _ := ProjectManager.Query().IsFalse("is_domain").CountWithError()
+	pq := ProjectManager.Query()
+	pq = db.ObjectIdQueryWithPolicyResult(pq, ProjectManager, result)
+	projCnt, _ := pq.IsFalse("is_domain").CountWithError()
 	results["projects"] = projCnt
 
-	roleCnt, _ := RoleManager.Query().CountWithError()
+	rq := RoleManager.Query()
+	rq = db.ObjectIdQueryWithPolicyResult(rq, RoleManager, result)
+	roleCnt, _ := rq.CountWithError()
 	results["roles"] = roleCnt
 
-	usrCnt, _ := UserManager.Query().CountWithError()
+	uq := UserManager.Query()
+	uq = db.ObjectIdQueryWithPolicyResult(uq, UserManager, result)
+	usrCnt, _ := uq.CountWithError()
 	results["users"] = usrCnt
 
-	grpCnt, _ := GroupManager.Query().CountWithError()
+	gq := GroupManager.Query()
+	gq = db.ObjectIdQueryWithPolicyResult(gq, GroupManager, result)
+	grpCnt, _ := gq.CountWithError()
 	results["groups"] = grpCnt
 
-	policy, _ := PolicyManager.Query().CountWithError()
+	pcq := PolicyManager.Query()
+	pcq = db.ObjectIdQueryWithPolicyResult(pcq, PolicyManager, result)
+	policy, _ := pcq.CountWithError()
 	results["policies"] = policy
 
 	return results


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: usage should be filtered by policy tags

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 
/area region keystone glance
/hold