### PR TITLE
Windows monitor agent

### DIFF
--- a/build/docker/Dockerfile.ansibleserver
+++ b/build/docker/Dockerfile.ansibleserver
@@ -1,7 +1,7 @@
-FROM registry.cn-beijing.aliyuncs.com/yunionio/ansibleserver-base:v1.0.5-2
+FROM registry.cn-beijing.aliyuncs.com/yunionio/ansibleserver-base:v1.1.0
 
 # install playbook and telegraf install pkg
-COPY --from=registry.cn-beijing.aliyuncs.com/yunionio/file-repo:v0.3.4 /opt/yunion/playbook /opt/yunion/playbook
-COPY --from=registry.cn-beijing.aliyuncs.com/yunionio/file-repo:v0.3.4 /opt/yunion/ansible-install-pkg /opt/yunion/ansible-install-pkg
+COPY --from=registry.cn-beijing.aliyuncs.com/yunionio/file-repo:v0.4.0 /opt/yunion/playbook /opt/yunion/playbook
+COPY --from=registry.cn-beijing.aliyuncs.com/yunionio/file-repo:v0.4.0 /opt/yunion/ansible-install-pkg /opt/yunion/ansible-install-pkg
 
 ADD ./_output/alpine-build/bin/ansibleserver /opt/yunion/bin/ansibleserver

--- a/build/docker/Dockerfile.ansibleserver-base
+++ b/build/docker/Dockerfile.ansibleserver-base
@@ -11,5 +11,8 @@ RUN set -x \
 	&& apk add openssh-client \
 	&& apk add sshpass \
 	&& apk add ansible \
