### PR TITLE
feat(host,region): suport live change disk storage

### DIFF
--- a/pkg/apis/compute/guest_metadata.go
+++ b/pkg/apis/compute/guest_metadata.go
@@ -19,6 +19,8 @@ const (
 	MIRROR_JOB_READY  = "ready"
 	MIRROR_JOB_FAILED = "failed"
 
+	DISK_CLONE_TASK_ID = "__disk_clone_task_id"
+
 	SSH_PORT = "__ssh_port"
 )
 

--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -756,6 +756,8 @@ type ServerChangeDiskStorageInternalInput struct {
 	ServerChangeDiskStorageInput
 	StorageId    string `json:"storage_id"`
 	TargetDiskId string `json:"target_disk_id"`
+	DiskFormat   string `json:"disk_format"`
+	GuestRunning bool   `josn:"guest_running"`
 }
 
 type ServerSetExtraOptionInput struct {

--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -160,6 +160,10 @@ func (manager *STaskManager) FilterByOwner(q *sqlchemy.SQuery, owner mcclient.II
 	return q
 }
 
+func (manager *STaskManager) FetchTaskById(taskId string) *STask {
+	return manager.fetchTask(taskId)
+}
+
 func (self *STask) AllowGetDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
 	return db.IsAdminAllowGet(ctx, userCred, self) || userCred.GetProjectId() == self.UserCred.GetProjectId()
 }

--- a/pkg/compute/guestdrivers/base.go
+++ b/pkg/compute/guestdrivers/base.go
@@ -449,6 +449,10 @@ func (self *SBaseGuestDriver) RequestChangeDiskStorage(ctx context.Context, user
 	return cloudprovider.ErrNotImplemented
 }
 
