### PR TITLE
Automated cherry pick of #13305: fix: rng device should use urandom instead of random

### DIFF
--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -33,7 +33,6 @@ import (
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/hostman/guestman/qemu"
 	"yunion.io/x/onecloud/pkg/hostman/options"
-	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/qemutils"
 	"yunion.io/x/onecloud/pkg/util/sysutils"
 )
@@ -481,7 +480,7 @@ function nic_mtu() {
 		qemu-system-x86_64: Unknown savevm section or instance '0000:00:05.0/virtio-rng' 0
 		qemu-system-x86_64: load of migration failed: Invalid argument
 	*/
-	if options.HostOptions.EnableVirtioRngDevice && fileutils2.Exists("/dev/random") {
+	if options.HostOptions.EnableVirtioRngDevice {
 		input.EnableRNGRandom = true
 	}
 

--- a/pkg/hostman/guestman/qemu/generate.go
+++ b/pkg/hostman/guestman/qemu/generate.go
@@ -24,6 +24,7 @@ import (
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/hostman/isolated_device"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 )
 
 type Monitor struct {
@@ -470,9 +471,17 @@ func GetNicDeviceModel(name string) string {
 }
 
 func getRNGRandomOptions(drvOpt QemuOptions) []string {
+	var randev string
+	if fileutils2.Exists("/dev/urandom") {
+		randev = "/dev/urandom"
+	} else if fileutils2.Exists("/dev/random") {
+		randev = "/dev/random"
+	} else {
+		return []string{}
+	}
 	return []string{
 		drvOpt.Object("rng-random", map[string]string{
-			"filename": "/dev/random",
+			"filename": randev,
 			"id":       "rng0",
 		}),
 		drvOpt.Device("virtio-rng-pci,rng=rng0,max-bytes=1024,period=1000"),

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -159,7 +159,7 @@ type SHostOptions struct {
 
 	EnableVmUuid bool `help:"enable vm UUID" default:"true" json:"enable_vm_uuid"`
 
-	EnableVirtioRngDevice bool `help:"enable qemu virtio-rng device" default:"false"`
+	EnableVirtioRngDevice bool `help:"enable qemu virtio-rng device" default:"true"`
 
 	RestrictQemuImgConvertWorker bool `help:"restrict qemu-img convert worker" default:"false"`
 }


### PR DESCRIPTION
Cherry pick of #13305 on release/3.9.

#13305: fix: rng device should use urandom instead of random