### PR TITLE
Automated cherry pick of #13392: fix(host): make tls-creds empty when no tls migrate

### DIFF
--- a/pkg/hostman/guestman/guesttasks.go
+++ b/pkg/hostman/guestman/guesttasks.go
@@ -681,7 +681,14 @@ func (s *SGuestLiveMigrateTask) startMigrate(res string) {
 			})
 		})
 	} else {
-		s.doMigrate()
+		s.Monitor.MigrateSetParameter("tls-creds", "", func(res string) {
+			if strings.Contains(strings.ToLower(res), "error") {
+				s.migrateTask = nil
+				hostutils.TaskFailed(s.ctx, fmt.Sprintf("Migrate set tls-creds to empty error: %s", res))
+				return
+			}
+			s.doMigrate()
+		})
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #13392 on release/3.8.

#13392: fix(host): make tls-creds empty when no tls migrate