### PR TITLE
Automated cherry pick of #13903: fix: save image for aarch64 os show os_arch of x86_64

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1027,12 +1027,14 @@ func (self *SDisk) PrepareSaveImage(ctx context.Context, userCred mcclient.Token
 		GenerateName string
 		VirtualSize  int
 		DiskFormat   string
+		OsArch       string
 		Properties   map[string]string
 	}{
 		Name:         input.Name,
 		GenerateName: input.GenerateName,
 		VirtualSize:  self.DiskSize,
 		DiskFormat:   self.DiskFormat,
+		OsArch:       input.OsArch,
 		Properties: map[string]string{
 			"notes":   input.Notes,
 			"os_type": input.OsType,


### PR DESCRIPTION
Cherry pick of #13903 on release/3.8.

#13903: fix: save image for aarch64 os show os_arch of x86_64