### PR TITLE
Automated cherry pick of #13368: fix(host): judge whether the resource exists correctly

### DIFF
--- a/pkg/hostman/isolated_device/isolated_device.go
+++ b/pkg/hostman/isolated_device/isolated_device.go
@@ -24,9 +24,9 @@ import (
 	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
-	"yunion.io/x/onecloud/pkg/util/httputils"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 )
 
@@ -199,7 +199,7 @@ func (man *isolatedDeviceManager) StartDetachTask() {
 					jsonutils.Marshal(map[string]interface{}{
 						"purge": true,
 					})); err != nil {
-					if jce, ok := errors.Cause(err).(*httputils.JSONClientError); ok && jce.Code == 404 {
+					if errors.Cause(err) == httperrors.ErrResourceNotFound {
 						break
 					}
 					log.Errorf("Detach device %s failed: %v, try again later", dev.Id, err)


### PR DESCRIPTION
Cherry pick of #13368 on release/3.8.

#13368: fix(host): judge whether the resource exists correctly