### PR TITLE
Automated cherry pick of #14130: fix(region): vdi check

### DIFF
--- a/pkg/compute/guestdrivers/kvm.go
+++ b/pkg/compute/guestdrivers/kvm.go
@@ -827,7 +827,7 @@ func (self *SKVMGuestDriver) RequestChangeDiskStorage(ctx context.Context, userC
 
 func (self *SKVMGuestDriver) validateVdiProtocol(vdi string) error {
 	if !utils.IsInStringArray(vdi, []string{api.VM_VDI_PROTOCOL_VNC, api.VM_VDI_PROTOCOL_SPICE}) {
-		return httperrors.NewInputParameterError("unsupported vdi protocol")
+		return httperrors.NewInputParameterError("unsupported vdi protocol %s", vdi)
 	}
 	return nil
 }

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -4500,6 +4500,7 @@ func (self *SGuest) createConvertedServer(
 	// generate guest create params
 	createInput := self.ToCreateInput(userCred)
 	createInput.Hypervisor = api.HYPERVISOR_KVM
+	createInput.Vdi = api.VM_VDI_PROTOCOL_VNC
 	createInput.GenerateName = fmt.Sprintf("%s-%s", self.Name, api.HYPERVISOR_KVM)
 	// change drivers so as to bootable in KVM
 	for i := range createInput.Disks {


### PR DESCRIPTION
Cherry pick of #14130 on release/3.8.

#14130: fix(region): vdi check