### PR TITLE
Automated cherry pick of #13881: fix: make temporary snapshots invisible

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -2504,7 +2504,7 @@ func (self *SDisk) CreateSnapshotAuto(
 	snapshotName string, snapshotPolicy *SSnapshotPolicy,
 ) error {
 	snap, err := SnapshotManager.CreateSnapshot(ctx, self.GetOwnerId(), api.SNAPSHOT_AUTO,
-		self.Id, "", "", snapshotName, snapshotPolicy.RetentionDays)
+		self.Id, "", "", snapshotName, snapshotPolicy.RetentionDays, false)
 	if err != nil {
 		return errors.Wrap(err, "disk create snapshot auto")
 	}

--- a/pkg/compute/models/instance_snapshots.go
+++ b/pkg/compute/models/instance_snapshots.go
@@ -376,6 +376,10 @@ func (manager *SInstanceSnapshotManager) CreateInstanceSnapshot(ctx context.Cont
 	instanceSnapshot.SetModelManager(manager, instanceSnapshot)
 	instanceSnapshot.Name = name
 	instanceSnapshot.AutoDelete = autoDelete
+	if autoDelete {
+		// hide auto-delete instance snapshots
+		instanceSnapshot.IsSystem = true
+	}
 	manager.fillInstanceSnapshot(userCred, guest, instanceSnapshot)
 	// compute size of instanceSnapshot
 	instanceSnapshot.SizeMb = guest.getDiskSize()

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -544,7 +544,7 @@ func (self *SSnapshotManager) GetDiskSnapshotCount(diskId string) (int, error) {
 }
 
 func (self *SSnapshotManager) CreateSnapshot(ctx context.Context, owner mcclient.IIdentityProvider,
-	createdBy, diskId, guestId, location, name string, retentionDay int) (*SSnapshot, error) {
+	createdBy, diskId, guestId, location, name string, retentionDay int, isSystem bool) (*SSnapshot, error) {
 	iDisk, err := DiskManager.FetchById(diskId)
 	if err != nil {
 		return nil, err
@@ -577,6 +577,7 @@ func (self *SSnapshotManager) CreateSnapshot(ctx context.Context, owner mcclient
 	if retentionDay > 0 {
 		snapshot.ExpiredAt = time.Now().AddDate(0, 0, retentionDay)
 	}
+	snapshot.IsSystem = isSystem
 	err = SnapshotManager.TableSpec().Insert(ctx, snapshot)
 	if err != nil {
 		return nil, err

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -1121,7 +1121,7 @@ func (self *SKVMRegionDriver) RequestCreateInstanceSnapshot(ctx context.Context,
 
 		return models.SnapshotManager.CreateSnapshot(
 			ctx, task.GetUserCred(), api.SNAPSHOT_MANUAL, disks[diskIndex].DiskId,
-			guest.Id, "", snapshotName, -1)
+			guest.Id, "", snapshotName, -1, false)
 	}()
 	if err != nil {
 		return err

--- a/pkg/compute/tasks/disk_backup_create_task.go
+++ b/pkg/compute/tasks/disk_backup_create_task.go
@@ -193,7 +193,7 @@ func (self *DiskBackupCreateTask) CreateSnapshot(ctx context.Context, diskBackup
 
 		return models.SnapshotManager.CreateSnapshot(
 			ctx, self.GetUserCred(), api.SNAPSHOT_MANUAL, disk.GetId(),
-			guest.Id, "", snapshotName, -1)
+			guest.Id, "", snapshotName, -1, true)
 	}()
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to create snapshot of disk %s", disk.GetId())


### PR DESCRIPTION
Cherry pick of #13881 on release/3.8.

#13881: fix: make temporary snapshots invisible