### PR TITLE
Automated cherry pick of #13663: fix(climc): add purge splitable for action and cloudevent

### DIFF
--- a/cmd/climc/shell/cloudevent/cloudevents.go
+++ b/cmd/climc/shell/cloudevent/cloudevents.go
@@ -43,10 +43,22 @@ func init() {
 		return nil
 	})
 
+	type CloudeventSplitTableOptions struct {
+	}
+
+	R(&CloudeventSplitTableOptions{}, "cloud-event-splitable", "Show obsolete cloud event logs", func(s *mcclient.ClientSession, opts *CloudeventSplitTableOptions) error {
+		resp, err := cloudevent.Cloudevents.Get(s, "splitable", nil)
+		if err != nil {
+			return err
+		}
+		printObject(resp)
+		return nil
+	})
+
 	type CloudeventLogsPurgeOptions struct {
 		Tables []string
 	}
-	R(&CloudeventLogsPurgeOptions{}, "cloud-event-purge", "Purge obsolete cloud event logs", func(s *mcclient.ClientSession, opts *CloudeventLogsPurgeOptions) error {
+	R(&CloudeventLogsPurgeOptions{}, "cloud-event-purge-splitable", "Purge obsolete cloud event logs", func(s *mcclient.ClientSession, opts *CloudeventLogsPurgeOptions) error {
 		resp, err := cloudevent.Cloudevents.PerformClassAction(s, "purge-splitable", jsonutils.Marshal(opts))
 		if err != nil {
 			return err

--- a/cmd/climc/shell/logger/actions.go
+++ b/cmd/climc/shell/logger/actions.go
@@ -120,6 +120,31 @@ func doActionList(s *mcclient.ClientSession, args *ActionListOptions) error {
 func init() {
 	R(&ActionListOptions{}, "action-show", "Show operation action logs", doActionList)
 
+	type ActionSplitTableOptions struct {
+	}
+
+	R(&ActionSplitTableOptions{}, "action-splitable", "Show splitables", func(s *mcclient.ClientSession, args *ActionSplitTableOptions) error {
+		resp, err := modules.Actions.Get(s, "splitable", nil)
+		if err != nil {
+			return err
+		}
+		printObject(resp)
+		return nil
+	})
+
+	type ActionPurgeOptions struct {
+		Tables []string
+	}
+
+	R(&ActionPurgeOptions{}, "action-purge-splitable", "Purge action splitables", func(s *mcclient.ClientSession, args *ActionPurgeOptions) error {
+		resp, err := modules.Actions.PerformClassAction(s, "purge-splitable", jsonutils.Marshal(args))
+		if err != nil {
+			return err
+		}
+		printObject(resp)
+		return nil
+	})
+
 	R(&TypeActionListOptions{}, "server-action", "Show operation action logs of server", func(s *mcclient.ClientSession, args *TypeActionListOptions) error {
 		nargs := ActionListOptions{BaseActionListOptions: args.BaseActionListOptions, Id: args.ID, Type: []string{"server"}}
 		return doActionList(s, &nargs)


### PR DESCRIPTION
Cherry pick of #13663 on release/3.9.

#13663: fix(climc): add purge splitable for action and cloudevent