### PR TITLE
Automated cherry pick of #13659: fix: aws s3 object with leading slash

### DIFF
--- a/pkg/multicloud/aws/region.go
+++ b/pkg/multicloud/aws/region.go
@@ -202,7 +202,10 @@ func (self *SRegion) GetS3Client() (*s3.S3, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "getAwsSession")
 		}
-		self.s3Client = s3.New(s)
+		self.s3Client = s3.New(s,
+			&aws.Config{
+				DisableRestProtocolURICleaning: aws.Bool(true),
+			})
 	}
 	return self.s3Client, nil
 }


### PR DESCRIPTION
Cherry pick of #13659 on release/3.8.

#13659: fix: aws s3 object with leading slash