### PR TITLE
Automated cherry pick of #14262: fix: kvm resume should be treated as start

### DIFF
--- a/pkg/compute/guestdrivers/kvm.go
+++ b/pkg/compute/guestdrivers/kvm.go
@@ -611,7 +611,7 @@ func (self *SKVMGuestDriver) RequestSuspendOnHost(ctx context.Context, guest *mo
 
 func (self *SKVMGuestDriver) RequestResumeOnHost(ctx context.Context, guest *models.SGuest, task taskman.ITask) error {
 	host, _ := guest.GetHost()
-	url := fmt.Sprintf("%s/servers/%s/resume", host.ManagerUri, guest.Id)
+	url := fmt.Sprintf("%s/servers/%s/start", host.ManagerUri, guest.Id)
 	header := self.getTaskRequestHeader(task)
 	_, _, err := httputils.JSONRequest(httputils.GetDefaultClient(), ctx, "POST", url, header, nil, false)
 	return err


### PR DESCRIPTION
Cherry pick of #14262 on release/3.9.

#14262: fix: kvm resume should be treated as start