### PR TITLE
fix: save image for aarch64 os show os_arch of x86_64

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1017,6 +1017,7 @@ func (self *SDisk) PrepareSaveImage(ctx context.Context, userCred mcclient.Token
 		GenerateName string
 		VirtualSize  int
 		DiskFormat   string
+		OsArch       string
 		Properties   map[string]string
 
 		EncryptKeyId string
@@ -1025,6 +1026,7 @@ func (self *SDisk) PrepareSaveImage(ctx context.Context, userCred mcclient.Token
 		GenerateName: input.GenerateName,
 		VirtualSize:  self.DiskSize,
 		DiskFormat:   self.DiskFormat,
+		OsArch:       input.OsArch,
 		Properties: map[string]string{
 			"notes":   input.Notes,
 			"os_type": input.OsType,


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: save image for aarch64 server shows wrong os_arch of x86_64

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8
- release/3.7

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 