### PR TITLE
Automated cherry pick of #13677: fix: server inherit the vdi_protocol of image property

### DIFF
--- a/cmd/climc/shell/image/images.go
+++ b/cmd/climc/shell/image/images.go
@@ -61,6 +61,7 @@ type ImageOptionalOptions struct {
 	NetDriver          string   `help:"Preferred network driver" choices:"virtio|e1000|vmxnet3"`
 	DisableUsbKbd      bool     `help:"Disable usb keyboard on this image(for hypervisor kvm)"`
 	BootMode           string   `help:"UEFI support" choices:"UEFI|BIOS"`
+	VdiProtocol        string   `help:"VDI protocol" choices:"vnc|spice"`
 }
 
 func addImageOptionalOptions(s *mcclient.ClientSession, params *jsonutils.JSONDict, args ImageOptionalOptions) error {
@@ -145,6 +146,9 @@ func addImageOptionalOptions(s *mcclient.ClientSession, params *jsonutils.JSONDi
 		params.Add(jsonutils.JSONTrue, "properties", "uefi_support")
 	} else if args.BootMode == "BIOS" {
 		params.Add(jsonutils.JSONFalse, "properties", "uefi_support")
+	}
+	if len(args.VdiProtocol) > 0 {
+		params.Add(jsonutils.NewString(args.VdiProtocol), "properties", "vdi_protocol")
 	}
 	return nil
 }

--- a/pkg/apis/image/consts.go
+++ b/pkg/apis/image/consts.go
@@ -58,6 +58,7 @@ const (
 	IMAGE_PARTITION_TYPE      = "partition_type"
 	IMAGE_INSTALLED_CLOUDINIT = "installed_cloud_init"
 	IMAGE_DISABLE_USB_KBD     = "disable_usb_kbd"
+	IMAGE_VDI_PROTOCOL        = "vdi_protocol"
 
 	IMAGE_STATUS_UPDATING = "updating"
 )

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1332,6 +1332,9 @@ func (manager *SGuestManager) validateCreateData(
 		}
 		input.DisableUsbKbd = imgProperties[imageapi.IMAGE_DISABLE_USB_KBD] == "true"
 
+		if vdi, ok := imgProperties[imageapi.IMAGE_VDI_PROTOCOL]; ok && len(vdi) > 0 {
+			input.Vdi = vdi
+		}
 		osType := input.OsType
 		osProf, err = osprofile.GetOSProfileFromImageProperties(imgProperties, hypervisor)
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #13677 on release/3.9.

#13677: fix: server inherit the vdi_protocol of image property