### PR TITLE
fix: rng device shoud use /dev/urandom instead of /dev/random

### DIFF
--- a/pkg/hostman/guestman/qemu-arm.go
+++ b/pkg/hostman/guestman/qemu-arm.go
@@ -239,8 +239,8 @@ function nic_mtu() {
 	cmd += s.extraOptions()
 
 	// cmd += s.getQgaDesc()
-	if options.HostOptions.EnableVirtioRngDevice && fileutils2.Exists("/dev/random") {
-		cmd += " -object rng-random,filename=/dev/random,id=rng0"
+	if options.HostOptions.EnableVirtioRngDevice && fileutils2.Exists("/dev/urandom") {
+		cmd += " -object rng-random,filename=/dev/urandom,id=rng0"
 		cmd += " -device virtio-rng-pci,rng=rng0,max-bytes=1024,period=1000"
 	}
 

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -689,8 +689,8 @@ function nic_mtu() {
 		qemu-system-x86_64: Unknown savevm section or instance '0000:00:05.0/virtio-rng' 0
 		qemu-system-x86_64: load of migration failed: Invalid argument
 	*/
-	if options.HostOptions.EnableVirtioRngDevice && fileutils2.Exists("/dev/random") {
-		cmd += " -object rng-random,filename=/dev/random,id=rng0"
+	if options.HostOptions.EnableVirtioRngDevice && fileutils2.Exists("/dev/urandom") {
+		cmd += " -object rng-random,filename=/dev/urandom,id=rng0"
 		cmd += " -device virtio-rng-pci,rng=rng0,max-bytes=1024,period=1000"
 	}
 

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -159,7 +159,7 @@ type SHostOptions struct {
 
 	EnableVmUuid bool `help:"enable vm UUID" default:"true" json:"enable_vm_uuid"`
 
-	EnableVirtioRngDevice bool `help:"enable qemu virtio-rng device" default:"false"`
+	EnableVirtioRngDevice bool `help:"enable qemu virtio-rng device" default:"true"`
 }
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: rng device shoud use /dev/urandom instead of /dev/random

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 