### PR TITLE
Automated cherry pick of #14396: fix(region):资源统计bug，已使用资源统计包含裸金属资源，总数未包含，导致资源使用率统计异常。

### DIFF
--- a/pkg/compute/usages/handler.go
+++ b/pkg/compute/usages/handler.go
@@ -839,7 +839,7 @@ func guestUsage(prefix string, scope rbacutils.TRbacScope, userCred mcclient.IId
 	hostTypes []string, resourceTypes []string, providers []string, brands []string, cloudEnv string,
 	status []string, pendingDelete, includeSystem bool, since *time.Time) Usage {
 	hypervisors := sets.NewString(api.HYPERVISORS...)
-	hypervisors.Delete(api.HYPERVISOR_CONTAINER)
+	hypervisors.Delete(api.HYPERVISOR_CONTAINER, api.HYPERVISOR_BAREMETAL)
 	return guestHypervisorsUsage(prefix, scope, userCred, rangeObjs, hostTypes, resourceTypes, providers, brands, cloudEnv, status, hypervisors.List(), pendingDelete, includeSystem, since)
 }
 


### PR DESCRIPTION
Cherry pick of #14396 on release/3.7.

#14396: fix(region):资源统计bug，已使用资源统计包含裸金属资源，总数未包含，导致资源使用率统计异常。