### PR TITLE
Automated cherry pick of #13896: fix: host inherit class metadata from wire

### DIFF
--- a/cmd/climc/shell/compute/wires.go
+++ b/cmd/climc/shell/compute/wires.go
@@ -33,4 +33,5 @@ func init() {
 	cmd.PerformWithKeyword("merge", "merge-from", new(options.WireMergeOptions))
 	cmd.Perform("merge-network", new(options.WireOptions))
 	cmd.Get("topology", &options.WireOptions{})
+	cmd.Perform("set-class-metadata", &options.ResourceMetadataOptions{})
 }

--- a/pkg/cloudcommon/db/virtualresource.go
+++ b/pkg/cloudcommon/db/virtualresource.go
@@ -288,7 +288,7 @@ func (model *SVirtualResourceBase) PostCreate(ctx context.Context, userCred mccl
 		log.Errorf("unable to GetTenantCache: %s", err.Error())
 		return
 	}
-	err = Inherit(ctx, project, model)
+	err = InheritFromTo(ctx, project, model)
 	if err != nil {
 		log.Errorf("unable to inherit class metadata from poject %s: %s", project.GetId(), err.Error())
 	}

--- a/pkg/compute/models/backup.go
+++ b/pkg/compute/models/backup.go
@@ -280,7 +280,7 @@ func (db *SDiskBackup) PostCreate(ctx context.Context, userCred mcclient.TokenCr
 	if err != nil {
 		log.Errorf("unable to GetDisk: %s", err.Error())
 	}
-	err = disk.Inherit(ctx, &db.SStandaloneAnonResourceBase)
+	err = disk.InheritTo(ctx, db)
 	if err != nil {
 		log.Errorf("unable to inherit from disk %s to backup %s: %s", disk.GetId(), db.GetId(), err.Error())
 	}

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -4733,7 +4733,7 @@ func (self *SGuest) PerformInstanceSnapshot(
 			ctx, userCred, pendingUsage, pendingUsage, false)
 		return nil, httperrors.NewInternalServerError("create instance snapshot failed: %s", err)
 	}
-	err = self.Inherit(ctx, &instanceSnapshot.SStandaloneAnonResourceBase)
+	err = self.InheritTo(ctx, instanceSnapshot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to inherit from guest %s to instance snapshot %s", self.GetId(), instanceSnapshot.GetId())
 	}
