### PR TITLE
region/host: fix reset ceph root disk after rebuild root

### DIFF
--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -1208,6 +1208,9 @@ func (self *SKVMRegionDriver) GetDiskResetParams(snapshot *models.SSnapshot) *js
 	params.Set("snapshot_id", jsonutils.NewString(snapshot.Id))
 	params.Set("out_of_chain", jsonutils.NewBool(snapshot.OutOfChain))
 	params.Set("location", jsonutils.NewString(snapshot.Location))
+	if len(snapshot.BackingDiskId) > 0 {
+		params.Set("backing_disk_id", jsonutils.NewString(snapshot.BackingDiskId))
+	}
 	return params
 }
 

--- a/pkg/hostman/storageman/disk_rbd.go
+++ b/pkg/hostman/storageman/disk_rbd.go
@@ -275,9 +275,13 @@ func (d *SRBDDisk) ResetFromSnapshot(ctx context.Context, params interface{}) (j
 	if !ok {
 		return nil, hostutils.ParamsError
 	}
+	diskId := resetParams.BackingDiskId
+	if len(diskId) == 0 {
+		diskId = d.GetId()
+	}
 	storage := d.Storage.(*SRbdStorage)
 	pool, _ := storage.StorageConf.GetString("pool")
-	return nil, storage.resetDisk(pool, d.GetId(), resetParams.SnapshotId)
+	return nil, storage.resetDisk(pool, diskId, resetParams.SnapshotId)
 }
 
 func (d *SRBDDisk) CreateFromRbdSnapshot(ctx context.Context, snapshot, srcDiskId, srcPool string) error {

--- a/pkg/hostman/storageman/diskhandlers/diskhandler.go
+++ b/pkg/hostman/storageman/diskhandlers/diskhandler.go
@@ -310,9 +310,11 @@ func diskReset(ctx context.Context, storage storageman.IStorage, diskId string, 
 	if err != nil {
 		return nil, httperrors.NewMissingParameterError("snapshot_id")
 	}
+	backingDiskId, _ := body.GetString("backing_disk_id")
 	hostutils.DelayTask(ctx, disk.ResetFromSnapshot, &storageman.SDiskReset{
-		SnapshotId: snapshotId,
-		Input:      body,
+		SnapshotId:    snapshotId,
+		BackingDiskId: backingDiskId,
+		Input:         body,
 	})
 	return nil, nil
 }

--- a/pkg/hostman/storageman/storagehelper.go
+++ b/pkg/hostman/storageman/storagehelper.go
@@ -35,8 +35,9 @@ func (i *SDiskCreateByDiskinfo) String() string {
 }
 
 type SDiskReset struct {
-	SnapshotId string
-	Input      jsonutils.JSONObject
+	SnapshotId    string
+	BackingDiskId string
+	Input         jsonutils.JSONObject
 }
 
 type SDiskCleanupSnapshots struct {


### PR DESCRIPTION
Ceph storage disk rebuild root will rename origin disk to backing
disk, so we need use backing disk reset snapshot.

Signed-off-by: wanyaoqi <wanyaoqi1995@163.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
