### PR TITLE
fix: qemu no nic addr at release/3.8

### DIFF
--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -677,7 +677,7 @@ function nic_mtu() {
 		} else {
 			cmd += nicCmd
 		}
-		cmd += s.getVnicDesc(nics[i], true)
+		cmd += s.getVnicDesc(nics[i], false)
 	}
 
 	// USB 3.0


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: qemu no nic addr 

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 