### PR TITLE
feat(region,host): support multiqueues on vhost network

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -62,11 +62,12 @@ type NetworkConfig struct {
 
 	// 驱动方式
 	// 若指定镜像的网络驱动方式，此参数会被覆盖
-	Driver   string `json:"driver"`
-	BwLimit  int    `json:"bw_limit"`
-	Vip      bool   `json:"vip"`
-	Reserved bool   `json:"reserved"`
-	NetType  string `json:"net_type"`
+	Driver    string `json:"driver"`
+	BwLimit   int    `json:"bw_limit"`
+	Vip       bool   `json:"vip"`
+	Reserved  bool   `json:"reserved"`
+	NetType   string `json:"net_type"`
+	NumQueues int    `json:"num_queues"`
 
 	RequireDesignatedIP bool `json:"require_designated_ip"`
 

--- a/pkg/apis/compute/guestnetwork.go
+++ b/pkg/apis/compute/guestnetwork.go
@@ -90,6 +90,7 @@ type GuestnetworkJsonDesc struct {
 	Ifname     string               `json:"ifname"`
 	Masklen    int8                 `json:"masklen"`
 	Driver     string               `json:"driver"`
+	NumQueues  int                  `json:"num_queues"`
 	Vlan       int                  `json:"vlan"`
 	Bw         int                  `json:"bw"`
 	Mtu        int                  `json:"mtu"`

--- a/pkg/cloudcommon/cmdline/parser.go
+++ b/pkg/cloudcommon/cmdline/parser.go
@@ -242,6 +242,8 @@ func ParseNetworkConfig(desc string, idx int) (*compute.NetworkConfig, error) {
 			netConfig.StandbyAddrCount, _ = strconv.Atoi(p[len("standby-addr="):])
 		} else if utils.IsInStringArray(p, []string{"virtio", "e1000", "vmxnet3"}) {
 			netConfig.Driver = p
+		} else if strings.HasPrefix(p, "num-queues=") {
+			netConfig.NumQueues, _ = strconv.Atoi(p[len("num-queues="):])
 		} else if regutils.MatchSize(p) {
 			bw, err := fileutils.GetSizeMb(p, 'M', 1000)
 			if err != nil {

--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -85,6 +85,8 @@ type SGuestnetwork struct {
 	Ip6Addr string `width:"64" charset:"ascii" nullable:"true" list:"user"`
 	// 虚拟网卡驱动
 	Driver string `width:"16" charset:"ascii" nullable:"true" list:"user" update:"user"`
+	// 网卡队列数
+	NumQueues int `nullable:"true" default:"1" list:"user" update:"user"`
 	// 带宽限制，单位mbps
 	BwLimit int `nullable:"false" default:"0" list:"user"`
 	// 网卡序号
@@ -256,6 +258,7 @@ type newGuestNetworkArgs struct {
 	macAddr     string
 	bwLimit     int
 	nicDriver   string
+	numQueues   int
 	teamWithMac string
 
 	virtual bool
@@ -276,6 +279,7 @@ func (manager *SGuestnetworkManager) newGuestNetwork(
 		address              = args.ipAddr
 		mac                  = args.macAddr
 		driver               = args.nicDriver
+		numQueues            = args.numQueues
 		bwLimit              = args.bwLimit
 		virtual              = args.virtual
 		reserved             = args.tryReserved
@@ -294,6 +298,7 @@ func (manager *SGuestnetworkManager) newGuestNetwork(
 		driver = "virtio"
 	}
 	gn.Driver = driver
+	gn.NumQueues = numQueues
 	if bwLimit >= 0 {
 		gn.BwLimit = bwLimit
 	}
@@ -584,6 +589,7 @@ func (self *SGuestnetwork) getJsonDesc() *api.GuestnetworkJsonDesc {
 	desc.Ifname = self.GetIfname()
 	desc.Masklen = net.GuestIpMask
 	desc.Driver = self.Driver
+	desc.NumQueues = self.NumQueues
 	desc.Vlan = net.VlanId
 	desc.Bw = self.getBandwidth()
 	desc.Mtu = self.getMtu(net)

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2951,6 +2951,7 @@ type Attach2NetworkArgs struct {
 
 	BwLimit   int
 	NicDriver string
+	NumQueues int
 	NicConfs  []SNicConfig
 
 	Virtual bool
@@ -2973,6 +2974,7 @@ func (args *Attach2NetworkArgs) onceArgs(i int) attach2NetworkOnceArgs {
 
 		bwLimit:   args.BwLimit,
 		nicDriver: args.NicDriver,
+		numQueues: args.NumQueues,
 		nicConf:   args.NicConfs[i],
 
 		virtual: args.Virtual,
@@ -2988,6 +2990,7 @@ func (args *Attach2NetworkArgs) onceArgs(i int) attach2NetworkOnceArgs {
 		r.useDesignatedIP = false
 		r.nicConf = args.NicConfs[i]
 		r.nicDriver = ""
+		r.numQueues = 1
 	}
 	return r
 }
@@ -3003,6 +3006,7 @@ type attach2NetworkOnceArgs struct {
 
 	bwLimit     int
 	nicDriver   string
+	numQueues   int
 	nicConf     SNicConfig
 	teamWithMac string
 
@@ -3073,6 +3077,7 @@ func (self *SGuest) attach2NetworkOnce(
 		macAddr:     args.nicConf.Mac,
 		bwLimit:     args.bwLimit,
 		nicDriver:   nicDriver,
+		numQueues:   args.numQueues,
 		teamWithMac: args.teamWithMac,
 
 		virtual: args.virtual,
@@ -3647,6 +3652,13 @@ func (self *SGuest) CreateNetworksOnHost(
 		if candidateNet != nil {
 			networkIds = candidateNet.NetworkIds
 		}
+		if idx == 0 && netConfig.NumQueues == 0 {
+			numQueues := self.VcpuCount / 2
+			if numQueues > 16 {
+				numQueues = 16
+			}
+			netConfig.NumQueues = numQueues
+		}
 		_, err = self.attach2NetworkDesc(ctx, userCred, host, netConfig, pendingUsage, networkIds)
 		if err != nil {
 			return errors.Wrap(err, "self.attach2NetworkDesc")
@@ -3711,6 +3723,7 @@ func (self *SGuest) attach2NamedNetworkDesc(ctx context.Context, userCred mcclie
 			PendingUsage:        pendingUsage,
 			IpAddr:              netConfig.Address,
 			NicDriver:           netConfig.Driver,
+			NumQueues:           netConfig.NumQueues,
 			BwLimit:             netConfig.BwLimit,
 			Virtual:             netConfig.Vip,
 			TryReserved:         netConfig.Reserved,

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -434,6 +434,13 @@ function nic_mtu() {
 	}
 
 	// inject nic and disks
+	for i := 0; i < len(input.Nics); i++ {
+		nic := nics[i].(*jsonutils.JSONDict)
+		if numQueues, _ := nic.Int("num_queues"); numQueues > 1 {
+			nic.Set("vectors", jsonutils.NewInt(2*numQueues+1))
+		}
+	}
+
 	if input.OsName == OS_NAME_MACOS {
 		for i := 0; i < len(input.Disks); i++ {
 			disks[i].Driver = DISK_DRIVER_SATA


### PR DESCRIPTION
Guest network add attribute num_queues, one is default.
And we can assign queues on guest create, eg:
server-create --net num-queues=4

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
