### PR TITLE
fix: wrong hypervisor in kvm vnc info

### DIFF
--- a/pkg/compute/guestdrivers/kvm.go
+++ b/pkg/compute/guestdrivers/kvm.go
@@ -208,7 +208,7 @@ func (self *SKVMGuestDriver) GetGuestVncInfo(ctx context.Context, userCred mccli
 		Host:       host.AccessIp,
 		Protocol:   guest.GetVdi(),
 		Port:       int64(port),
-		Hypervisor: api.HYPERVISOR_ESXI,
+		Hypervisor: api.HYPERVISOR_KVM,
 	}
 	return result, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: wrong hypervisor in kvm vnc info

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 