### PR TITLE
Automated cherry pick of #13867: fix: support qemu backing file with json format

### DIFF
--- a/pkg/util/qemuimg/qemuimg_test.go
+++ b/pkg/util/qemuimg/qemuimg_test.go
@@ -173,3 +173,14 @@ func TestVmdk(t *testing.T) {
 	t.Logf("%s %v", img, img.IsSparse())
 	img.Delete()
 }*/
+
+func TestParseBackingFile(t *testing.T) {
+	in := `json:{"driver":"qcow2","file":{"driver":"file","filename":"/opt/cloud/workspace/disks/snapshots/72a2383d-e980-486f-816c-6c562e1757f3_snap/f39f225a-921f-492e-8fb6-0a4167d6ed91"}}`
+	want := "/opt/cloud/workspace/disks/snapshots/72a2383d-e980-486f-816c-6c562e1757f3_snap/f39f225a-921f-492e-8fb6-0a4167d6ed91"
+	path, err := parseBackingFilepath(in)
+	if err != nil {
+		t.Errorf("parseBackingFilepath: %s", err)
+	} else if path != want {
+		t.Errorf("want: %s got: %s", want, path)
+	}
+}


### PR DESCRIPTION
Cherry pick of #13867 on release/3.9.

#13867: fix: support qemu backing file with json format