### PR TITLE
Automated cherry pick of #14156: fix: apigateway sends encrypt_passwd to indicate passwd encryption

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -146,6 +146,7 @@ func (h *AuthHandlers) GetRegionsResponse(ctx context.Context, w http.ResponseWr
 		SCommonConfig: agapi.SCommonConfig{
 			ApiServer: options.Options.ApiServer,
 		},
+		EncryptPasswd: true,
 	}
 
 	s := auth.GetAdminSession(ctx, regions[0], "")

--- a/pkg/apis/apigateway/regions.go
+++ b/pkg/apis/apigateway/regions.go
@@ -37,5 +37,7 @@ type SRegionsReponse struct {
 	Idps              []SIdp `json:"idps,allowempty"`
 	ReturnFullDomains bool   `json:"return_full_domains"`
 
+	EncryptPasswd bool `json:"encrypt_passwd"`
+
 	SCommonConfig
 }


### PR DESCRIPTION
Cherry pick of #14156 on release/3.9.

#14156: fix: apigateway sends encrypt_passwd to indicate passwd encryption