### PR TITLE
Automated cherry pick of #13757: fix(region): host sched tag sync

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1876,17 +1876,18 @@ func (s *SHost) syncSchedtags(ctx context.Context, userCred mcclient.TokenCreden
 			st.DomainId = s.DomainId
 			st.Name = stStr
 			st.Description = "Sync from cloud"
+			st.SetModelManager(SchedtagManager, st)
 			err := SchedtagManager.TableSpec().Insert(ctx, st)
 			if err != nil {
 				return errors.Wrapf(err, "unable to create schedtag %q", stStr)
 			}
-			st.SetModelManager(SchedtagManager, st)
 			st.SetMetadata(ctx, METADATA_EXT_SCHEDTAG_KEY, stStr, userCred)
 		}
 		// attach
 		hostschedtag := &SHostschedtag{
 			HostId: s.GetId(),
 		}
+		hostschedtag.SetModelManager(HostschedtagManager, hostschedtag)
 		hostschedtag.SchedtagId = st.GetId()
 		err = HostschedtagManager.TableSpec().Insert(ctx, hostschedtag)
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #13757 on release/3.9.

#13757: fix(region): host sched tag sync