### PR TITLE
fix(host/region): fix import servers from libvirt

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -3877,11 +3877,11 @@ func (man *SGuestManager) DoImport(
 	}
 	// 2. import networks
 	if err := gst.importNics(ctx, userCred, desc.Nics); err != nil {
-		return nil, err
+		return gst, err
 	}
 	// 3. import disks
 	if err := gst.importDisks(ctx, userCred, desc.Disks); err != nil {
-		return nil, err
+		return gst, err
 	}
 	// 4. set metadata
 	for k, v := range desc.Metadata {

--- a/pkg/hostman/guestman/guesthandlers/guestimport.go
+++ b/pkg/hostman/guestman/guesthandlers/guestimport.go
@@ -16,7 +16,6 @@ package guesthandlers
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 
 	"yunion.io/x/jsonutils"
@@ -27,7 +26,10 @@ import (
 	"yunion.io/x/onecloud/pkg/hostman/hostutils"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
+	"yunion.io/x/onecloud/pkg/util/procutils"
 )
+
+const libvirtMountPath = "/opt/cloud/libvirt"
 
 func guestPrepareImportFormLibvirt(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	_, _, body := appsrv.FetchEnv(ctx, w, r)
@@ -41,9 +43,10 @@ func guestPrepareImportFormLibvirt(ctx context.Context, w http.ResponseWriter, r
 		hostutils.Response(ctx, w, httperrors.NewMissingParameterError("xml_file_path"))
 		return
 	}
-	if !fileutils2.Exists(config.XmlFilePath) {
+	err = procutils.NewRemoteCommandAsFarAsPossible("test", "-d", config.XmlFilePath).Run()
+	if err != nil {
 		hostutils.Response(ctx, w,
-			httperrors.NewBadRequestError("xml_file_path %s not found", config.XmlFilePath))
+			httperrors.NewBadRequestError("check xml_file_path %s failed: %s", config.XmlFilePath, err))
 		return
 	}
 
@@ -53,11 +56,35 @@ func guestPrepareImportFormLibvirt(ctx context.Context, w http.ResponseWriter, r
 	}
 
 	if len(config.MonitorPath) > 0 {
-		if _, err := ioutil.ReadDir(config.MonitorPath); err != nil {
-			hostutils.Response(ctx, w,
-				httperrors.NewBadRequestError("Monitor path %s can't open as dir: %s", config.MonitorPath, err))
+		err = procutils.NewRemoteCommandAsFarAsPossible("test", "-d", config.MonitorPath).Run()
+		if err != nil {
+			hostutils.Response(ctx, w, httperrors.NewBadRequestError(
+				"check monitor_path %s failed: %s", config.MonitorPath, err,
+			))
 			return
 		}
+
+		// monitor path may not exist in container
+		err = procutils.NewRemoteCommandAsFarAsPossible("mkdir", "-p", libvirtMountPath).Run()
+		if err != nil {
+			hostutils.Response(ctx, w, httperrors.NewBadRequestError(
+				"mkdir libvirt cloud path %s failed: %s", libvirtMountPath, err,
+			))
+			return
+		}
+
+		if err = procutils.NewRemoteCommandAsFarAsPossible("mountpoint", libvirtMountPath).Run(); err != nil {
+			out, err := procutils.NewRemoteCommandAsFarAsPossible(
+				"mount", "--bind", config.MonitorPath, libvirtMountPath,
+			).Output()
+			if err != nil {
+				hostutils.Response(ctx, w, httperrors.NewBadRequestError(
+					"monitor path create symbolic link failed: %s", out,
+				))
+				return
+			}
+		}
+		config.MonitorPath = libvirtMountPath
 	}
 
 	hostutils.DelayTask(ctx, guestman.GetGuestManager().PrepareImportFromLibvirt, config)

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -148,6 +148,10 @@ func (s *SKVMGuestInstance) getOriginId() string {
 	return originId
 }
 
+func (s *SKVMGuestInstance) isImportFromLibvirt() bool {
+	return len(s.getOriginId()) > 0
+}
+
 func (s *SKVMGuestInstance) GetPid() int {
 	return s.getPid(s.GetPidFilePath(), s.getOriginId())
 }
@@ -1360,7 +1364,7 @@ func (s *SKVMGuestInstance) SyncConfig(ctx context.Context, desc jsonutils.JSONO
 	var changedNetworks [][]jsonutils.JSONObject
 	var cdrom *string
 
-	if !fwOnly {
+	if !fwOnly && !s.isImportFromLibvirt() {
 		delDisks, addDisks = s.compareDescDisks(desc)
 		cdrom = s.compareDescCdrom(desc)
 		delNetworks, addNetworks, changedNetworks = s.compareDescNetworks(desc)


### PR DESCRIPTION
make servers_import_from_libvirt workable in container environment.
bindmount libvirt monitor dir to host container and use procutils read
guest xml configure.

Signed-off-by: wanyaoqi <wanyaoqi1995@163.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
