### PR TITLE
Automated cherry pick of #13749: fix(region): vmware no need secgroup

### DIFF
--- a/pkg/multicloud/cloudpods/instance.go
+++ b/pkg/multicloud/cloudpods/instance.go
@@ -167,6 +167,9 @@ func (self *SInstance) AssignSecurityGroup(id string) error {
 }
 
 func (self *SInstance) SetSecurityGroups(ids []string) error {
+	if self.Hypervisor == api.HYPERVISOR_ESXI {
+		return nil
+	}
 	input := api.GuestSetSecgroupInput{}
 	input.SecgroupIds = ids
 	_, err := self.host.zone.region.perform(&modules.Servers, self.Id, "set-secgroup", input)


### PR DESCRIPTION
Cherry pick of #13749 on release/3.8.

#13749: fix(region): vmware no need secgroup