### PR TITLE
fix(region,host): auto migrate on host down

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3991,7 +3991,6 @@ func (self *SHost) PerformAutoMigrateOnHostDown(
 	if val == "enable" {
 		meta = map[string]interface{}{
 			"__auto_migrate_on_host_down": "enable",
-			"__on_host_down":              "shutdown-servers",
 		}
 		_, err := self.Request(ctx, userCred, "POST", "/hosts/shutdown-servers-on-host-down",
 			mcclient.GetTokenHeaders(userCred), nil)
@@ -4001,7 +4000,6 @@ func (self *SHost) PerformAutoMigrateOnHostDown(
 	} else {
 		meta = map[string]interface{}{
 			"__auto_migrate_on_host_down": "disable",
-			"__on_host_down":              "",
 		}
 	}
 

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -328,14 +328,14 @@ func (m *SGuestManager) LoadServer(sid string) {
 	m.CandidateServers[sid] = guest
 }
 
-func (m *SGuestManager) ShutdownSharedStorageServers() {
+func (m *SGuestManager) ShutdownServers() {
 	m.Servers.Range(func(k, v interface{}) bool {
 		guest := v.(*SKVMGuestInstance)
-		if guest.IsSharedStorage() {
-			log.Infof("Start shutdown server %s", guest.GetName())
-			if !guest.scriptStop() {
-				log.Errorf("shutdown server %s failed", guest.GetName())
-			}
+		log.Infof("Start shutdown server %s", guest.GetName())
+
+		// scriptStop maybe stuck on guest storage offline
+		if !guest.forceStop() {
+			log.Errorf("shutdown server %s failed", guest.GetName())
 		}
 		return true
 	})

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -1294,6 +1294,15 @@ func (s *SKVMGuestInstance) scriptStop() bool {
 	return true
 }
 
+func (s *SKVMGuestInstance) forceStop() bool {
+	_, err := procutils.NewRemoteCommandAsFarAsPossible("bash", s.GetStopScriptPath(), "--force").Output()
+	if err != nil {
+		log.Errorln(err)
+		return false
+	}
+	return true
+}
+
 func (s *SKVMGuestInstance) ExecStopTask(ctx context.Context, params interface{}) (jsonutils.JSONObject, error) {
 	timeout, ok := params.(int64)
 	if !ok {

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -641,7 +641,7 @@ func (s *SKVMGuestInstance) generateStopScript(data *jsonutils.JSONDict) string 
 	cmd := ""
 	cmd += fmt.Sprintf("VNC_FILE=%s\n", s.GetVncFilePath())
 	cmd += fmt.Sprintf("PID_FILE=%s\n", s.GetPidFilePath())
-	cmd += "if [ -f $VNC_FILE ]; then\n"
+	cmd += "if [ \"$1\" != \"--force\" ] && [ -f $VNC_FILE ]; then\n"
 	cmd += "  VNC=`cat $VNC_FILE`\n"
 
 	// TODO, replace with qmp monitor

--- a/pkg/hostman/guestman/types/interface.go
+++ b/pkg/hostman/guestman/types/interface.go
@@ -22,7 +22,7 @@ import (
 // yunion.io/x/onecloud/pkg/hostman/guestman
 
 type IHealthCheckReactor interface {
-	ShutdownSharedStorageServers()
+	ShutdownServers()
 }
 
 var HealthCheckReactor IHealthCheckReactor

--- a/pkg/hostman/host_health/etcd.go
+++ b/pkg/hostman/host_health/etcd.go
@@ -17,6 +17,8 @@ package host_health
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"yunion.io/x/log"
@@ -26,6 +28,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/etcd"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/hostman/options"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 )
 
 func NewEtcdOptions(
@@ -84,6 +87,7 @@ func (c *SEtcdClient) SetOnUnhealthy(onUnhealthy func()) {
 }
 
 func (c *SEtcdClient) OnKeepaliveFailure() {
+	nicRecord := c.recordNic()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(c.timeout))
 	defer cancel()
 	err := c.cli.RestartSessionWithContext(ctx)
@@ -99,10 +103,59 @@ func (c *SEtcdClient) OnKeepaliveFailure() {
 		}
 	}
 	log.Errorf("keep etcd lease failed: %s", err)
-	if c.onUnhealthy != nil {
-		c.onUnhealthy()
+
+	if c.networkAvailable(nicRecord) {
+		// may be etcd not work
+		c.Reconnect()
+	} else {
+		if c.onUnhealthy != nil {
+			c.onUnhealthy()
+		}
 	}
-	go c.Reconnect()
+}
+
+func (c *SEtcdClient) recordNic() map[string]int {
+	nicRecord := make(map[string]int)
+	for _, n := range options.HostOptions.Networks {
+		data := strings.Split(n, "/")
+		interf := data[0]
+		rx, err := fileutils2.FileGetContents(
+			fmt.Sprintf("/sys/class/net/%s/statistics/rx_bytes", interf),
+		)
+		if err != nil {
+			log.Errorf("failed get nic rx %s  statistics %s", interf, err)
+			continue
+		}
+		tx, err := fileutils2.FileGetContents(
+			fmt.Sprintf("/sys/class/net/%s/statistics/tx_bytes", interf),
+		)
+		if err != nil {
+			log.Errorf("failed get nic tx %s  statistics %s", interf, err)
+			continue
+		}
+		irx, _ := strconv.Atoi(rx)
+		itx, _ := strconv.Atoi(tx)
+		nicRecord[interf] = irx + itx
+	}
+	return nicRecord
+}
+
+func (c *SEtcdClient) networkAvailable(oldRecord map[string]int) bool {
+	newRecord := c.recordNic()
+	for _, n := range options.HostOptions.Networks {
+		oldR, ok := oldRecord[n]
+		if !ok {
+			continue
+		}
+		newR, ok := newRecord[n]
+		if !ok {
+			log.Errorf("nic %s record not found", n)
+		}
+		if newR != oldR {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *SEtcdClient) Reconnect() {

--- a/pkg/hostman/host_health/health_manager.go
+++ b/pkg/hostman/host_health/health_manager.go
@@ -78,11 +78,12 @@ func (m *SHostHealthManager) StartHealthCheck() error {
 }
 
 func (m *SHostHealthManager) OnUnhealth() {
-	log.Debugf("Host unhealthy, going to shotdown servers")
 	m.status = UNHEALTHY
 	if m.onHostDown == SHUTDOWN_SERVERS {
+		log.Errorf("Host unhealthy, going to shotdown servers")
 		m.shutdownServers()
 	}
+	m.cli.Reconnect()
 	utils.DumpAllGoroutineStack(log.Logger().Out)
 	os.Exit(1)
 }
@@ -93,7 +94,7 @@ func (m *SHostHealthManager) SetOnHostDown(onHostDown string) {
 
 // shutdown servers used shared storage
 func (m *SHostHealthManager) shutdownServers() {
-	types.HealthCheckReactor.ShutdownSharedStorageServers()
+	types.HealthCheckReactor.ShutdownServers()
 }
 
 func (m *SHostHealthManager) Stop() error {
@@ -111,5 +112,6 @@ func SetOnHostDown(onHostDown string) error {
 type Client interface {
 	StartHostHealthCheck(context.Context) error
 	SetOnUnhealthy(func())
+	Reconnect()
 	Stop() error
 }

--- a/pkg/hostman/hosthandler/handler.go
+++ b/pkg/hostman/hosthandler/handler.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/hostman/host_health"
 	"yunion.io/x/onecloud/pkg/hostman/hostinfo"
+	"yunion.io/x/onecloud/pkg/hostman/hostinfo/hostconsts"
 	"yunion.io/x/onecloud/pkg/hostman/hostutils"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 )
@@ -52,7 +53,7 @@ func AddHostHandler(prefix string, app *appsrv.Application) {
 }
 
 func setOnHostDown(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	if err := host_health.SetOnHostDown(host_health.SHUTDOWN_SERVERS); err != nil {
+	if err := host_health.SetOnHostDown(hostconsts.SHUTDOWN_SERVERS); err != nil {
 		hostutils.Response(ctx, w, err)
 		return
 	}

--- a/pkg/hostman/hostinfo/hostconsts/hostconsts.go
+++ b/pkg/hostman/hostinfo/hostconsts/hostconsts.go
@@ -25,4 +25,6 @@ const (
 	TELEGRAF_TAG_ONECLOUD_RES_TYPE             = "host"
 	TELEGRAF_TAG_ONECLOUD_HOST_TYPE_HOST       = "host"
 	TELEGRAF_TAG_ONECLOUD_HOST_TYPE_CONTROLLER = "controller"
+
+	SHUTDOWN_SERVERS = "shutdown-servers"
 )

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1220,7 +1220,10 @@ func (h *SHostInfo) onUpdateHostInfoSucc(hostbody jsonutils.JSONObject) {
 		h.onFail(err)
 		return
 	}
-	h.onHostDown, _ = hostbody.GetString("metadata", "__on_host_down")
+	if jsonutils.QueryBoolean(hostbody, "auto_migrate_on_host_down", false) {
+		h.onHostDown = hostconsts.SHUTDOWN_SERVERS
+	}
+	log.Infof("on host down %s", h.onHostDown)
 
 	memReservedMb, _ := hostbody.Int("mem_reserved")
 	if options.HostOptions.HugepagesOption == "native" && memReservedMb > int64(h.getReservedMemMb()) {


### PR DESCRIPTION
This patch fix source servers not shutdown on network unreachable.
Restart etcd session add timeout, and shutdown servers add force
option incase host stuck on scriptStop.

Signed-off-by: wanyaoqi <wanyaoqi@yunion.cn>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
