### PR TITLE
Automated cherry pick of #13600: fix(region): remote useless info of azure lb

### DIFF
--- a/pkg/multicloud/azure/loadbalancer.go
+++ b/pkg/multicloud/azure/loadbalancer.go
@@ -110,7 +110,6 @@ func (self *SLoadbalancer) GetSysTags() map[string]string {
 	data["capacity"] = self.Properties.Sku.Capacity
 	data["max_capacity"] = strconv.Itoa(self.Properties.AutoscaleConfiguration.MaxCapacity)
 	data["min_capacity"] = strconv.Itoa(self.Properties.AutoscaleConfiguration.MinCapacity)
-	data["properties"] = jsonutils.Marshal(self.Properties).String()
 	return data
 }
 


### PR DESCRIPTION
Cherry pick of #13600 on release/3.9.

#13600: fix(region): remote useless info of azure lb