### PR TITLE
fix: cloudshell use dynamic keystone endpoint

### DIFF
--- a/pkg/mcclient/modules/webconsole/mod_webconsole.go
+++ b/pkg/mcclient/modules/webconsole/mod_webconsole.go
@@ -109,12 +109,17 @@ func (m WebConsoleManager) DoCloudShell(s *mcclient.ClientSession, _ jsonutils.J
 	req.Namespace = "onecloud"
 	req.Container = "climc"
 	req.Command = "/bin/bash"
+	endpointType := "internal"
+	authUrl, _ := s.GetServiceURL("identity", endpointType)
+	if err != nil {
+		return nil, httperrors.NewNotFoundError("auth_url not found")
+	}
 	req.Env = map[string]string{
 		"OS_AUTH_TOKEN":           s.GetToken().GetTokenString(),
 		"OS_PROJECT_NAME":         s.GetProjectName(),
 		"OS_PROJECT_DOMAIN":       s.GetProjectDomain(),
-		"OS_AUTH_URL":             "https://default-keystone:30500/v3",
-		"OS_ENDPOINT_TYPE":        "internal",
+		"OS_AUTH_URL":             authUrl,
+		"OS_ENDPOINT_TYPE":        endpointType,
 		"YUNION_USE_CACHED_TOKEN": "false",
 		"YUNION_INSECURE":         "true",
 		"OS_USERNAME":             "",


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: cloudshell use dynamic keystone endpoint

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 