### PR TITLE
fix(host): fix get disk pci addr

### DIFF
--- a/pkg/hostman/guestman/qemu/generate.go
+++ b/pkg/hostman/guestman/qemu/generate.go
@@ -372,7 +372,8 @@ func GetNicAddr(index int, disksLen int, isoDevsLen int, isVdiSpice bool) int {
 }
 
 func GetDiskAddr(idx int, isVdiSpice bool) int {
-	var base = 5
+	// host-bridge / isa-bridge / vga / serial / network / block / usb / rng
+	var base = 7
 	if isVdiSpice {
 		base += 10
 	}


### PR DESCRIPTION
Fix hot-plug virtio disk failed.
after add usb and rng deivce, available pci address should update.

Signed-off-by: wanyaoqi <wanyaoqi1995@163.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
