### PR TITLE
Automated cherry pick of #14421: fix(host): Telegraf 1.19.2 conf

### DIFF
--- a/pkg/hostman/system_service/telegraf.go
+++ b/pkg/hostman/system_service/telegraf.go
@@ -176,8 +176,11 @@ func (s *STelegraf) GetConfig(kwargs map[string]interface{}) string {
 	conf += "[[inputs.internal]]\n"
 	conf += "  collect_memstats = false\n"
 	conf += "\n"
-	conf += "[[inputs.http_listener]]\n"
+	conf += "[[inputs.http_listener_v2]]\n"
 	conf += "  service_address = \"127.0.0.1:8087\"\n"
+	conf += "  path = \"/write\"\n"
+	conf += "  data_source = \"body\"\n"
+	conf += "  data_format = \"influx\"\n"
 	conf += "\n"
 	return conf
 }


### PR DESCRIPTION
Cherry pick of #14421 on release/3.9.

#14421: fix(host): Telegraf 1.19.2 conf