### PR TITLE
fix: apigateway sends encrypt_passwd to indicate passwd encryption

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -146,6 +146,7 @@ func (h *AuthHandlers) GetRegionsResponse(ctx context.Context, w http.ResponseWr
 		SCommonConfig: agapi.SCommonConfig{
 			ApiServer: options.Options.ApiServer,
 		},
+		EncryptPasswd: true,
 	}
 
 	s := auth.GetAdminSession(ctx, regions[0], "")

--- a/pkg/apis/apigateway/regions.go
+++ b/pkg/apis/apigateway/regions.go
@@ -37,5 +37,7 @@ type SRegionsReponse struct {
 	Idps              []SIdp `json:"idps,allowempty"`
 	ReturnFullDomains bool   `json:"return_full_domains"`
 
+	EncryptPasswd bool `json:"encrypt_passwd"`
+
 	SCommonConfig
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: passwd encryption when apigateway sends encrypt_passwd=true

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 