### PR TITLE
Automated cherry pick of #13971: fix: disk create input preserve encrypt info

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -521,7 +521,10 @@ func (manager *SDiskManager) ValidateCreateData(ctx context.Context, userCred mc
 		if err != nil {
 			return input, err
 		}
+		// preserve encrypt info
+		encInput := input.EncryptedResourceCreateInput
 		input = *serverInput.ToDiskCreateInput()
+		input.EncryptedResourceCreateInput = encInput
 		quotaKey = diskCreateInput2ComputeQuotaKeys(input, ownerId)
 	}
 


### PR DESCRIPTION
Cherry pick of #13971 on release/3.9.

#13971: fix: disk create input preserve encrypt info