### PR TITLE
Automated cherry pick of #14483: fix: climc create aksk not return access_key

### DIFF
--- a/cmd/climc/shell/identity/credentials.go
+++ b/cmd/climc/shell/identity/credentials.go
@@ -181,7 +181,9 @@ func init() {
 		if err != nil {
 			return err
 		}
-		printObject(jsonutils.Marshal(&secret))
+		result := jsonutils.Marshal(secret)
+		result.(*jsonutils.JSONDict).Add(jsonutils.NewString(secret.KeyId), "access_key")
+		printObject(result)
 		return nil
 	})
 


### PR DESCRIPTION
Cherry pick of #14483 on release/3.9.

#14483: fix: climc create aksk not return access_key