### PR TITLE
Automated cherry pick of #13451: fix: class network mtu should consider default_mtu

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -165,11 +165,13 @@ func (self *SNetwork) getMtu() int {
 
 	wire, _ := self.GetWire()
 	if wire != nil {
-		baseMtu = options.Options.OvnUnderlayMtu
 		if IsOneCloudVpcResource(wire) {
-			baseMtu -= api.VPC_OVN_ENCAP_COST
+			return options.Options.OvnUnderlayMtu - api.VPC_OVN_ENCAP_COST
+		} else if wire.Mtu != 0 {
+			return wire.Mtu
+		} else {
+			return baseMtu
 		}
-		return baseMtu
 	}
 
 	return baseMtu


### PR DESCRIPTION
Cherry pick of #13451 on release/3.8.

#13451: fix: class network mtu should consider default_mtu