### PR TITLE
Automated cherry pick of #13610: fix(scheduledtask): treat hour and minute as utc time

### DIFF
--- a/pkg/compute/models/scaling_trigger_test.go
+++ b/pkg/compute/models/scaling_trigger_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestSTimer_Update(t *testing.T) {
-	loc, _ := time.LoadLocation("Asia/Shanghai")
+	loc := time.UTC
 	ins := []struct {
 		Timer       *STimer
 		UpdateTimes int


### PR DESCRIPTION
Cherry pick of #13610 on release/3.8.

#13610: fix(scheduledtask): treat hour and minute as utc time