### PR TITLE
Automated cherry pick of #13979: fix: change qemu default version to 4.2.0

### DIFF
--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -71,7 +71,7 @@ type SHostOptions struct {
 	LocalImagePath  []string `help:"Local image storage paths"`
 	SharedStorages  []string `help:"Path of shared storages"`
 
-	DefaultQemuVersion string `help:"Default qemu version" default:"2.12.1"`
+	DefaultQemuVersion string `help:"Default qemu version" default:"4.2.0"`
 
 	DhcpRelay       []string `help:"DHCP relay upstream"`
 	DhcpLeaseTime   int      `default:"100663296" help:"DHCP lease time in seconds"`


### PR DESCRIPTION
Cherry pick of #13979 on release/3.9.

#13979: fix: change qemu default version to 4.2.0