### PR TITLE
Automated cherry pick of #13816: fix(telegraf-raid-plugin): zombies recycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ image:
 .PHONY: image
 
 image-telegraf-raid-plugin:
-	VERSION=release-1.6.2 ARCH=all make image telegraf-raid-plugin
+	VERSION=release-1.6.3 ARCH=all make image telegraf-raid-plugin
 
 %:
 	@:

--- a/cmd/telegraf-raid-plugin/main.go
+++ b/cmd/telegraf-raid-plugin/main.go
@@ -19,6 +19,7 @@ import (
 	"yunion.io/x/onecloud/pkg/baremetal/utils/raid/drivers"
 	"yunion.io/x/onecloud/pkg/compute/baremetal"
 	"yunion.io/x/onecloud/pkg/util/httputils"
+	"yunion.io/x/onecloud/pkg/util/procutils"
 )
 
 const (
@@ -128,6 +129,7 @@ func (c *RaidInfoCollector) CollectReportData() string {
 }
 
 func (c *RaidInfoCollector) Start() {
+	go procutils.WaitZombieLoop(context.TODO())
 	for {
 		c.runMain()
 		time.Sleep(time.Second * 1)


### PR DESCRIPTION
Cherry pick of #13816 on release/3.6.

#13816: fix(telegraf-raid-plugin): zombies recycle