### PR TITLE
fix: opsadmin should have project list and get permission

### DIFF
--- a/pkg/keystone/locale/predefined_yaml.go
+++ b/pkg/keystone/locale/predefined_yaml.go
@@ -46,9 +46,15 @@ policy:
   image:
     '*':
       '*': allow
+  identity:
+    '*':
+	  '*': deny
+	  list: allow
+	  get: allow
   log:
     actions:
       list: deny
+	  get: deny
 `
 
 var secAdminPolicy = `
@@ -104,6 +110,7 @@ policy:
   log:
     actions:
       list: deny
+	  get: deny
   yunionconf:
     '*':
       '*': allow
@@ -119,6 +126,11 @@ policy:
       '*': deny
       get: allow
       list: allow
+  identity:
+	'*':
+	  '*': deny
+	  list: allow
+	  get: allow
 `
 
 var normalUserPolicy = `


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: opsadmin should have read permission on identity resources

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 