### PR TITLE
Automated cherry pick of #13941: fix(region): exclude the host whose config or config.network is nil

### DIFF
--- a/pkg/multicloud/esxi/net_topology_pro.go
+++ b/pkg/multicloud/esxi/net_topology_pro.go
@@ -173,7 +173,14 @@ func (cli *SESXiClient) HostVmIPsPro(ctx context.Context) (SNetworkInfoPro, erro
 	if err != nil {
 		return SNetworkInfoPro{}, errors.Wrap(err, "scanAllMObjects")
 	}
-	return cli.hostVMIPsPro(ctx, hosts)
+	filtedHosts := make([]mo.HostSystem, 0, len(hosts))
+	for i := range hosts {
+		if hosts[i].Config == nil || hosts[i].Config.Network == nil {
+			continue
+		}
+		filtedHosts = append(filtedHosts, hosts[i])
+	}
+	return cli.hostVMIPsPro(ctx, filtedHosts)
 }
 
 func vpgMapKey(prefix, key string) string {


### PR DESCRIPTION
Cherry pick of #13941 on release/3.8.

#13941: fix(region): exclude the host whose config or config.network is nil