### PR TITLE
Automated cherry pick of #13734: fix(region): get project id correctly when recovery guest

### DIFF
--- a/pkg/compute/models/instance_backup.go
+++ b/pkg/compute/models/instance_backup.go
@@ -246,6 +246,8 @@ func (manager *SInstanceBackupManager) fillInstanceBackup(ctx context.Context, u
 	instanceBackup.CloudregionId = zone.CloudregionId
 
 	createInput := guest.ToCreateInput(ctx, userCred)
+	createInput.ProjectId = guest.ProjectId
+	createInput.ProjectDomainId = guest.DomainId
 	for i := 0; i < len(createInput.Networks); i++ {
 		createInput.Networks[i].Mac = ""
 		createInput.Networks[i].Address = ""

--- a/pkg/compute/tasks/instance_backup_recovery_task.go
+++ b/pkg/compute/tasks/instance_backup_recovery_task.go
@@ -62,6 +62,9 @@ func (self *InstanceBackupRecoveryTask) OnInit(ctx context.Context, obj db.IStan
 		serverName, _ = ib.ServerConfig.GetString("name")
 	}
 	projectId, _ := ib.ServerConfig.GetString("project_id")
+	if projectId == "" {
+		projectId, _ = ib.ServerConfig.GetString("tenant_id")
+	}
 	sourceInput := &compute.ServerCreateInput{}
 	sourceInput.ServerConfigs = &compute.ServerConfigs{}
 	sourceInput.GenerateName = serverName


### PR DESCRIPTION
Cherry pick of #13734 on release/3.9.

#13734: fix(region): get project id correctly when recovery guest