### PR TITLE
feat(notify): filter notification by topic_type

### DIFF
--- a/cmd/climc/shell/notifyv2/notification.go
+++ b/cmd/climc/shell/notifyv2/notification.go
@@ -89,6 +89,7 @@ func init() {
 
 		ContactType string `help:"contact_type"`
 		ReceiverId  string `help:"receiver_id"`
+		TopicType   string `help:"topic type"`
 	}
 	R(&NotificationListInput{}, "notify-list", "List notify message", func(s *mcclient.ClientSession, args *NotificationListInput) error {
 		params, err := options.ListStructToParams(args)

--- a/pkg/apis/notify/notification.go
+++ b/pkg/apis/notify/notification.go
@@ -85,6 +85,7 @@ type NotificationListInput struct {
 	ContactType string
 	ReceiverId  string
 	Tag         string
+	TopicType   string
 }
 
 type SContact struct {

--- a/pkg/notify/models/event.go
+++ b/pkg/notify/models/event.go
@@ -44,13 +44,15 @@ type SEvent struct {
 	Message     string
 	Event       string `width:"64" nullable:"true"`
 	AdvanceDays int
+	TopicId     string `width:"128" nullable:"true" index:"true"`
 }
 
-func (e *SEventManager) CreateEvent(ctx context.Context, event, message string, advanceDays int) (*SEvent, error) {
+func (e *SEventManager) CreateEvent(ctx context.Context, event, topicId, message string, advanceDays int) (*SEvent, error) {
 	eve := &SEvent{
 		Message:     message,
 		Event:       event,
 		AdvanceDays: advanceDays,
+		TopicId:     topicId,
 	}
 	err := e.TableSpec().Insert(ctx, eve)
 	if err != nil {

--- a/pkg/notify/models/topic.go
+++ b/pkg/notify/models/topic.go
@@ -436,6 +436,19 @@ func (s *STopic) getActions() []notify.SAction {
 	return actions
 }
 
+func (sm *STopicManager) TopicByEvent(eventStr string, advanceDays int) (*STopic, error) {
+	topics, err := sm.TopicsByEvent(eventStr, advanceDays)
+	if err != nil {
+		return nil, err
+	}
+	if len(topics) == 0 {
+		return nil, nil
+	}
+	// free memory in time
+	topic := topics[0]
+	return &topic, nil
+}
+
 func (sm *STopicManager) TopicsByEvent(eventStr string, advanceDays int) ([]STopic, error) {
 	event, err := parseEvent(eventStr)
 	if err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:
之前的模型，消息和Event是一一对应的，一个Event可以和多个Topic对应，
为了支持通过Topic Type过滤消息，现在Event和Topic是一一对应的。

消息列表可以通过topic_type过滤
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area notify
/cc @zexi 