### PR TITLE
fix: allow view events of owner objects

### DIFF
--- a/pkg/cloudcommon/db/opslog.go
+++ b/pkg/cloudcommon/db/opslog.go
@@ -430,15 +430,30 @@ func (self *SOpsLogManager) FilterByOwner(q *sqlchemy.SQuery, ownerId mcclient.I
 		switch scope {
 		case rbacutils.ScopeUser:
 			if len(ownerId.GetUserId()) > 0 {
+				/*
+				 * 默认只能查看本人发起的操作
+				 */
 				q = q.Filter(sqlchemy.Equals(q.Field("user_id"), ownerId.GetUserId()))
 			}
 		case rbacutils.ScopeProject:
 			if len(ownerId.GetProjectId()) > 0 {
-				q = q.Filter(sqlchemy.Equals(q.Field("tenant_id"), ownerId.GetProjectId()))
+				/*
+				 * 项目视图可以查看本项目人员发起的操作，或者对本项目资源实施的操作, QIU Jian
+				 */
+				q = q.Filter(sqlchemy.OR(
+					sqlchemy.Equals(q.Field("tenant_id"), ownerId.GetProjectId()),
+					sqlchemy.Equals(q.Field("owner_tenant_id"), ownerId.GetProjectId()),
+				))
 			}
 		case rbacutils.ScopeDomain:
 			if len(ownerId.GetProjectDomainId()) > 0 {
-				q = q.Filter(sqlchemy.Equals(q.Field("project_domain_id"), ownerId.GetProjectDomainId()))
+				/*
+				 * 域视图可以查看本域人员发起的操作，或者对本域资源实施的操作, QIU Jian
+				 */
+				q = q.Filter(sqlchemy.OR(
+					sqlchemy.Equals(q.Field("project_domain_id"), ownerId.GetProjectDomainId()),
+					sqlchemy.Equals(q.Field("owner_domain_id"), ownerId.GetProjectDomainId()),
+				))
 			}
 		default:
 			// systemScope, no filter


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allow viewing events of resources of owner projects or domains
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 