### PR TITLE
Automated cherry pick of #13903: fix: save image for aarch64 os show os_arch of x86_64

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1017,6 +1017,7 @@ func (self *SDisk) PrepareSaveImage(ctx context.Context, userCred mcclient.Token
 		GenerateName string
 		VirtualSize  int
 		DiskFormat   string
+		OsArch       string
 		Properties   map[string]string
 
 		EncryptKeyId string
@@ -1025,6 +1026,7 @@ func (self *SDisk) PrepareSaveImage(ctx context.Context, userCred mcclient.Token
 		GenerateName: input.GenerateName,
 		VirtualSize:  self.DiskSize,
 		DiskFormat:   self.DiskFormat,
+		OsArch:       input.OsArch,
 		Properties: map[string]string{
 			"notes":   input.Notes,
 			"os_type": input.OsType,


### PR DESCRIPTION
Cherry pick of #13903 on release/3.9.

#13903: fix: save image for aarch64 os show os_arch of x86_64