### PR TITLE
Automated cherry pick of #13606: fix: disable cache for oidc auth callback

### DIFF
--- a/pkg/apigateway/handler/oidc.go
+++ b/pkg/apigateway/handler/oidc.go
@@ -100,6 +100,7 @@ func handleOIDCAuth(ctx context.Context, w http.ResponseWriter, req *http.Reques
 	qs.Set("code", jsonutils.NewString(code))
 	qs.Set("state", jsonutils.NewString(auth.State))
 	redirUrl := addQuery(auth.RedirectUri, qs)
+	appsrv.DisableClientCache(w)
 	appsrv.SendRedirect(w, redirUrl)
 }
 


### PR DESCRIPTION
Cherry pick of #13606 on release/3.7.

#13606: fix: disable cache for oidc auth callback