### PR TITLE
fix: make temporary snapshots invisible

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -2502,7 +2502,7 @@ func (self *SDisk) CreateSnapshotAuto(
 	snapshotName string, snapshotPolicy *SSnapshotPolicy,
 ) error {
 	snap, err := SnapshotManager.CreateSnapshot(ctx, self.GetOwnerId(), api.SNAPSHOT_AUTO,
-		self.Id, "", "", snapshotName, snapshotPolicy.RetentionDays)
+		self.Id, "", "", snapshotName, snapshotPolicy.RetentionDays, false)
 	if err != nil {
 		return errors.Wrap(err, "disk create snapshot auto")
 	}

--- a/pkg/compute/models/instance_snapshots.go
+++ b/pkg/compute/models/instance_snapshots.go
@@ -384,6 +384,10 @@ func (manager *SInstanceSnapshotManager) CreateInstanceSnapshot(ctx context.Cont
 	instanceSnapshot.SetModelManager(manager, instanceSnapshot)
 	instanceSnapshot.Name = name
 	instanceSnapshot.AutoDelete = autoDelete
+	if autoDelete {
+		// hide auto-delete instance snapshots
+		instanceSnapshot.IsSystem = true
+	}
 	manager.fillInstanceSnapshot(ctx, userCred, guest, instanceSnapshot)
 	// compute size of instanceSnapshot
 	instanceSnapshot.SizeMb = guest.getDiskSize()

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -540,7 +540,7 @@ func (self *SSnapshotManager) GetDiskSnapshotCount(diskId string) (int, error) {
 }
 
 func (self *SSnapshotManager) CreateSnapshot(ctx context.Context, owner mcclient.IIdentityProvider,
-	createdBy, diskId, guestId, location, name string, retentionDay int) (*SSnapshot, error) {
+	createdBy, diskId, guestId, location, name string, retentionDay int, isSystem bool) (*SSnapshot, error) {
 	iDisk, err := DiskManager.FetchById(diskId)
 	if err != nil {
 		return nil, err
@@ -573,6 +573,7 @@ func (self *SSnapshotManager) CreateSnapshot(ctx context.Context, owner mcclient
 	if retentionDay > 0 {
 		snapshot.ExpiredAt = time.Now().AddDate(0, 0, retentionDay)
 	}
+	snapshot.IsSystem = isSystem
 	err = SnapshotManager.TableSpec().Insert(ctx, snapshot)
 	if err != nil {
 		return nil, err

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -1172,7 +1172,7 @@ func (self *SKVMRegionDriver) RequestCreateInstanceSnapshot(ctx context.Context,
 
 		return models.SnapshotManager.CreateSnapshot(
 			ctx, task.GetUserCred(), api.SNAPSHOT_MANUAL, disks[diskIndex].DiskId,
-			guest.Id, "", snapshotName, -1)
+			guest.Id, "", snapshotName, -1, false)
 	}()
 	if err != nil {
 		return err

--- a/pkg/compute/tasks/disk_backup_create_task.go
+++ b/pkg/compute/tasks/disk_backup_create_task.go
@@ -193,7 +193,7 @@ func (self *DiskBackupCreateTask) CreateSnapshot(ctx context.Context, diskBackup
 
 		return models.SnapshotManager.CreateSnapshot(
 			ctx, self.GetUserCred(), api.SNAPSHOT_MANUAL, disk.GetId(),
-			guest.Id, "", snapshotName, -1)
+			guest.Id, "", snapshotName, -1, true)
 	}()
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to create snapshot of disk %s", disk.GetId())


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: make tempory instance-snapshot for snapshot and clone or snapshot for backup invisible by setting is_system=true

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8


<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 