### PR TITLE
fix: aws s3 object with leading slash

### DIFF
--- a/pkg/multicloud/aws/region.go
+++ b/pkg/multicloud/aws/region.go
@@ -202,7 +202,10 @@ func (self *SRegion) GetS3Client() (*s3.S3, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "getAwsSession")
 		}
-		self.s3Client = s3.New(s)
+		self.s3Client = s3.New(s,
+			&aws.Config{
+				DisableRestProtocolURICleaning: aws.Bool(true),
+			})
 	}
 	return self.s3Client, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fail to retrieve aws S3 object with leading slash
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8
- release/3.7

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi @ioito @zhaoxiangchun 