### PR TITLE
Automated cherry pick of #14141: fix: fail to delete storages with fake-deleted snapshots

### DIFF
--- a/pkg/compute/storagedrivers/base.go
+++ b/pkg/compute/storagedrivers/base.go
@@ -58,9 +58,12 @@ func (self *SBaseStorageDriver) ValidateSnapshotDelete(ctx context.Context, snap
 	}
 
 	if !snapshot.OutOfChain && snapshot.FakeDeleted {
-		_, err := models.SnapshotManager.GetConvertSnapshot(snapshot)
-		if err != nil {
-			return httperrors.NewBadRequestError("disk need at least one of snapshot as backing file")
+		disk, _ := snapshot.GetDisk()
+		if disk != nil {
+			_, err := models.SnapshotManager.GetConvertSnapshot(snapshot)
+			if err != nil {
+				return httperrors.NewBadRequestError("disk need at least one of snapshot as backing file")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Cherry pick of #14141 on release/3.9.

#14141: fix: fail to delete storages with fake-deleted snapshots