### PR TITLE
Automated cherry pick of #14096: fix(region): sync vm name

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2639,7 +2639,7 @@ func (self *SGuest) syncWithCloudVM(ctx context.Context, userCred mcclient.Token
 	diff, err := db.UpdateWithLock(ctx, self, func() error {
 		if options.NameSyncResources.Contains(self.Keyword()) && !recycle {
 			newName, _ := db.GenerateAlterName(self, extVM.GetName())
-			if len(newName) > 0 && newName != self.Name && extVM.GetName() != extVM.GetHostname() {
+			if len(newName) > 0 && newName != self.Name {
 				self.Name = newName
 			}
 		}


### PR DESCRIPTION
Cherry pick of #14096 on release/3.9.

#14096: fix(region): sync vm name