### PR TITLE
Automated cherry pick of #14505: fix: imageinfo.OsInfo empty

### DIFF
--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -1694,6 +1694,11 @@ func (image *SImage) updateImageInfo(
 	userCred mcclient.TokenCredential,
 	imageInfo *deployapi.ImageInfo,
 ) error {
+	if imageInfo.OsInfo == nil {
+		log.Warningln("imageInfo.OsInfo is empty!")
+		return nil
+	}
+
 	db.Update(image, func() error {
 		image.OsArch = imageInfo.OsInfo.Arch
 		return nil


### PR DESCRIPTION
Cherry pick of #14505 on release/3.9.

#14505: fix: imageinfo.OsInfo empty