### PR TITLE
fix: keystoen cronman use uninitialized admin token

### DIFF
--- a/pkg/cloudcommon/cronman/cronman.go
+++ b/pkg/cloudcommon/cronman/cronman.go
@@ -22,9 +22,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/appctx"
 	"yunion.io/x/onecloud/pkg/appsrv"
@@ -35,7 +34,7 @@ import (
 
 var (
 	DefaultAdminSessionGenerator = auth.AdminCredential
-	ErrCronJobNameConflict       = errors.New("Cron job Name Conflict")
+	ErrCronJobNameConflict       = errors.Error("Cron job Name Conflict")
 )
 
 type TCronJobFunction func(ctx context.Context, userCred mcclient.TokenCredential, isStart bool)
@@ -164,7 +163,7 @@ func (self *SCronJobManager) AddJobAtIntervals(name string, interval time.Durati
 
 func (self *SCronJobManager) AddJobAtIntervalsWithStartRun(name string, interval time.Duration, jobFunc TCronJobFunction, startRun bool) error {
 	if interval <= 0 {
-		return errors.New("AddJobAtIntervals: interval must > 0")
+		return errors.Error("AddJobAtIntervals: interval must > 0")
 	}
 	self.dataLock.Lock()
 	defer self.dataLock.Unlock()
@@ -193,13 +192,13 @@ func (self *SCronJobManager) AddJobAtIntervalsWithStartRun(name string, interval
 func (self *SCronJobManager) AddJobEveryFewDays(name string, day, hour, min, sec int, jobFunc TCronJobFunction, startRun bool) error {
 	switch {
 	case day <= 0:
-		return errors.New("AddJobEveryFewDays: day must > 0")
+		return errors.Error("AddJobEveryFewDays: day must > 0")
 	case hour < 0:
-		return errors.New("AddJobEveryFewDays: hour must > 0")
+		return errors.Error("AddJobEveryFewDays: hour must > 0")
 	case min < 0:
-		return errors.New("AddJobEveryFewDays: min must > 0")
+		return errors.Error("AddJobEveryFewDays: min must > 0")
 	case sec < 0:
-		return errors.New("AddJobEveryFewDays: sec must > 0")
+		return errors.Error("AddJobEveryFewDays: sec must > 0")
 	}
 
 	self.dataLock.Lock()
@@ -232,11 +231,11 @@ func (self *SCronJobManager) AddJobEveryFewDays(name string, day, hour, min, sec
 func (self *SCronJobManager) AddJobEveryFewHour(name string, hour, min, sec int, jobFunc TCronJobFunction, startRun bool) error {
 	switch {
 	case hour <= 0:
-		return errors.New("AddJobEveryFewHour: hour must > 0")
+		return errors.Error("AddJobEveryFewHour: hour must > 0")
 	case min < 0:
-		return errors.New("AddJobEveryFewHour: min must > 0")
+		return errors.Error("AddJobEveryFewHour: min must > 0")
 	case sec < 0:
-		return errors.New("AddJobEveryFewHour: sec must > 0")
+		return errors.Error("AddJobEveryFewHour: sec must > 0")
 	}
 
 	self.dataLock.Lock()

--- a/pkg/keystone/cronjobs/project_resources.go
+++ b/pkg/keystone/cronjobs/project_resources.go
@@ -95,7 +95,7 @@ func refreshScopeResourceCount(ctx context.Context) error {
 			url = ep.external
 		}
 		url = httputils.JoinPath(url, "scope-resources")
-		tk, _ := tokens.GetDefaultToken()
+		tk := tokens.GetDefaultToken()
 		hdr := http.Header{}
 		hdr.Add("X-Auth-Token", tk)
 		_, ret, err := httputils.JSONRequest(

--- a/pkg/keystone/models/default_admin.go
+++ b/pkg/keystone/models/default_admin.go
@@ -53,10 +53,6 @@ func GetDefaultAdminCred() mcclient.TokenCredential {
 	return defaultAdminCred
 }
 
-func GetDefaultAdminSSimpleToken() *mcclient.SSimpleToken {
-	return getDefaultAdminCred()
-}
-
 func getDefaultAdminCred() *mcclient.SSimpleToken {
 	token := mcclient.SSimpleToken{}
 	usr, _ := UserManager.FetchUserExtended("", api.SystemAdminUser, api.DEFAULT_DOMAIN_ID, "")

--- a/pkg/keystone/service/service.go
+++ b/pkg/keystone/service/service.go
@@ -51,7 +51,7 @@ func StartService() {
 	db.DefaultProjectsFetcher = keystoneProjectsFetcher
 	policy.DefaultPolicyFetcher = localPolicyFetcher
 	logclient.DefaultSessionGenerator = models.GetDefaultClientSession
-	cronman.DefaultAdminSessionGenerator = models.GetDefaultAdminCred
+	cronman.DefaultAdminSessionGenerator = tokens.GetDefaultAdminCredToken
 	notifyclient.AdminSessionGenerator = util.GetDefaulAdminSession
 	notifyclient.UserLangFetcher = models.GetUserLangForKeyStone
 

--- a/pkg/keystone/tokens/auth.go
+++ b/pkg/keystone/tokens/auth.go
@@ -73,9 +73,8 @@ func authUserByIdentity(ctx context.Context, ident mcclient.SAuthenticationIdent
 		ident.Password.User.Password = "***"
 		log.Errorf("authenticate fail for %s reason: %s", jsonutils.Marshal(ident), err)
 		user := logclient.NewSimpleObject(ident.Password.User.Id, ident.Password.User.Name, "user")
-		token := models.GetDefaultAdminSSimpleToken()
-		token.Token, _ = GetDefaultToken()
-		token.Context = authCtx
+		token := GetDefaultAdminCredToken()
+		token.(*mcclient.SSimpleToken).Context = authCtx
 		logclient.AddActionLogWithContext(ctx, user, logclient.ACT_AUTHENTICATE, err, token, false)
 	}
 	return usr, err

--- a/pkg/keystone/util/session.go
+++ b/pkg/keystone/util/session.go
@@ -16,47 +16,12 @@ package util
 
 import (
 	"context"
-	"time"
 
-	"yunion.io/x/pkg/utils"
-
-	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/keystone/models"
 	"yunion.io/x/onecloud/pkg/keystone/tokens"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
-var (
-	authToken   *tokens.SAuthToken
-	simpleToken *mcclient.SSimpleToken
-)
-
-func getDefaultAdminCredWithToken() (mcclient.TokenCredential, error) {
-	if simpleToken == nil {
-		simpleToken = models.GetDefaultAdminSSimpleToken()
-	}
-	var err error
-	if now := time.Now(); authToken == nil || authToken.ExpiresAt.Sub(now) < time.Duration(3600) {
-		authTokenTmp := &tokens.SAuthToken{
-			UserId:    simpleToken.GetUserId(),
-			Method:    api.AUTH_METHOD_TOKEN,
-			ProjectId: simpleToken.GetProjectId(),
-			ExpiresAt: now.Add(24 * time.Hour),
-			AuditIds:  []string{utils.GenRequestId(16)},
-		}
-		simpleToken.Token, err = authTokenTmp.EncodeFernetToken()
-		if err != nil {
-			return nil, err
-		}
-		authToken = authTokenTmp
-	}
-	return simpleToken, nil
-}
-
 func GetDefaulAdminSession(ctx context.Context, region, apiVersion string) (*mcclient.ClientSession, error) {
-	cred, err := getDefaultAdminCredWithToken()
-	if err != nil {
-		return nil, err
-	}
-	return models.GetDefaultClientSession(ctx, cred, region, apiVersion), nil
+	return models.GetDefaultClientSession(ctx, tokens.GetDefaultAdminCredToken(), region, apiVersion), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: keystone cronman use unintialized admin token

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 