### PR TITLE
fix: climc create aksk not return access_key

### DIFF
--- a/cmd/climc/shell/identity/credentials.go
+++ b/cmd/climc/shell/identity/credentials.go
@@ -181,7 +181,9 @@ func init() {
 		if err != nil {
 			return err
 		}
-		printObject(jsonutils.Marshal(&secret))
+		result := jsonutils.Marshal(secret)
+		result.(*jsonutils.JSONDict).Add(jsonutils.NewString(secret.KeyId), "access_key")
+		printObject(result)
 		return nil
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: climc create aksk not return access_key
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 