+    && apk add py3-pip \
 	&& apk add tzdata git ca-certificates \
 	&& rm -rf /var/cache/apk/*
+
+RUN pip3 install pywinrm

--- a/build/docker/Dockerfile.file-repo
+++ b/build/docker/Dockerfile.file-repo
@@ -11,10 +11,12 @@ RUN set -x \
 
 # install default playbook and install pkg
 Run mkdir -p /opt/yunion/ansible-install-pkg
-Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf-1.19.2-yn~fe11a96b-0.aarch64.rpm -P /opt/yunion/ansible-install-pkg
-Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf-1.19.2-yn~fe11a96b-0.x86_64.rpm -P /opt/yunion/ansible-install-pkg
-Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf_1.19.2-yn~fe11a96b-0_amd64.deb -P /opt/yunion/ansible-install-pkg
-Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf_1.19.2-yn~fe11a96b-0_arm64.deb -P /opt/yunion/ansible-install-pkg
+Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf-1.19.2-yn~be742cbf-0.x86_64.rpm -P /opt/yunion/ansible-install-pkg
+Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf-1.19.2-yn~be742cbf-0.aarch64.rpm -P /opt/yunion/ansible-install-pkg
+Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf_1.19.2-yn~be742cbf-0_arm64.deb -P /opt/yunion/ansible-install-pkg
+Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf_1.19.2-yn~be742cbf-0_amd64.deb -P /opt/yunion/ansible-install-pkg
+Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf-1.19.2-yn~be742cbf_windows_amd64.zip -P /opt/yunion/ansible-install-pkg
+Run wget https://yunioniso.oss-cn-beijing.aliyuncs.com/rpms/telegraf/telegraf-1.19.2-yn~be742cbf_windows_i386.zip -P /opt/yunion/ansible-install-pkg
 
 Run mkdir -p /opt/yunion/playbook
 Run mkdir /opt/yunion/playbook/monitor-agent

--- a/pkg/ansibleserver/models/ansibleplaybook_instance.go
+++ b/pkg/ansibleserver/models/ansibleplaybook_instance.go
@@ -84,6 +84,13 @@ func (aim *SAnsiblePlaybookInstanceManager) createInstance(ctx context.Context, 
 		"ansible_host": host.IP,
 		"ansible_port": host.Port,
 	}
+	if host.OsType == "Windows" {
+		vars["ansible_password"] = host.Password
+		vars["ansible_connection"] = "winrm"
+		vars["ansible_winrm_server_cert_validation"] = "ignore"
+		vars["ansible_winrm_transport"] = "ntlm"
+		vars["ansible_become"] = false
+	}
 	h := ansiblev2.NewHost()
 	h.Vars = vars
 	inv.SetHost(host.Name, h)

--- a/pkg/apis/ansible/ansible.go
+++ b/pkg/apis/ansible/ansible.go
@@ -31,10 +31,12 @@ type AnsiblePlaybookCreateInput struct {
 type AnsiblePlaybookUpdateInput AnsiblePlaybookCreateInput
 
 type AnsibleHost struct {
-	User string `json:"user"`
-	IP   string `json:"ip"`
-	Port int    `json:"port"`
-	Name string `json:"name"`
+	User     string `json:"user"`
+	IP       string `json:"ip"`
+	Port     int    `json:"port"`
+	Name     string `json:"name"`
+	Password string `json:"password"`
+	OsType   string `json:"os_type"`
 }
 
 type AnsiblePlaybookReferenceCreateInput struct {

--- a/pkg/devtool/tasks/apply_script_task.go
+++ b/pkg/devtool/tasks/apply_script_task.go
@@ -123,10 +123,12 @@ func (self *ApplyScriptTask) OnInit(ctx context.Context, obj db.IStandaloneModel
 	}
 
 	host := ansible_api.AnsibleHost{
-		User: sshable.User,
-		IP:   sshable.Host,
-		Port: sshable.Port,
-		Name: sshable.ServerName,
+		User:     sshable.User,
+		IP:       sshable.Host,
+		Port:     sshable.Port,
+		Name:     sshable.ServerName,
+		Password: sshable.Password,
+		OsType:   sshable.OsType,
 	}
 
 	// genrate args

--- a/pkg/devtool/utils/service_url.go
+++ b/pkg/devtool/utils/service_url.go
@@ -335,8 +335,18 @@ func checkUrl(ctx context.Context, completeUrl string, expectedCode int, host *a
 		"ansible_port": fmt.Sprintf("%d", host.Port),
 		"ansible_user": host.User,
 	}
+	if host.OsType == "Windows" {
+		ahost.Vars["ansible_password"] = host.Password
+		ahost.Vars["ansible_connection"] = "winrm"
+		ahost.Vars["ansible_winrm_server_cert_validation"] = "ignore"
+		ahost.Vars["ansible_winrm_transport"] = "ntlm"
+	}
+	modulename := "uri"
+	if host.OsType == "Windows" {
+		modulename = "ansible.windows.win_uri"
+	}
 	mod := ansible.Module{
-		Name: "uri",
+		Name: modulename,
 		Args: []string{
 			fmt.Sprintf("url=%s", completeUrl),
 			"method=GET",

--- a/pkg/devtool/utils/ssh.go
+++ b/pkg/devtool/utils/ssh.go
@@ -37,12 +37,14 @@ type SSHable struct {
 	Ok     bool
 	Reason string
 
-	User string
-	Host string
-	Port int
+	User     string
+	Host     string
+	Port     int
+	Password string
 
 	ServerName       string
 	ServerHypervisor string
+	OsType           string
 
 	ProxyEndpointId string
 	ProxyAgentId    string
@@ -93,7 +95,7 @@ type SServerInfo struct {
 }
 
 func CheckSshableForYunionCloud(session *mcclient.ClientSession, serverInfo SServerInfo) (sshable SSHable, cleanFunc func() error, err error) {
-	sshable, clean, err := checkSshableForYunionCloud(session, serverInfo)
+	sshable, clean, err := checkSshableForYunionCloud(session, serverInfo, false)
 	if err != nil {
 		return
 	}
@@ -115,20 +117,37 @@ func CheckSshableForYunionCloud(session *mcclient.ClientSession, serverInfo SSer
 	return
 }
 
-func checkSshableForYunionCloud(session *mcclient.ClientSession, serverInfo SServerInfo) (sshable SSHable, clean bool, err error) {
-	port, err := getServerSshport(session, serverInfo.Id)
+func getLoginInfo(session *mcclient.ClientSession, serverId string) (username string, password string, err error) {
+	ret, err := modules.Servers.GetLoginInfo(session, serverId, jsonutils.NewDict())
+	if err != nil {
+		return
+	}
+	username, _ = ret.GetString("username")
+	password, _ = ret.GetString("password")
+	return
+}
+
+func checkSshableForYunionCloud(session *mcclient.ClientSession, serverInfo SServerInfo, isWindows bool) (sshable SSHable, clean bool, err error) {
+	port, err := getServerSshport(session, serverInfo.Id, isWindows)
 	if err != nil {
 		err = errors.Wrapf(err, "unable to get ssh port of server %s", serverInfo.Id)
 		return
 	}
 	ip := serverInfo.Ip
-	if serverInfo.Hypervisor == comapi.HYPERVISOR_BAREMETAL || serverInfo.VpcId == "" || serverInfo.VpcId == comapi.DEFAULT_VPC_ID {
-		sshable = SSHable{
-			Ok:   true,
-			User: "cloudroot",
-			Host: ip,
-			Port: port,
+	username, password := "cloudroot", ""
+	if isWindows {
+		username, password, err = getLoginInfo(session, serverInfo.Id)
+		if err != nil {
+			return
 		}
+		sshable.OsType = "Windows"
+	}
+	sshable.User = username
+	sshable.Password = password
+	sshable.Port = port
+	sshable.Host = ip
+	if serverInfo.Hypervisor == comapi.HYPERVISOR_BAREMETAL || serverInfo.VpcId == "" || serverInfo.VpcId == comapi.DEFAULT_VPC_ID {
+		sshable.Ok = true
 		return
 	}
 	lfParams := jsonutils.NewDict()
@@ -167,12 +186,9 @@ func checkSshableForYunionCloud(session *mcclient.ClientSession, serverInfo SSer
 	proxyAddr, _ := forward.GetString("proxy_addr")
 	proxyPort, _ := forward.Int("proxy_port")
 	// register
-	sshable = SSHable{
-		Ok:   true,
-		User: "cloudroot",
-		Host: proxyAddr,
-		Port: int(proxyPort),
-	}
+	sshable.Port = int(proxyPort)
+	sshable.Host = proxyAddr
+	sshable.Ok = true
 	return
 }
 
@@ -181,6 +197,10 @@ func checkSshableForYunionCloudWithDetail(session *mcclient.ClientSession, serve
 		err = fmt.Errorf("empty ips for server %s", serverDetail.Id)
 		return
 	}
+	isWindows := false
+	if serverDetail.OsType == "Windows" {
+		isWindows = true
+	}
 	ips := strings.Split(serverDetail.IPs, ",")
 	ip := strings.TrimSpace(ips[0])
 	return checkSshableForYunionCloud(session, SServerInfo{
@@ -188,7 +208,7 @@ func checkSshableForYunionCloudWithDetail(session *mcclient.ClientSession, serve
 		Id:         serverDetail.Id,
 		Hypervisor: serverDetail.Hypervisor,
 		VpcId:      serverDetail.VpcId,
-	})
+	}, isWindows)
 }
 
 func CheckSSHable(session *mcclient.ClientSession, serverId string) (sshable SSHable, cleanFunc func() error, err error) {
@@ -258,7 +278,7 @@ func CheckSSHable(session *mcclient.ClientSession, serverId string) (sshable SSH
 		return
 	} else {
 		var sshport int
-		sshport, err = getServerSshport(session, serverDetail.Id)
+		sshport, err = getServerSshport(session, serverDetail.Id, false)
 		if err != nil {
 			err = errors.Wrapf(err, "unable to get sshport of server %s", serverDetail.Id)
 		}
@@ -323,7 +343,10 @@ func GetCleanFunc(session *mcclient.ClientSession, hypervisor, serverId, host, f
 	}
 }
 
-func getServerSshport(session *mcclient.ClientSession, serverId string) (int, error) {
+func getServerSshport(session *mcclient.ClientSession, serverId string, isWindows bool) (int, error) {
+	if isWindows {
+		return 5985, nil
+	}
 	data, err := modules.Servers.GetSpecific(session, serverId, "sshport", nil)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
### What this PR does / why we need it:
支持安装监控Agent到windows中，这需要windows能够被ansible控制，本PR是在建立此前提上的。
比如 Windows_Server_2016_Datacenter_CN_20200212.qcow2 这个镜像，本身就满足上述前提；不过需要VNC登陆上去，否则可能网络没有初始化完成，无法访问到此虚拟机。

### 如何让ansible控制windows:
ansible控制windows需要 powershell3.0+ .NET Framework 4.0+ 以及winrm服务。
- 安装powershell以及net framework；可以参考https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html#upgrading-powershell-and-net-framework 
有提供脚本。
- 安装winrm；可以参考https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html#winrm-setup
有提供脚本。


一般确保以上两步就可以了，其他请继续参考 https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html

### 如何检查是否安装成功:
开始菜单->服务器管理器->本地服务器->服务 搜索Telegraf
前端打开监控面板查看数据
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

### Does this PR need to be backport to the previous release branch?

- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area devtool ansibleserver
/cc @zexi @swordqiu 