### PR TITLE
Automated cherry pick of #13877: fix(notify): enable websocket notifications defaultly for event notify

### DIFF
--- a/pkg/notify/models/notification.go
+++ b/pkg/notify/models/notification.go
@@ -352,7 +352,7 @@ func (nm *SNotificationManager) PerformEventNotify(ctx context.Context, userCred
 
 func (nm *SNotificationManager) needWebconsole(topics []STopic) bool {
 	for i := range topics {
-		if topics[i].WebconsoleDisable.IsFalse() {
+		if topics[i].WebconsoleDisable.IsFalse() || topics[i].WebconsoleDisable.IsNone() {
 			return true
 		}
 	}


### PR DESCRIPTION
Cherry pick of #13877 on release/3.8.

#13877: fix(notify): enable websocket notifications defaultly for event notify