### PR TITLE
Automated cherry pick of #13541: fix(region): call parent's PostCreate in virtualResourceBase.PostCreate

### DIFF
--- a/pkg/cloudcommon/db/virtualresource.go
+++ b/pkg/cloudcommon/db/virtualresource.go
@@ -292,6 +292,7 @@ func (model *SVirtualResourceBase) PostCreate(ctx context.Context, userCred mccl
 	if err != nil {
 		log.Errorf("unable to inherit class metadata from poject %s: %s", project.GetId(), err.Error())
 	}
+	model.SStatusStandaloneResourceBase.PostCreate(ctx, userCred, ownerId, query, data)
 }
 
 func (manager *SVirtualResourceBaseManager) FetchCustomizeColumns(


### PR DESCRIPTION
Cherry pick of #13541 on release/3.9.

#13541: fix(region): call parent's PostCreate in virtualResourceBase.PostCreate