### PR TITLE
fix: add CreateByInsertOrUpdate flag

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -1241,7 +1241,11 @@ func _doCreateItem(
 		return model, nil
 	}
 
-	err = manager.TableSpec().InsertOrUpdate(ctx, model)
+	if manager.CreateByInsertOrUpdate() {
+		err = manager.TableSpec().InsertOrUpdate(ctx, model)
+	} else {
+		err = manager.TableSpec().Insert(ctx, model)
+	}
 	if err != nil {
 		return nil, httperrors.NewGeneralError(err)
 	}

--- a/pkg/cloudcommon/db/interface.go
+++ b/pkg/cloudcommon/db/interface.go
@@ -133,6 +133,8 @@ type IModelManager interface {
 	GetI18N(ctx context.Context, idstr string, resObj jsonutils.JSONObject) *jsonutils.JSONDict
 
 	GetSplitTable() *splitable.SSplitTableSpec
+
+	CreateByInsertOrUpdate() bool
 }
 
 type IModel interface {

--- a/pkg/cloudcommon/db/modelbase.go
+++ b/pkg/cloudcommon/db/modelbase.go
@@ -76,6 +76,10 @@ func NewModelBaseManagerWithSplitableDBName(model interface{}, tableName string,
 	return modelMan
 }
 
+func (manager *SModelBaseManager) CreateByInsertOrUpdate() bool {
+	return true
+}
+
 func (manager *SModelBaseManager) IsStandaloneManager() bool {
 	return false
 }

--- a/pkg/cloudcommon/db/opslog.go
+++ b/pkg/cloudcommon/db/opslog.go
@@ -112,6 +112,10 @@ func InitOpsLog() {
 	opslogWriteWorkerMan = appsrv.NewWorkerManager("opslog_write_worker", 1, 2048, true)
 }
 
+func (manager *SOpsLogManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SOpsLogManager) CustomizeHandlerInfo(info *appsrv.SHandlerInfo) {
 	manager.SModelBaseManager.CustomizeHandlerInfo(info)
 

--- a/pkg/cloudcommon/db/standalone_anon.go
+++ b/pkg/cloudcommon/db/standalone_anon.go
@@ -77,6 +77,10 @@ func NewStandaloneAnonResourceBaseManager(
 	}
 }
 
+func (manager *SStandaloneAnonResourceBaseManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SStandaloneAnonResourceBaseManager) IsStandaloneManager() bool {
 	return true
 }

--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -96,6 +96,10 @@ type STask struct {
 	taskObjects []db.IStandaloneModel `ignore:"true"`
 }
 
+func (manager *STaskManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *STaskManager) AllowListItems(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
 	return true
 }

--- a/pkg/cloudevent/models/cloudevents.go
+++ b/pkg/cloudevent/models/cloudevents.go
@@ -99,6 +99,10 @@ func (event *SCloudevent) BeforeInsert() {
 	event.EventId = db.CurrentTimestamp(t)
 }
 
+func (manager *SCloudeventManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 // 云平台操作日志列表
 func (manager *SCloudeventManager) ListItemFilter(
 	ctx context.Context,

--- a/pkg/compute/models/access_group_rules.go
+++ b/pkg/compute/models/access_group_rules.go
@@ -77,6 +77,10 @@ func (self *SAccessGroupRule) GetId() string {
 	return self.Id
 }
 
+func (manager *SAccessGroupRuleManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SAccessGroupRuleManager) ResourceScope() rbacutils.TRbacScope {
 	return rbacutils.ScopeDomain
 }

--- a/pkg/compute/models/billingresource.go
+++ b/pkg/compute/models/billingresource.go
@@ -208,8 +208,8 @@ type SBillingResourceCheckManager struct {
 
 type SBillingResourceCheck struct {
 	db.SResourceBase
-	ResourceId   string `width:"128" charset:"ascii" index:"true"`
-	ResourceType string `width:"36" charset:"ascii" index:"true"`
+	ResourceId   string `width:"128" charset:"ascii" primary:"true"`
+	ResourceType string `width:"36" charset:"ascii" primary:"true"`
 	AdvanceDays  int
 	LastCheck    time.Time
 	NotifyNumber int
@@ -270,7 +270,7 @@ func (bm *SBillingResourceCheckManager) Create(ctx context.Context, resourceId, 
 		LastCheck:    time.Now(),
 		NotifyNumber: 1,
 	}
-	return bm.TableSpec().Insert(ctx, &bc)
+	return bm.TableSpec().InsertOrUpdate(ctx, &bc)
 }
 
 func (bm *SBillingResourceCheckManager) Fetch(resourceIds []string, advanceDays int, length int) (map[string]*SBillingResourceCheck, error) {

--- a/pkg/compute/models/dbinstance_privileges.go
+++ b/pkg/compute/models/dbinstance_privileges.go
@@ -66,6 +66,10 @@ func (self *SDBInstancePrivilege) BeforeInsert() {
 	}
 }
 
+func (manager *SDBInstancePrivilegeManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SDBInstancePrivilegeManager) GetContextManagers() [][]db.IModelManager {
 	return [][]db.IModelManager{
 		{DBInstanceAccountManager, DBInstanceDatabaseManager},

--- a/pkg/compute/models/reservedips.go
+++ b/pkg/compute/models/reservedips.go
@@ -76,6 +76,10 @@ type SReservedip struct {
 	Status string `width:"12" charset:"ascii" nullable:"false" default:"unknown" list:"user" create:"optional" update:"user"`
 }
 
+func (manager *SReservedipManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SReservedipManager) ReserveIP(userCred mcclient.TokenCredential, network *SNetwork, ip string, notes string) error {
 	return manager.ReserveIPWithDuration(userCred, network, ip, notes, 0)
 }

--- a/pkg/compute/models/secgrouprules.go
+++ b/pkg/compute/models/secgrouprules.go
@@ -76,6 +76,10 @@ func (self *SSecurityGroupRule) GetId() string {
 	return self.Id
 }
 
+func (manager *SSecurityGroupRuleManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SSecurityGroupRuleManager) FetchUniqValues(ctx context.Context, data jsonutils.JSONObject) jsonutils.JSONObject {
 	secgroupId, _ := data.GetString("secgroup_id")
 	return jsonutils.Marshal(map[string]string{"secgroup_id": secgroupId})

--- a/pkg/keystone/models/identitybase.go
+++ b/pkg/keystone/models/identitybase.go
@@ -27,7 +27,6 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/onecloud/pkg/util/logclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
@@ -398,17 +397,14 @@ func (self *SEnabledIdentityBaseResource) ValidateDeleteCondition(ctx context.Co
 
 func (model *SIdentityBaseResource) PostCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) {
 	model.SStandaloneResourceBase.PostCreate(ctx, userCred, ownerId, query, data)
-	logclient.AddActionLogWithContext(ctx, model, logclient.ACT_CREATE, data, userCred, true)
 }
 
 func (model *SIdentityBaseResource) PostUpdate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) {
 	model.SStandaloneResourceBase.PostUpdate(ctx, userCred, query, data)
-	// logclient.AddActionLogWithContext(ctx, model, logclient.ACT_UPDATE, data, userCred, true)
 }
 
 func (model *SIdentityBaseResource) PostDelete(ctx context.Context, userCred mcclient.TokenCredential) {
 	model.SStandaloneResourceBase.PostDelete(ctx, userCred)
-	logclient.AddActionLogWithContext(ctx, model, logclient.ACT_DELETE, nil, userCred, true)
 }
 
 func (manager *SIdentityBaseResourceManager) totalCount(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider) int {

--- a/pkg/keystone/models/localusers.go
+++ b/pkg/keystone/models/localusers.go
@@ -80,6 +80,10 @@ func (user *SLocalUser) GetName() string {
 	return user.Name
 }
 
+func (manager *SLocalUserManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SLocalUserManager) FetchLocalUserById(localId int) (*SLocalUser, error) {
 	return manager.fetchLocalUser("", "", localId)
 }

--- a/pkg/keystone/models/passwords.go
+++ b/pkg/keystone/models/passwords.go
@@ -83,6 +83,10 @@ func shaPassword(passwd string) string {
 	return hex.EncodeToString(shaOut[:])
 }
 
+func (manager *SPasswordManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SPasswordManager) FetchLastPassword(localUserId int) (*SPassword, error) {
 	passes, err := manager.fetchByLocaluserId(localUserId)
 	if err != nil {

--- a/pkg/logger/models/baremetalevents.go
+++ b/pkg/logger/models/baremetalevents.go
@@ -100,6 +100,10 @@ func (event *SBaremetalEvent) GetModelManager() db.IModelManager {
 	return BaremetalEventManager
 }
 
+func (manager *SBaremetalEventManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SBaremetalEventManager) ResourceScope() rbacutils.TRbacScope {
 	return rbacutils.ScopeSystem
 }

--- a/pkg/scheduledtask/models/scheduledtask_label.go
+++ b/pkg/scheduledtask/models/scheduledtask_label.go
@@ -42,8 +42,8 @@ type SScheduledTaskLabelManager struct {
 
 type SScheduledTaskLabel struct {
 	db.SResourceBase
-	ScheduledTaskId string `width:"36" charset:"ascii" nullable:"false" index:"true"`
-	Label           string `width:"64" charset:"utf8" nullable:"false" index:"true"`
+	ScheduledTaskId string `width:"36" charset:"ascii" nullable:"false" primary:"true"`
+	Label           string `width:"64" charset:"utf8" nullable:"false" primary:"true"`
 }
 
 func (slm *SScheduledTaskLabelManager) Attach(ctx context.Context, taskId, label string) error {
@@ -51,7 +51,7 @@ func (slm *SScheduledTaskLabelManager) Attach(ctx context.Context, taskId, label
 		ScheduledTaskId: taskId,
 		Label:           label,
 	}
-	return slm.TableSpec().Insert(ctx, sl)
+	return slm.TableSpec().InsertOrUpdate(ctx, sl)
 }
 
 func (sl *SScheduledTaskLabel) Detach(ctx context.Context, userCred mcclient.TokenCredential) error {

--- a/pkg/yunionconf/models/parameters.go
+++ b/pkg/yunionconf/models/parameters.go
@@ -166,6 +166,10 @@ func getNamespace(userCred mcclient.TokenCredential, resource string, query json
 	return namespace, namespace_id, nil
 }
 
+func (manager *SParameterManager) CreateByInsertOrUpdate() bool {
+	return false
+}
+
 func (manager *SParameterManager) NamespaceScope() rbacutils.TRbacScope {
 	return rbacutils.ScopeUser
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add CreateByInsertOrUpdate flag to indicate whether the create reset api use InsertOrUpdate to create item

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi @ioito 