### PR TITLE
Automated cherry pick of #14249: fix(apigateway): 修复oidc认证中，返回的id_token为空

### DIFF
--- a/pkg/apigateway/clientman/authtoken.go
+++ b/pkg/apigateway/clientman/authtoken.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwe"
-	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/pquerna/otp/totp"
 
@@ -279,11 +278,11 @@ func (t *SAuthToken) VerifyTotpPasscode(s *mcclient.ClientSession, uid, passcode
 }
 
 func SignJWT(t jwt.Token) (string, error) {
-	jwkKey, err := jwk.New(privateKey)
-	if err != nil {
-		return "", errors.Wrap(err, "jwk.New")
-	}
-	signed, err := jwt.Sign(t, jwa.RS256, jwkKey)
+	//jwkKey, err := jwk.New(privateKey)
+	//if err != nil {
+	//	return "", errors.Wrap(err, "jwk.New")
+	//}
+	signed, err := jwt.Sign(t, jwa.RS256, privateKey)
 	if err != nil {
 		return "", errors.Wrap(err, "jwt.Sign")
 	}


### PR DESCRIPTION
Cherry pick of #14249 on release/3.8.

#14249: fix(apigateway): 修复oidc认证中，返回的id_token为空