### PR TITLE
Automated cherry pick of #14227: fix: host sync wire class metadata

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -4350,6 +4350,7 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 				if err != nil {
 					return err
 				}
+				hw.syncClassMetadata(ctx)
 			} else {
 				db.Update(hw, func() error {
 					hw.Bridge = bridge
@@ -4359,6 +4360,7 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 					hw.IsMaster = isMaster
 					return nil
 				})
+				hw.syncClassMetadata(ctx)
 			}
 		}
 	}

--- a/pkg/compute/models/hostwires.go
+++ b/pkg/compute/models/hostwires.go
@@ -299,10 +299,16 @@ func (hw *SHostwire) PostCreate(
 	data jsonutils.JSONObject,
 ) {
 	hw.SHostJointsBase.PostCreate(ctx, userCred, ownerId, query, data)
+	hw.syncClassMetadata(ctx)
+}
+
+func (hw *SHostwire) syncClassMetadata(ctx context.Context) error {
 	host := hw.GetHost()
 	wire := hw.GetWire()
 	err := db.InheritFromTo(ctx, wire, host)
 	if err != nil {
 		log.Errorf("Inherit class metadata from host to wire fail: %s", err)
+		return errors.Wrap(err, "InheritFromTo")
 	}
+	return nil
 }


### PR DESCRIPTION
Cherry pick of #14227 on release/3.9.

#14227: fix: host sync wire class metadata