### PR TITLE
Automated cherry pick of #13844: fix: aarch64 ensure UEFI

### DIFF
--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -418,9 +418,11 @@ function nic_mtu() {
 	}
 
 	// UEFI ovmf file path
-	if s.getBios() == qemu.BIOS_UEFI || input.QemuArch == qemu.Arch_aarch64 {
+	if input.QemuArch == qemu.Arch_aarch64 && !strings.HasPrefix(input.BIOS, qemu.BIOS_UEFI) {
 		input.BIOS = qemu.BIOS_UEFI
-		input.OVMFPath = options.HostOptions.OvmfPath
+		if len(input.OVMFPath) == 0 {
+			input.OVMFPath = options.HostOptions.OvmfPath
+		}
 	}
 
 	// inject nic and disks


### PR DESCRIPTION
Cherry pick of #13844 on release/3.9.

#13844: fix: aarch64 ensure UEFI