### PR TITLE
fix(host): judge whether the resource exists correctly

### DIFF
--- a/pkg/hostman/isolated_device/isolated_device.go
+++ b/pkg/hostman/isolated_device/isolated_device.go
@@ -24,9 +24,9 @@ import (
 	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	modules "yunion.io/x/onecloud/pkg/mcclient/modules/compute"
-	"yunion.io/x/onecloud/pkg/util/httputils"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 )
 
@@ -199,7 +199,7 @@ func (man *isolatedDeviceManager) StartDetachTask() {
 					jsonutils.Marshal(map[string]interface{}{
 						"purge": true,
 					})); err != nil {
-					if jce, ok := errors.Cause(err).(*httputils.JSONClientError); ok && jce.Code == 404 {
+					if errors.Cause(err) == httperrors.ErrResourceNotFound {
 						break
 					}
 					log.Errorf("Detach device %s failed: %v, try again later", dev.Id, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
remove #13260
调用完我们的SDK之后正确判断资源是否存在的方法是 errors.Cause(err) == httperrors.ErrResourceNotFound
因为 *httputils.JSONClientError 实现了Cause()，所以errors.Cause(err) 拿到的并不是 *httputils.JSONClientError
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area host
/cc @zexi @swordqiu 