### PR TITLE
Automated cherry pick of #13856: fix: fail to snapshot and clone due to mismatch class metadata

### DIFF
--- a/pkg/compute/models/instance_snapshots.go
+++ b/pkg/compute/models/instance_snapshots.go
@@ -391,7 +391,11 @@ func (manager *SInstanceSnapshotManager) CreateInstanceSnapshot(ctx context.Cont
 	instanceSnapshot.MemoryFileHostId = guest.HostId
 	err := manager.TableSpec().Insert(ctx, instanceSnapshot)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Insert")
+	}
+	err = db.Inherit(ctx, guest, instanceSnapshot)
+	if err != nil {
+		return nil, errors.Wrap(err, "Inherit ClassMetadata")
 	}
 	return instanceSnapshot, nil
 }


### PR DESCRIPTION
Cherry pick of #13856 on release/3.9.

#13856: fix: fail to snapshot and clone due to mismatch class metadata