### PR TITLE
Automated cherry pick of #14392: fix(host): openvswitch service name on UOS

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -710,7 +710,10 @@ func (h *SHostInfo) detectOsDist() {
 		}
 	}
 	if utils.IsInStringArray(strings.ToLower(h.sysinfo.OsDistribution), []string{"uos", "debian", "ubuntu"}) {
-		system_service.SetOpenvswitchName("openvswitch-switch")
+		if err := procutils.NewRemoteCommandAsFarAsPossible("systemctl", "cat", "--", "openvswitch").Run(); err != nil {
+			log.Warningf("system_service.SetOpenvswitchName to openvswitch-switch")
+			system_service.SetOpenvswitchName("openvswitch-switch")
+		}
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #14392 on release/3.9.

#14392: fix(host): openvswitch service name on UOS