### PR TITLE
Automated cherry pick of #14048: fix: allow opsadmin view logs

### DIFF
--- a/pkg/keystone/locale/predefined_yaml.go
+++ b/pkg/keystone/locale/predefined_yaml.go
@@ -62,8 +62,9 @@ policy:
       '*': deny
   log:
     actions:
-      list: deny
-      get: deny
+      list:
+        '*': allow
+        splitable: deny
 `
 
 var secAdminPolicy = `


### PR DESCRIPTION
Cherry pick of #14048 on release/3.9.

#14048: fix: allow opsadmin view logs