### PR TITLE
fix: support qemu backing file with json format

### DIFF
--- a/pkg/util/qemuimg/qemuimg_test.go
+++ b/pkg/util/qemuimg/qemuimg_test.go
@@ -173,3 +173,14 @@ func TestVmdk(t *testing.T) {
 	t.Logf("%s %v", img, img.IsSparse())
 	img.Delete()
 }*/
+
+func TestParseBackingFile(t *testing.T) {
+	in := `json:{"driver":"qcow2","file":{"driver":"file","filename":"/opt/cloud/workspace/disks/snapshots/72a2383d-e980-486f-816c-6c562e1757f3_snap/f39f225a-921f-492e-8fb6-0a4167d6ed91"}}`
+	want := "/opt/cloud/workspace/disks/snapshots/72a2383d-e980-486f-816c-6c562e1757f3_snap/f39f225a-921f-492e-8fb6-0a4167d6ed91"
+	path, err := parseBackingFilepath(in)
+	if err != nil {
+		t.Errorf("parseBackingFilepath: %s", err)
+	} else if path != want {
+		t.Errorf("want: %s got: %s", want, path)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: support qemu backing file info in json format

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 