@@ -4776,7 +4776,7 @@ func (self *SGuest) PerformInstanceBackup(ctx context.Context, userCred mcclient
 	if err != nil {
 		return nil, httperrors.NewInternalServerError("create instance backup failed: %s", err)
 	}
-	err = self.Inherit(ctx, &instanceBackup.SStandaloneAnonResourceBase)
+	err = self.InheritTo(ctx, instanceBackup)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to inherit from guest %s to instance backup %s", self.GetId(), instanceBackup.GetId())
 	}

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -3856,7 +3856,7 @@ func (self *SGuest) createDiskOnHost(
 	if autoAttach {
 		err = self.attach2Disk(ctx, disk, userCred, diskConfig.Driver, diskConfig.Cache, diskConfig.Mountpoint)
 	}
-	err = self.Inherit(ctx, &disk.SStandaloneAnonResourceBase)
+	err = self.InheritTo(ctx, disk)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to inherit from guest %s to disk %s", self.GetId(), disk.GetId())
 	}

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -4276,7 +4276,7 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 		}
 		// inherit wire's class metadata
 		if sw != nil {
-			err := db.Inherit(ctx, sw, self)
+			err := db.InheritFromTo(ctx, sw, self)
 			if err != nil {
 				return errors.Wrapf(err, "unable to inherit class metadata from sw %s", sw.GetName())
 			}

--- a/pkg/compute/models/hostwires.go
+++ b/pkg/compute/models/hostwires.go
@@ -290,3 +290,19 @@ func (manager *SHostwireManager) ListItemExportKeys(ctx context.Context,
 
 	return q, nil
 }
+
+func (hw *SHostwire) PostCreate(
+	ctx context.Context,
+	userCred mcclient.TokenCredential,
+	ownerId mcclient.IIdentityProvider,
+	query jsonutils.JSONObject,
+	data jsonutils.JSONObject,
+) {
+	hw.SHostJointsBase.PostCreate(ctx, userCred, ownerId, query, data)
+	host := hw.GetHost()
+	wire := hw.GetWire()
+	err := db.InheritFromTo(ctx, wire, host)
+	if err != nil {
+		log.Errorf("Inherit class metadata from host to wire fail: %s", err)
+	}
+}

--- a/pkg/compute/models/instance_snapshots.go
+++ b/pkg/compute/models/instance_snapshots.go
@@ -393,7 +393,7 @@ func (manager *SInstanceSnapshotManager) CreateInstanceSnapshot(ctx context.Cont
 	if err != nil {
 		return nil, errors.Wrap(err, "Insert")
 	}
-	err = db.Inherit(ctx, guest, instanceSnapshot)
+	err = db.InheritFromTo(ctx, guest, instanceSnapshot)
 	if err != nil {
 		return nil, errors.Wrap(err, "Inherit ClassMetadata")
 	}

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -2792,7 +2792,7 @@ func (manager *SNetworkManager) PerformTryCreateNetwork(ctx context.Context, use
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to get wire")
 		}
-		err = db.Inherit(ctx, wire, newNetwork)
+		err = db.InheritFromTo(ctx, wire, newNetwork)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to inherit wire")
 		}

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -411,7 +411,7 @@ func (snapshot *SSnapshot) PostCreate(ctx context.Context, userCred mcclient.Tok
 	if err != nil {
 		log.Errorf("unable to GetDisk: %s", err.Error())
 	}
-	err = disk.Inherit(ctx, &snapshot.SStandaloneAnonResourceBase)
+	err = disk.InheritTo(ctx, snapshot)
 	if err != nil {
 		log.Errorf("unable to inherit from disk %s to snapshot %s: %s", disk.GetId(), snapshot.GetId(), err.Error())
 	}

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -1471,7 +1471,7 @@ func (model *SWire) PostCreate(ctx context.Context, userCred mcclient.TokenCrede
 	if err != nil {
 		log.Errorf("unable to getvpc of wire %s: %s", model.GetId(), vpc.GetId())
 	}
-	err = db.Inherit(ctx, vpc, model)
+	err = db.InheritFromTo(ctx, vpc, model)
 	if err != nil {
 		log.Errorf("unable to inhert vpc to model %s: %s", model.GetId(), err.Error())
 	}

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -1178,7 +1178,7 @@ func (self *SKVMRegionDriver) RequestCreateInstanceSnapshot(ctx context.Context,
 		return err
 	}
 
-	err = isp.Inherit(ctx, &snapshot.SStandaloneAnonResourceBase)
+	err = isp.InheritTo(ctx, snapshot)
 	if err != nil {
 		return errors.Wrapf(err, "unable to inherit from instance snapshot %s to snapshot %s", isp.GetId(), snapshot.GetId())
 	}
@@ -1333,7 +1333,7 @@ func (self *SKVMRegionDriver) RequestCreateInstanceBackup(ctx context.Context, g
 		if err != nil {
 			return err
 		}
-		err = ib.Inherit(ctx, &backup.SStandaloneAnonResourceBase)
+		err = ib.InheritTo(ctx, backup)
 		if err != nil {
 			return errors.Wrapf(err, "unable to inherit from instance backup %s to backup %s", ib.GetId(), backup.GetId())
 		}

--- a/pkg/mcclient/options/metadata.go
+++ b/pkg/mcclient/options/metadata.go
@@ -141,7 +141,11 @@ func (opts *ResourceMetadataOptions) GetId() string {
 func (opts *ResourceMetadataOptions) Params() (jsonutils.JSONObject, error) {
 	params := jsonutils.NewDict()
 	for _, tag := range opts.TAGS {
-		info := strings.Split(tag, "=")
+		sep := "="
+		if strings.Index(tag, sep) < 0 {
+			sep = ":"
+		}
+		info := strings.Split(tag, sep)
 		if len(info) == 2 {
 			if len(info[0]) == 0 {
 				return nil, fmt.Errorf("invalidate tag info %s", tag)


### PR DESCRIPTION
Cherry pick of #13896 on release/3.9.

#13896: fix: host inherit class metadata from wire