### PR TITLE
fix(region): get project id correctly when recovery guest

### DIFF
--- a/pkg/compute/models/instance_backup.go
+++ b/pkg/compute/models/instance_backup.go
@@ -246,6 +246,8 @@ func (manager *SInstanceBackupManager) fillInstanceBackup(ctx context.Context, u
 	instanceBackup.CloudregionId = zone.CloudregionId
 
 	createInput := guest.ToCreateInput(ctx, userCred)
+	createInput.ProjectId = guest.ProjectId
+	createInput.ProjectDomainId = guest.DomainId
 	for i := 0; i < len(createInput.Networks); i++ {
 		createInput.Networks[i].Mac = ""
 		createInput.Networks[i].Address = ""

--- a/pkg/compute/tasks/instance_backup_recovery_task.go
+++ b/pkg/compute/tasks/instance_backup_recovery_task.go
@@ -62,6 +62,9 @@ func (self *InstanceBackupRecoveryTask) OnInit(ctx context.Context, obj db.IStan
 		serverName, _ = ib.ServerConfig.GetString("name")
 	}
 	projectId, _ := ib.ServerConfig.GetString("project_id")
+	if projectId == "" {
+		projectId, _ = ib.ServerConfig.GetString("tenant_id")
+	}
 	sourceInput := &compute.ServerCreateInput{}
 	sourceInput.ServerConfigs = &compute.ServerConfigs{}
 	sourceInput.GenerateName = serverName


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zexi 