### PR TITLE
Automated cherry pick of #13894: fix: opsadmin should have project list and get permission

### DIFF
--- a/pkg/keystone/locale/predefined_yaml.go
+++ b/pkg/keystone/locale/predefined_yaml.go
@@ -46,9 +46,15 @@ policy:
   image:
     '*':
       '*': allow
+  identity:
+    '*':
+	  '*': deny
+	  list: allow
+	  get: allow
   log:
     actions:
       list: deny
+	  get: deny
 `
 
 var secAdminPolicy = `
@@ -104,6 +110,7 @@ policy:
   log:
     actions:
       list: deny
+	  get: deny
   yunionconf:
     '*':
       '*': allow
@@ -119,6 +126,11 @@ policy:
       '*': deny
       get: allow
       list: allow
+  identity:
+	'*':
+	  '*': deny
+	  list: allow
+	  get: allow
 `
 
 var normalUserPolicy = `


### PR DESCRIPTION
Cherry pick of #13894 on release/3.9.

#13894: fix: opsadmin should have project list and get permission