### PR TITLE
fix(region): release lock in SyncAppEnvironments

### DIFF
--- a/pkg/compute/models/app_environment.go
+++ b/pkg/compute/models/app_environment.go
@@ -104,7 +104,7 @@ func (aem *SAppEnvironmentManager) QueryDistinctExtraField(q *sqlchemy.SQuery, f
 
 func (a *SApp) SyncAppEnvironments(ctx context.Context, userCred mcclient.TokenCredential, provider *SCloudprovider, exts []cloudprovider.ICloudAppEnvironment) compare.SyncResult {
 	lockman.LockRawObject(ctx, AppEnvironmentManager.KeywordPlural(), a.Id)
-	defer lockman.LockRawObject(ctx, AppEnvironmentManager.KeywordPlural(), a.Id)
+	defer lockman.ReleaseRawObject(ctx, AppEnvironmentManager.KeywordPlural(), a.Id)
 	result := compare.SyncResult{}
 	aes, err := a.GetAppEnvironments()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zexi @ioito 