### PR TITLE
Automated cherry pick of #13589: fix(region,devtool): get ssh port from 'servers/<id>/sshport' api

### DIFF
--- a/cmd/climc/shell/compute/servers.go
+++ b/cmd/climc/shell/compute/servers.go
@@ -101,6 +101,8 @@ func init() {
 	cmd.Get("make-sshable-cmd", new(options.ServerIdOptions))
 	cmd.Get("change-owner-candidate-domains", new(options.ServerChangeOwnerCandidateDomainsOptions))
 	cmd.Get("change-owner-candidate-domains", new(options.ServerChangeOwnerCandidateDomainsOptions))
+	cmd.Get("sshport", new(options.ServerIdOptions))
+
 	cmd.GetProperty(&options.ServerStatusStatisticsOptions{})
 
 	type ServerTaskShowOptions struct {

--- a/pkg/apis/compute/guest_sshable.go
+++ b/pkg/apis/compute/guest_sshable.go
@@ -66,6 +66,10 @@ type GuestMakeSshableCmdOutput struct {
 	ShellCmd string
 }
 
-type GuestSetSshPortInput struct {
+type GuestSetSshportInput struct {
+	Port int
+}
+
+type GuestSshportOutput struct {
 	Port int
 }

--- a/pkg/compute/models/guest_sshable.go
+++ b/pkg/compute/models/guest_sshable.go
@@ -595,13 +595,18 @@ func (guest *SGuest) SetSshPort(ctx context.Context, userCred mcclient.TokenCred
 	return guest.SetMetadata(ctx, compute_api.SSH_PORT, port, userCred)
 }
 
-func (guest *SGuest) AllowPerformSetSshport(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
-	return guest.IsOwner(userCred) || db.IsAdminAllowPerform(userCred, guest, "set-sshport")
-}
-
-func (guest *SGuest) PerformSetSshPort(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input compute_api.GuestSetSshPortInput) (jsonutils.JSONObject, error) {
+func (guest *SGuest) PerformSetSshport(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input compute_api.GuestSetSshportInput) (jsonutils.JSONObject, error) {
 	if input.Port < 0 {
 		return nil, httperrors.NewInputParameterError("invalid port")
 	}
 	return nil, guest.SetSshPort(ctx, userCred, input.Port)
+}
+
+func (guest *SGuest) GetDetailsSshport(
+	ctx context.Context,
+	userCred mcclient.TokenCredential,
+	query jsonutils.JSONObject,
+) (compute_api.GuestSshportOutput, error) {
+	port := guest.GetSshPort(userCred)
+	return compute_api.GuestSshportOutput{Port: port}, nil
 }


### PR DESCRIPTION
Cherry pick of #13589 on release/3.7.

#13589: fix(region,devtool): get ssh port from 'servers/<id>/sshport' api