### PR TITLE
Automated cherry pick of #14108: fix(region): secgroup created time

### DIFF
--- a/pkg/compute/models/secgroupcache.go
+++ b/pkg/compute/models/secgroupcache.go
@@ -374,6 +374,9 @@ func (self *SSecurityGroupCache) SyncBaseInfo(ctx context.Context, userCred mccl
 		if err == nil {
 			self.ReferenceCount = len(references)
 		}
+		if createdAt := ext.GetCreatedAt(); !createdAt.IsZero() {
+			self.CreatedAt = createdAt
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #14108 on release/3.9.

#14108: fix(region): secgroup created time