### PR TITLE
Automated cherry pick of #14114: fix: imags peripherals missing id

### DIFF
--- a/pkg/image/models/image_peripherals.go
+++ b/pkg/image/models/image_peripherals.go
@@ -14,11 +14,19 @@
 
 package models
 
-import "yunion.io/x/onecloud/pkg/cloudcommon/db"
+import (
+	"strconv"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+)
 
 type SImagePeripheral struct {
 	db.SResourceBase
 
 	Id      int    `primary:"true" auto_increment:"true" nullable:"false"`
 	ImageId string `width:"36" index:"true" nullable:"false"`
+}
+
+func (ip *SImagePeripheral) GetId() string {
+	return strconv.Itoa(ip.Id)
 }


### PR DESCRIPTION
Cherry pick of #14114 on release/3.8.

#14114: fix: imags peripherals missing id