### PR TITLE
Automated cherry pick of #13914: fix: typos in predefined policy yaml

### DIFF
--- a/pkg/keystone/locale/predefined_yaml.go
+++ b/pkg/keystone/locale/predefined_yaml.go
@@ -48,13 +48,13 @@ policy:
       '*': allow
   identity:
     '*':
-	  '*': deny
-	  list: allow
-	  get: allow
+      '*': deny
+      list: allow
+      get: allow
   log:
     actions:
       list: deny
-	  get: deny
+      get: deny
 `
 
 var secAdminPolicy = `
@@ -110,7 +110,7 @@ policy:
   log:
     actions:
       list: deny
-	  get: deny
+      get: deny
   yunionconf:
     '*':
       '*': allow
@@ -127,10 +127,10 @@ policy:
       get: allow
       list: allow
   identity:
-	'*':
-	  '*': deny
-	  list: allow
-	  get: allow
+    '*':
+    '*': deny
+    list: allow
+    get: allow
 `
 
 var normalUserPolicy = `


### PR DESCRIPTION
Cherry pick of #13914 on release/3.9.

#13914: fix: typos in predefined policy yaml