### PR TITLE
Automated cherry pick of #14359: fix: wrong hypervisor in kvm vnc info

### DIFF
--- a/pkg/compute/guestdrivers/kvm.go
+++ b/pkg/compute/guestdrivers/kvm.go
@@ -208,7 +208,7 @@ func (self *SKVMGuestDriver) GetGuestVncInfo(ctx context.Context, userCred mccli
 		Host:       host.AccessIp,
 		Protocol:   guest.GetVdi(),
 		Port:       int64(port),
-		Hypervisor: api.HYPERVISOR_ESXI,
+		Hypervisor: api.HYPERVISOR_KVM,
 	}
 	return result, nil
 }


### PR DESCRIPTION
Cherry pick of #14359 on release/3.9.

#14359: fix: wrong hypervisor in kvm vnc info