### PR TITLE
Automated cherry pick of #13548: feat(region): add server-cpuset-cores cmd to get pinned and usable cores

### DIFF
--- a/cmd/climc/shell/compute/servers.go
+++ b/cmd/climc/shell/compute/servers.go
@@ -112,6 +112,8 @@ func init() {
 	cmd.Get("make-sshable-cmd", new(options.ServerIdOptions))
 	cmd.Get("change-owner-candidate-domains", new(options.ServerChangeOwnerCandidateDomainsOptions))
 	cmd.Get("change-owner-candidate-domains", new(options.ServerChangeOwnerCandidateDomainsOptions))
+	cmd.Get("cpuset-cores", new(options.ServerIdOptions))
+
 	cmd.GetProperty(&options.ServerStatusStatisticsOptions{})
 	cmd.GetProperty(&options.ServerProjectStatisticsOptions{})
 	cmd.GetProperty(&options.ServerDomainStatisticsOptions{})

--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -811,3 +811,10 @@ type ServerCPUSetRemoveResp struct {
 	Done  bool   `json:"done"`
 	Error string `json:"error"`
 }
+
+type ServerGetCPUSetCoresInput struct{}
+
+type ServerGetCPUSetCoresResp struct {
+	PinnedCores []int `json:"pinned_cores"`
+	HostCores   []int `json:"host_cores"`
+}


### PR DESCRIPTION
Cherry pick of #13548 on release/3.9.

#13548: feat(region): add server-cpuset-cores cmd to get pinned and usable cores