### PR TITLE
fix(region): format time from utc_offset in scheduledtask

### DIFF
--- a/cmd/climc/shell/compute/scheduled_task.go
+++ b/cmd/climc/shell/compute/scheduled_task.go
@@ -33,6 +33,7 @@ func init() {
 		ScheduledType string `help:"scheduled type" choices:"timing|cycle"`
 		ResourceType  string `help:"resource type"`
 		Operation     string `help:"operation"`
+		UtcOffset     int    `help:"utc offset"`
 	}
 	R(&ScheduledTaskListOptions{}, "scheduledtask-list", "list Scheduled Task", func(s *mcclient.ClientSession, args *ScheduledTaskListOptions) error {
 		params, err := options.ListStructToParams(args)

--- a/pkg/compute/models/scaling_trigger.go
+++ b/pkg/compute/models/scaling_trigger.go
@@ -203,7 +203,7 @@ func (st *SScalingTimer) TriggerId() string {
 var cstSh, _ = time.LoadLocation("Asia/Shanghai")
 
 func (st *SScalingTimer) TriggerDescription() string {
-	detail := st.descEnglish()
+	detail := st.descEnglish(time.Local)
 	name := st.ScalingPolicyId
 	sp, _ := st.ScalingPolicy()
 	if sp != nil {

--- a/pkg/compute/models/scheduled_tasks.go
+++ b/pkg/compute/models/scheduled_tasks.go
@@ -113,11 +113,13 @@ func (stm *SScheduledTaskManager) FetchCustomizeColumns(
 	fields stringutils2.SSortedStrings,
 	isList bool,
 ) []api.ScheduledTaskDetails {
+	utcOffset, _ := query.Int("utc_offset")
+	zone := time.FixedZone("UTC", int(utcOffset)*3600)
 	rows := make([]api.ScheduledTaskDetails, len(objs))
 	virRows := stm.SVirtualResourceBaseManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
 	var err error
 	for i := range rows {
-		rows[i], err = objs[i].(*SScheduledTask).getMoreDetails(ctx, userCred, query, isList)
+		rows[i], err = objs[i].(*SScheduledTask).getMoreDetails(ctx, userCred, query, isList, zone)
 		if err != nil {
 			log.Errorf("SScheduledTask.getMoreDetails error: %s", err)
 		}
@@ -126,7 +128,7 @@ func (stm *SScheduledTaskManager) FetchCustomizeColumns(
 	return rows
 }
 
-func (st *SScheduledTask) getMoreDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, isList bool) (api.ScheduledTaskDetails, error) {
+func (st *SScheduledTask) getMoreDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, isList bool, zone *time.Location) (api.ScheduledTaskDetails, error) {
 	var out api.ScheduledTaskDetails
 	switch st.ScheduledType {
 	case api.ST_TYPE_TIMING:
@@ -134,7 +136,7 @@ func (st *SScheduledTask) getMoreDetails(ctx context.Context, userCred mcclient.
 	case api.ST_TYPE_CYCLE:
 		out.CycleTimer = st.STimer.CycleTimerDetails()
 	}
-	out.TimerDesc = st.Description(ctx)
+	out.TimerDesc = st.Description(ctx, zone)
 	// fill label
 	stLabels, err := st.STLabels()
 	if err != nil {

--- a/pkg/compute/models/timer.go
+++ b/pkg/compute/models/timer.go
@@ -172,13 +172,13 @@ func init() {
 	timerDescTable.Set("timerLang", i18n.NewTableEntry().EN("en").CN("cn"))
 }
 
-func (st *STimer) Description(ctx context.Context) string {
+func (st *STimer) Description(ctx context.Context, zone *time.Location) string {
 	lang := timerDescTable.Lookup(ctx, TIMERLANG)
 	switch lang {
 	case "en":
-		return st.descEnglish()
+		return st.descEnglish(zone)
 	case "cn":
-		return st.descChinese()
+		return st.descChinese(zone)
 	}
 	return ""
 }
@@ -186,11 +186,9 @@ func (st *STimer) Description(ctx context.Context) string {
 var (
 	wdsCN = []string{"", "一", "二", "三", "四", "五", "六", "日"}
 	wdsEN = []string{"", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
-	zone  = time.Now().Local().Location()
-	//zone  = time.FixedZone("GMT", 8*3600)
 )
 
-func (st *STimer) descChinese() string {
+func (st *STimer) descChinese(zone *time.Location) string {
 	format := "2006-01-02 15:04:05"
 	var prefix string
 	switch st.Type {
@@ -216,7 +214,7 @@ func (st *STimer) descChinese() string {
 	return fmt.Sprintf("%s %02d:%02d触发 有效时间为%s至%s", prefix, st.Hour, st.Minute, st.StartTime.In(zone).Format(format), st.EndTime.In(zone).Format(format))
 }
 
-func (st *STimer) descEnglish() string {
+func (st *STimer) descEnglish(zone *time.Location) string {
 	var detail string
 	format := "2006-01-02 15:04:05"
 	switch st.Type {


### PR DESCRIPTION
Cherry pick of #13327 on release/3.8.

#13327: fix(scheduledtask): format time from utc_offset