### PR TITLE
fix: allow opsadmin view logs

### DIFF
--- a/pkg/keystone/locale/predefined_yaml.go
+++ b/pkg/keystone/locale/predefined_yaml.go
@@ -62,8 +62,9 @@ policy:
       '*': deny
   log:
     actions:
-      list: deny
-      get: deny
+      list:
+        '*': allow
+        splitable: deny
 `
 
 var secAdminPolicy = `


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allow opsadmin view logs

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 