### PR TITLE
fix: class network mtu should consider default_mtu

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -161,11 +161,13 @@ func (self *SNetwork) getMtu() int {
 
 	wire, _ := self.GetWire()
 	if wire != nil {
-		baseMtu = options.Options.OvnUnderlayMtu
 		if IsOneCloudVpcResource(wire) {
-			baseMtu -= api.VPC_OVN_ENCAP_COST
+			return options.Options.OvnUnderlayMtu - api.VPC_OVN_ENCAP_COST
+		} else if wire.Mtu != 0 {
+			return wire.Mtu
+		} else {
+			return baseMtu
 		}
-		return baseMtu
 	}
 
 	return baseMtu


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: mtu of classic network 
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 