### PR TITLE
fix: aarch64 ensure UEFI

### DIFF
--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -418,9 +418,11 @@ function nic_mtu() {
 	}
 
 	// UEFI ovmf file path
-	if s.getBios() == qemu.BIOS_UEFI || input.QemuArch == qemu.Arch_aarch64 {
+	if input.QemuArch == qemu.Arch_aarch64 && !strings.HasPrefix(input.BIOS, qemu.BIOS_UEFI) {
 		input.BIOS = qemu.BIOS_UEFI
-		input.OVMFPath = options.HostOptions.OvmfPath
+		if len(input.OVMFPath) == 0 {
+			input.OVMFPath = options.HostOptions.OvmfPath
+		}
 	}
 
 	// inject nic and disks


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: aarch64 requires UEFI

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 