### PR TITLE
Automated cherry pick of #13973: fix: encrypt server cannot attach disk with conflict encrypt key

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -758,6 +758,9 @@ func (self *SGuest) ValidateAttachDisk(ctx context.Context, disk *SDisk) error {
 	if err != nil {
 		return err
 	}
+	if self.EncryptKeyId != disk.EncryptKeyId {
+		return errors.Wrapf(httperrors.ErrConflict, "conflict encryption key between server and disk")
+	}
 	if !ok {
 		return httperrors.NewForbiddenError("the class metadata of guest and disk is different")
 	}


### PR DESCRIPTION
Cherry pick of #13973 on release/3.9.

#13973: fix: encrypt server cannot attach disk with conflict encrypt key