+func (self *SBaseGuestDriver) RequestSwitchToTargetStorageDisk(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, input *api.ServerChangeDiskStorageInternalInput, task taskman.ITask) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 func (self *SBaseGuestDriver) RequestSyncIsolatedDevice(ctx context.Context, guest *models.SGuest, task taskman.ITask) error {
 	task.ScheduleRun(nil)
 	return nil

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -215,6 +215,7 @@ type IGuestDriver interface {
 	ValidateChangeDiskStorage(ctx context.Context, userCred mcclient.TokenCredential, guest *SGuest, input *api.ServerChangeDiskStorageInput) error
 	StartChangeDiskStorageTask(guest *SGuest, ctx context.Context, userCred mcclient.TokenCredential, params *api.ServerChangeDiskStorageInternalInput, parentTaskId string) error
 	RequestChangeDiskStorage(ctx context.Context, userCred mcclient.TokenCredential, guest *SGuest, input *api.ServerChangeDiskStorageInternalInput, task taskman.ITask) error
+	RequestSwitchToTargetStorageDisk(ctx context.Context, userCred mcclient.TokenCredential, guest *SGuest, input *api.ServerChangeDiskStorageInternalInput, task taskman.ITask) error
 
 	RequestSyncIsolatedDevice(ctx context.Context, guest *SGuest, task taskman.ITask) error
 

--- a/pkg/compute/tasks/guest_delete_task.go
+++ b/pkg/compute/tasks/guest_delete_task.go
@@ -176,7 +176,7 @@ func (self *GuestDeleteTask) OnDiskDetachComplete(ctx context.Context, obj db.IS
 		return
 	}
 	purge := jsonutils.QueryBoolean(self.Params, "purge", false)
-	guest.StartGuestDetachdiskTask(ctx, self.UserCred, lastDisk, true, self.GetTaskId(), purge)
+	guest.StartGuestDetachdiskTask(ctx, self.UserCred, lastDisk, true, self.GetTaskId(), purge, false)
 }
 
 func (self *GuestDeleteTask) OnDiskDetachCompleteFailed(ctx context.Context, obj db.IStandaloneModel, err jsonutils.JSONObject) {

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -79,19 +79,21 @@ type SKVMGuestInstance struct {
 	QemuVersion string
 	VncPassword string
 
-	Desc        *jsonutils.JSONDict
-	Monitor     monitor.Monitor
-	manager     *SGuestManager
-	startupTask *SGuestResumeTask
-	migrateTask *SGuestLiveMigrateTask
-	stopping    bool
-	syncMeta    *jsonutils.JSONDict
+	Desc           *jsonutils.JSONDict
+	Monitor        monitor.Monitor
+	manager        *SGuestManager
+	startupTask    *SGuestResumeTask
+	migrateTask    *SGuestLiveMigrateTask
+	stopping       bool
+	syncMeta       *jsonutils.JSONDict
+	blockJobTigger map[string]chan struct{}
 }
 
 func NewKVMGuestInstance(id string, manager *SGuestManager) *SKVMGuestInstance {
 	return &SKVMGuestInstance{
-		Id:      id,
-		manager: manager,
+		Id:             id,
+		manager:        manager,
+		blockJobTigger: make(map[string]chan struct{}),
 	}
 }
 
@@ -594,49 +596,123 @@ func (s *SKVMGuestInstance) StartMonitor(ctx context.Context, cb func()) {
 
 func (s *SKVMGuestInstance) onReceiveQMPEvent(event *monitor.Event) {
 	switch {
-	case event.Event == `"BLOCK_JOB_READY"` && s.IsMaster():
-		if itype, ok := event.Data["type"]; ok {
-			stype, _ := itype.(string)
-			if stype == "mirror" {
-				mirrorStatus := s.MirrorJobStatus()
-				if mirrorStatus.IsSucc() {
-					_, err := hostutils.UpdateServerStatus(context.Background(), s.GetId(), api.VM_RUNNING, "BLOCK_JOB_READY")
-					if err != nil {
-						log.Errorf("onReceiveQMPEvent update server status error: %s", err)
-					}
-				} else if mirrorStatus.IsFailed() {
-					s.SyncMirrorJobFailed("Block job missing")
-				}
-			}
-		}
+	case event.Event == `"BLOCK_JOB_READY"`:
+		s.eventBlockJobReady(event)
 	case event.Event == `"BLOCK_JOB_ERROR"`:
 		s.SyncMirrorJobFailed("BLOCK_JOB_ERROR")
+	case event.Event == `"BLOCK_JOB_COMPLETED"`:
+		s.eventBlockJobCompleted(event)
 	case event.Event == `"GUEST_PANICKED"`:
-		// qemu runc state event source qemu/src/qapi/run-state.json
-		params := jsonutils.NewDict()
-		if action, ok := event.Data["action"]; ok {
-			sAction, _ := action.(string)
-			params.Set("action", jsonutils.NewString(sAction))
-		}
-		if info, ok := event.Data["info"]; ok {
-			params.Set("info", jsonutils.Marshal(info))
-		}
-		params.Set("event", jsonutils.NewString(strings.Trim(event.Event, "\"")))
-		modules.Servers.PerformAction(
-			hostutils.GetComputeSession(context.Background()),
-			s.GetId(), "event", params)
-		// case utils.IsInStringArray(event.Event, []string{`"SHUTDOWN"`, `"POWERDOWN"`, `"RESET"`}):
-		// 	params := jsonutils.NewDict()
-		// 	params.Set("event", jsonutils.NewString(strings.Trim(event.Event, "\"")))
-		// 	modules.Servers.PerformAction(
-		// 		hostutils.GetComputeSession(context.Background()),
-		// 		s.GetId(), "event", params)
+		s.eventGuestPaniced(event)
 	case event.Event == `"STOP"`:
 		if s.migrateTask != nil {
 			// migrating complete
 			s.migrateTask.migrateComplete()
 		}
 		hostutils.UpdateServerProgress(context.Background(), s.Id, 0.0, 0)
+	}
+}
+
+func (s *SKVMGuestInstance) eventBlockJobCompleted(event *monitor.Event) {
+	itype, ok := event.Data["type"]
+	if !ok {
+		log.Errorf("BLOCK_JOB_COMPLETED missing event type")
+		return
+	}
+	// only dealwith event type mirror
+	stype, _ := itype.(string)
+	if stype != "mirror" {
+		return
+	}
+
+	iDevice, ok := event.Data["device"]
+	if !ok {
+		return
+	}
+	device := iDevice.(string)
+	if !strings.HasPrefix(device, "drive_") {
+		return
+	}
+	disks, _ := s.Desc.GetArray("disks")
+	log.Infof("mirror job complete disk index %s", device[len("drive_"):])
+	diskIndex, err := strconv.Atoi(device[len("drive_"):])
+	if err != nil || diskIndex < 0 || diskIndex >= len(disks) {
+		log.Errorf("failed get disk from index %d", diskIndex)
+		return
+	}
+	diskId, _ := disks[diskIndex].GetString("disk_id")
+	if c, ok := s.blockJobTigger[diskId]; ok {
+		c <- struct{}{}
+	}
+}
+
+func (s *SKVMGuestInstance) eventGuestPaniced(event *monitor.Event) {
+	// qemu runc state event source qemu/src/qapi/run-state.json
+	params := jsonutils.NewDict()
+	if action, ok := event.Data["action"]; ok {
+		sAction, _ := action.(string)
+		params.Set("action", jsonutils.NewString(sAction))
+	}
+	if info, ok := event.Data["info"]; ok {
+		params.Set("info", jsonutils.Marshal(info))
+	}
+	params.Set("event", jsonutils.NewString(strings.Trim(event.Event, "\"")))
+	_, err := modules.Servers.PerformAction(
+		hostutils.GetComputeSession(context.Background()),
+		s.GetId(), "event", params)
+	if err != nil {
+		log.Errorf("Server %s send event guest paniced got error %s", s.GetId(), err)
+	}
+}
+
+func (s *SKVMGuestInstance) eventBlockJobReady(event *monitor.Event) {
+	itype, ok := event.Data["type"]
+	if !ok {
+		log.Errorf("BLOCK_JOB_READY missing event type")
+		return
+	}
+	// only dealwith event type mirror
+	stype, _ := itype.(string)
+	if stype != "mirror" {
+		return
+	}
+
+	if s.IsMaster() { // has backup server
+		mirrorStatus := s.MirrorJobStatus()
+		if mirrorStatus.IsSucc() {
+			_, err := hostutils.UpdateServerStatus(context.Background(), s.GetId(), api.VM_RUNNING, "BLOCK_JOB_READY")
+			if err != nil {
+				log.Errorf("onReceiveQMPEvent update server status error: %s", err)
+			}
+		} else if mirrorStatus.IsFailed() {
+			s.SyncMirrorJobFailed("Block job missing")
+		}
+	} else {
+		iDevice, ok := event.Data["device"]
+		if !ok {
+			return
+		}
+		device := iDevice.(string)
+		if !strings.HasPrefix(device, "drive_") {
+			return
+		}
+		disks, _ := s.Desc.GetArray("disks")
+		log.Infof("mirror job ready disk index %s", device[len("drive_"):])
+		diskIndex, err := strconv.Atoi(device[len("drive_"):])
+		if err != nil || diskIndex < 0 || diskIndex >= len(disks) {
+			log.Errorf("failed get disk from index %d", diskIndex)
+			return
+		}
+		diskId, _ := disks[diskIndex].GetString("disk_id")
+		params := jsonutils.NewDict()
+		params.Set("disk_id", jsonutils.NewString(diskId))
+		_, err = modules.Servers.PerformAction(
+			hostutils.GetComputeSession(context.Background()),
+			s.GetId(), "block-mirror-ready", params,
+		)
+		if err != nil {
+			log.Errorf("Server %s perform block-mirror-ready got error %s", s.GetId(), err)
+		}
 	}
 }
 
@@ -944,6 +1020,7 @@ func (s *SKVMGuestInstance) CheckBlockOrRunning(jobs int) {
 				s.SyncMirrorJobFailed("Block job missing")
 			}
 		} else {
+			// TODO: check block jobs ready
 			status = api.VM_BLOCK_STREAM
 		}
 	}

--- a/pkg/hostman/monitor/hmp.go
+++ b/pkg/hostman/monitor/hmp.go
@@ -400,7 +400,7 @@ func (m *HmpMonitor) ReloadDiskBlkdev(device, path string, callback StringCallba
 	m.Query(fmt.Sprintf("reload_disk_snapshot_blkdev -n %s %s", device, path), callback)
 }
 
-func (m *HmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMode string, unmap, blockReplication bool) {
+func (m *HmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMode, format string, unmap, blockReplication bool) {
 	cmd := "drive_mirror -n"
 	if blockReplication {
 		cmd += " -c"
@@ -408,7 +408,7 @@ func (m *HmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMod
 	if syncMode == "full" {
 		cmd += " -f"
 	}
-	cmd += fmt.Sprintf(" %s %s", drive, target)
+	cmd += fmt.Sprintf(" %s %s %s", drive, target, format)
 	m.Query(cmd, callback)
 }
 
@@ -418,6 +418,23 @@ func (m *HmpMonitor) BlockStream(drive string, _, _ int, callback StringCallback
 		cmd   = fmt.Sprintf("block_stream %s %d", drive, speed)
 	)
 	m.Query(cmd, callback)
+}
+
+func (m *HmpMonitor) BlockJobComplete(drive string, callback StringCallback) {
+	m.Query(fmt.Sprintf("block_job_complete"), callback)
+}
+
+func (m *HmpMonitor) BlockReopenImage(drive, newImagePath, format string, cb StringCallback) {
+	m.Query(fmt.Sprintf("block_reopen_image %s %s %s", drive, newImagePath, format), cb)
+}
+
+func (m *HmpMonitor) SnapshotBlkdev(drive, newImagePath, format string, reuse bool, cb StringCallback) {
+	var cmd = "snapshot_blkdev"
+	if reuse {
+		cmd += " -n"
+	}
+	cmd += fmt.Sprintf(" %s %s %s", drive, newImagePath, format)
+	m.Query(cmd, cb)
 }
 
 func (m *HmpMonitor) SetVncPassword(proto, password string, callback StringCallback) {

--- a/pkg/hostman/monitor/monitor.go
+++ b/pkg/hostman/monitor/monitor.go
@@ -173,7 +173,10 @@ type Monitor interface {
 	DeviceAdd(dev string, params map[string]interface{}, callback StringCallback)
 
 	BlockStream(drive string, idx, blkCnt int, callback StringCallback)
-	DriveMirror(callback StringCallback, drive, target, syncMode string, unmap, blockReplication bool)
+	DriveMirror(callback StringCallback, drive, target, syncMode, format string, unmap, blockReplication bool)
+	BlockJobComplete(drive string, cb StringCallback)
+	BlockReopenImage(drive, newImagePath, format string, cb StringCallback)
+	SnapshotBlkdev(drive, newImagePath, format string, reuse bool, cb StringCallback)
 
 	MigrateSetDowntime(dtSec float32, callback StringCallback)
 	MigrateSetCapability(capability, state string, callback StringCallback)

--- a/pkg/hostman/monitor/qmp.go
+++ b/pkg/hostman/monitor/qmp.go
@@ -835,7 +835,7 @@ func (m *QmpMonitor) ReloadDiskBlkdev(device, path string, callback StringCallba
 	m.Query(cmd, cb)
 }
 
-func (m *QmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMode string, unmap, blockReplication bool) {
+func (m *QmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMode, format string, unmap, blockReplication bool) {
 	var (
 		cb = func(res *Response) {
 			callback(m.actionResult(res))
@@ -975,6 +975,37 @@ func (m *QmpMonitor) CancelBlockJob(driveName string, force bool, callback Strin
 		cmd += "-f "
 	}
 	cmd += driveName
+	m.HumanMonitorCommand(cmd, callback)
+}
+
+func (m *QmpMonitor) BlockJobComplete(drive string, callback StringCallback) {
+	m.HumanMonitorCommand(fmt.Sprintf("block_job_complete %s", drive), callback)
+}
+
+func (m *QmpMonitor) BlockReopenImage(drive, newImagePath, format string, callback StringCallback) {
+	var cb = func(res *Response) {
+		callback(m.actionResult(res))
+	}
+
+	var cmd = &Command{
+		Execute: "block_reopen_image",
+		Args: map[string]interface{}{
+			"device":    drive,
+			"new_image": newImagePath,
+			"format":    format,
+		},
+	}
+
+	m.Query(cmd, cb)
+}
+
+func (m *QmpMonitor) SnapshotBlkdev(drive, newImagePath, format string, reuse bool, callback StringCallback) {
+	var cmd = "snapshot_blkdev"
+	if reuse {
+		cmd += " -n"
+	}
+	cmd += fmt.Sprintf(" %s %s %s", drive, newImagePath, format)
+
 	m.HumanMonitorCommand(cmd, callback)
 }
 

--- a/pkg/hostman/storageman/storage_base.go
+++ b/pkg/hostman/storageman/storage_base.go
@@ -31,7 +31,7 @@ import (
 
 	"yunion.io/x/onecloud/pkg/apis"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
-	"yunion.io/x/onecloud/pkg/apis/host"
+	hostapi "yunion.io/x/onecloud/pkg/apis/host"
 	"yunion.io/x/onecloud/pkg/cloudcommon/cronman"
 	"yunion.io/x/onecloud/pkg/hostman/hostutils"
 	"yunion.io/x/onecloud/pkg/hostman/options"
@@ -129,7 +129,7 @@ type IStorage interface {
 	// GetCloneTargetDiskPath generate target disk path by target disk id
 	GetCloneTargetDiskPath(ctx context.Context, targetDiskId string) string
 	// CloneDiskFromStorage clone disk from other storage
-	CloneDiskFromStorage(ctx context.Context, srcStorage IStorage, srcDisk IDisk, targetDiskId string) (*host.ServerCloneDiskFromStorageResponse, error)
+	CloneDiskFromStorage(ctx context.Context, srcStorage IStorage, srcDisk IDisk, targetDiskId string, fullCopy bool) (*hostapi.ServerCloneDiskFromStorageResponse, error)
 
 	CreateSnapshotFormUrl(ctx context.Context, snapshotUrl, diskId, snapshotPath string) error
 
@@ -422,7 +422,9 @@ func (s *SBaseStorage) GetCloneTargetDiskPath(ctx context.Context, targetDiskId 
 	return ""
 }
 
-func (s *SBaseStorage) CloneDiskFromStorage(ctx context.Context, srcStorage IStorage, srcDisk IDisk, targetDiskId string) (*host.ServerCloneDiskFromStorageResponse, error) {
+func (s *SBaseStorage) CloneDiskFromStorage(
+	ctx context.Context, srcStorage IStorage, srcDisk IDisk, targetDiskId string, fullCopy bool,
+) (*hostapi.ServerCloneDiskFromStorageResponse, error) {
 	return nil, httperrors.ErrNotImplemented
 }
 


### PR DESCRIPTION
Guest start drive mirror job to copy full disk to target, after drive
mirror job ready, guest reopen target disk to replace source disk.
Qemu must support block reopen image feature.

Supported storage: local, ceph

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
