### PR TITLE
Automated cherry pick of #13426: fix: delay block stream after server start

### DIFF
--- a/pkg/hostman/guestman/guesttasks.go
+++ b/pkg/hostman/guestman/guesttasks.go
@@ -894,7 +894,10 @@ func (s *SGuestResumeTask) onStartRunning() {
 
 	disksIdx := s.GetNeedMergeBackingFileDiskIndexs()
 	if len(disksIdx) > 0 {
-		s.startStreamDisks(disksIdx)
+		s.SyncStatus("")
+		timeutils2.AddTimeout(
+			time.Second*time.Duration(options.HostOptions.AutoMergeDelaySeconds),
+			func() { s.startStreamDisks(disksIdx) })
 	} else if options.HostOptions.AutoMergeBackingTemplate {
 		s.SyncStatus("")
 		timeutils2.AddTimeout(


### PR DESCRIPTION
Cherry pick of #13426 on release/3.8.

#13426: fix: delay block stream after server start