### PR TITLE
Automated cherry pick of #14280: fix: force invalidate cached image early

### DIFF
--- a/pkg/apis/compute/cachedimages_const.go
+++ b/pkg/apis/compute/cachedimages_const.go
@@ -27,6 +27,6 @@ const (
 )
 
 const (
-	CACHED_IMAGE_REFRESH_SECONDS                  = 900   // 15 minutes
+	CACHED_IMAGE_REFRESH_SECONDS                  = 1     // 1 second
 	CACHED_IMAGE_REFERENCE_SESSION_EXPIRE_SECONDS = 86400 // 1 day
 )


### PR DESCRIPTION
Cherry pick of #14280 on release/3.9.

#14280: fix: force invalidate cached image early