### PR TITLE
fix(region): exclude the host whose config or config.network is nil

### DIFF
--- a/pkg/multicloud/esxi/net_topology_pro.go
+++ b/pkg/multicloud/esxi/net_topology_pro.go
@@ -173,7 +173,14 @@ func (cli *SESXiClient) HostVmIPsPro(ctx context.Context) (SNetworkInfoPro, erro
 	if err != nil {
 		return SNetworkInfoPro{}, errors.Wrap(err, "scanAllMObjects")
 	}
-	return cli.hostVMIPsPro(ctx, hosts)
+	filtedHosts := make([]mo.HostSystem, 0, len(hosts))
+	for i := range hosts {
+		if hosts[i].Config == nil || hosts[i].Config.Network == nil {
+			continue
+		}
+		filtedHosts = append(filtedHosts, hosts[i])
+	}
+	return cli.hostVMIPsPro(ctx, filtedHosts)
 }
 
 func vpgMapKey(prefix, key string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
现在的vmware纳管中，会有一些宿主机的config拿不到，这种宿主机我们不会纳管，在准备网络时也应该排除这类宿主机。
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region
/cc @zexi 