### PR TITLE
fix: imageinfo.OsInfo empty for 3.8

### DIFF
--- a/pkg/image/tasks/image_probe_task.go
+++ b/pkg/image/tasks/image_probe_task.go
@@ -165,6 +165,10 @@ func (self *ImageProbeTask) updateImageMetadata(
 }
 
 func (self *ImageProbeTask) updateImageInfo(ctx context.Context, image *models.SImage, imageInfo *deployapi.ImageInfo) {
+	if imageInfo.OsInfo == nil {
+		log.Warningln("image info.OsInfo is empty")
+		return
+	}
 	imageProperties := jsonutils.Marshal(imageInfo.OsInfo).(*jsonutils.JSONDict)
 	if len(imageInfo.OsInfo.Arch) > 0 {
 		imageProperties.Set(api.IMAGE_OS_ARCH, jsonutils.NewString(imageInfo.OsInfo.Arch))


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: imageinfo.OsInfo empty for 3.8

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi 