### PR TITLE
fix: encrypt server cannot attach disk with conflict encrypt key

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -758,6 +758,9 @@ func (self *SGuest) ValidateAttachDisk(ctx context.Context, disk *SDisk) error {
 	if err != nil {
 		return err
 	}
+	if self.EncryptKeyId != disk.EncryptKeyId {
+		return errors.Wrapf(httperrors.ErrConflict, "conflict encryption key between server and disk")
+	}
 	if !ok {
 		return httperrors.NewForbiddenError("the class metadata of guest and disk is different")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: encrypted server cannot attach encrypt disk

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 