### PR TITLE
fix(cloudmon): fix gcp metric pull

### DIFF
--- a/pkg/cloudmon/collectors/gcpmon/gcpservice.go
+++ b/pkg/cloudmon/collectors/gcpmon/gcpservice.go
@@ -42,7 +42,9 @@ func (self *SGoogleCloudReport) collectRegionMetricOfHost(region cloudprovider.I
 			continue
 		}
 		serverName, _ := server.GetString("name")
-		external_id = strings.Split(external_id, "/")[1]
+		if strings.Contains(external_id, "/") {
+			external_id = strings.Split(external_id, "/")[1]
+		}
 		for metricName, influxDbSpecs := range gcpMetricSpecs {
 			rtn, err := googleReg.GetMonitorData(external_id, serverName, metricName, since, until)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
1. external_id format


**Does this PR need to be backport to the previous release branch?**:
- release/3.8
- release/3.9

/cc @zexi 
/area cloudmon
