### PR TITLE
Automated cherry pick of #13718: fix(region): host schedtags with topology

### DIFF
--- a/pkg/apis/compute/vpc.go
+++ b/pkg/apis/compute/vpc.go
@@ -144,6 +144,7 @@ type HostTopologyOutput struct {
 	HostStatus string                      `json:"host_status"`
 	HostType   string                      `json:"host_type"`
 	Networks   []HostnetworkTopologyOutput `json:"networks"`
+	Schedtags  []SchedtagShortDescDetails  `json:"schedtags"`
 }
 
 type WireTopologyOutput struct {

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -1757,6 +1757,7 @@ func (self *SVpc) GetDetailsTopology(ctx context.Context, userCred mcclient.Toke
 				HostStatus: hosts[i].HostStatus,
 				HostType:   hosts[i].HostType,
 				Networks:   []api.HostnetworkTopologyOutput{},
+				Schedtags:  GetSchedtagsDetailsToResourceV2(&hosts[i], ctx),
 			}
 			for j := range hns {
 				host.Networks = append(host.Networks, api.HostnetworkTopologyOutput{

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -1561,6 +1561,7 @@ func (self *SWire) GetDetailsTopology(ctx context.Context, userCred mcclient.Tok
 			HostStatus: hosts[i].HostStatus,
 			HostType:   hosts[i].HostType,
 			Networks:   []api.HostnetworkTopologyOutput{},
+			Schedtags:  GetSchedtagsDetailsToResourceV2(&hosts[i], ctx),
 		}
 		for j := range hns {
 			host.Networks = append(host.Networks, api.HostnetworkTopologyOutput{


### PR DESCRIPTION
Cherry pick of #13718 on release/3.9.

#13718: fix(region): host schedtags with topology