### PR TITLE
host_health: auto migrate on host shutdown

### DIFF
--- a/pkg/compute/models/host_health.go
+++ b/pkg/compute/models/host_health.go
@@ -100,7 +100,12 @@ func (h *SHostHealthChecker) startWatcher(ctx context.Context, hostId string) {
 	if _, ok := h.hc[hostId]; !ok {
 		h.hc[hostId] = ch
 	}
-	h.cli.Watch(ctx, key, h.onHostOnline(ctx, hostId), h.onHostOffline(ctx, hostId), h.onHostOfflineDeleted(ctx, hostId))
+	h.cli.Watch(
+		ctx, key,
+		h.onHostOnline(ctx, hostId),
+		h.onHostOffline(ctx, hostId),
+		h.onHostOfflineDeleted(ctx, hostId),
+	)
 }
 
 func (h *SHostHealthChecker) onHostUnhealthy(ctx context.Context, hostId string) {
@@ -135,12 +140,14 @@ func (h *SHostHealthChecker) processHostOffline(ctx context.Context, hostId stri
 
 func (h *SHostHealthChecker) onHostOffline(ctx context.Context, hostId string) etcd.TEtcdModifyEventFunc {
 	return func(ctx context.Context, key, oldvalue, value []byte) {
+		log.Errorf("watch host key modified %s %s %s", key, oldvalue, value)
 		h.processHostOffline(ctx, hostId)
 	}
 }
 
 func (h *SHostHealthChecker) onHostOfflineDeleted(ctx context.Context, hostId string) etcd.TEtcdDeleteEventFunc {
 	return func(ctx context.Context, key []byte) {
+		log.Errorf("watch host key deleled %s", key)
 		h.processHostOffline(ctx, hostId)
 	}
 }

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -25,6 +25,9 @@ import (
 	"strings"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
@@ -57,6 +60,7 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient/modules/scheduler"
 	"yunion.io/x/onecloud/pkg/multicloud/esxi"
 	"yunion.io/x/onecloud/pkg/util/httputils"
+	"yunion.io/x/onecloud/pkg/util/k8s/tokens"
 	"yunion.io/x/onecloud/pkg/util/logclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
@@ -3938,9 +3942,6 @@ func (self *SHost) PerformOffline(ctx context.Context, userCred mcclient.TokenCr
 		if err != nil {
 			return nil, err
 		}
-		if hostHealthChecker != nil {
-			hostHealthChecker.UnwatchHost(context.Background(), self.Id)
-		}
 		db.OpsLog.LogEvent(self, db.ACT_OFFLINE, input.Reason, userCred)
 		logclient.AddActionLogWithContext(ctx, self, logclient.ACT_OFFLINE, input, userCred, true)
 		ndata := jsonutils.Marshal(self).(*jsonutils.JSONDict)
@@ -5445,7 +5446,38 @@ func (host *SHost) PerformHostMaintenance(ctx context.Context, userCred mcclient
 }
 
 func (host *SHost) OnHostDown(ctx context.Context, userCred mcclient.TokenCredential) {
-	log.Errorf("watched host down %s", host.Id)
+	log.Errorf("watched host down %s, status %s", host.Name, host.HostStatus)
+	hostHealthChecker.UnwatchHost(ctx, host.Id)
+
+	hostname := host.Name
+	if host.HostStatus == api.HOST_OFFLINE {
+		// host has been marked offline, check host status in k8s
+		coreCli, err := tokens.GetCoreClient()
+		if err != nil {
+			log.Errorf("failed get k8s client %s", err)
+			return
+		}
+		accessIp := strings.Replace(host.AccessIp, ".", "-", -1)
+		if strings.HasSuffix(host.Name, "-"+accessIp) {
+			hostname = hostname[0 : len(hostname)-len(accessIp)-1]
+		}
+		node, err := coreCli.Nodes().Get(context.TODO(), hostname, metav1.GetOptions{})
+		if err != nil {
+			log.Errorf("failed get node %s info %s", hostname, err)
+			return
+		}
+
+		// check node status is ready
+		if length := len(node.Status.Conditions); length > 0 {
+			if node.Status.Conditions[length-1].Type == v1.NodeReady &&
+				node.Status.Conditions[length-1].Status == v1.ConditionTrue {
+				log.Infof("node %s status ready, no need entry rescue", hostname)
+				return
+			}
+		}
+	}
+
+	log.Errorf("host %s down, try rescue guests", hostname)
 	db.OpsLog.LogEvent(host, db.ACT_HOST_DOWN, "", userCred)
 	if _, err := host.SaveCleanUpdates(func() error {
 		host.EnableHealthCheck = false

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -335,9 +335,10 @@ func (m *SGuestManager) ShutdownServers() {
 		log.Infof("Start shutdown server %s", guest.GetName())
 
 		// scriptStop maybe stuck on guest storage offline
-		if !guest.forceStop() {
+		if !guest.forceScriptStop() {
 			log.Errorf("shutdown server %s failed", guest.GetName())
 		}
+		guest.Monitor.Disconnect()
 		return true
 	})
 }

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -1295,7 +1295,7 @@ func (s *SKVMGuestInstance) scriptStop() bool {
 	return true
 }
 
-func (s *SKVMGuestInstance) forceStop() bool {
+func (s *SKVMGuestInstance) forceScriptStop() bool {
 	_, err := procutils.NewRemoteCommandAsFarAsPossible("bash", s.GetStopScriptPath(), "--force").Output()
 	if err != nil {
 		log.Errorln(err)

--- a/pkg/hostman/host_health/health_manager.go
+++ b/pkg/hostman/host_health/health_manager.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/hostman/guestman/types"
+	"yunion.io/x/onecloud/pkg/hostman/hostinfo/hostconsts"
 	"yunion.io/x/onecloud/pkg/hostman/options"
 )
 
@@ -41,11 +42,9 @@ type SHostHealthManager struct {
 	onHostDown string
 }
 
-const SHUTDOWN_SERVERS = "shutdown-servers"
-
 var (
 	manager         *SHostHealthManager
-	HostDownActions = []string{SHUTDOWN_SERVERS}
+	HostDownActions = []string{hostconsts.SHUTDOWN_SERVERS}
 )
 
 func InitHostHealthManager(hostId, onHostDown string) (*SHostHealthManager, error) {
@@ -79,7 +78,7 @@ func (m *SHostHealthManager) StartHealthCheck() error {
 
 func (m *SHostHealthManager) OnUnhealth() {
 	m.status = UNHEALTHY
-	if m.onHostDown == SHUTDOWN_SERVERS {
+	if m.onHostDown == hostconsts.SHUTDOWN_SERVERS {
 		log.Errorf("Host unhealthy, going to shotdown servers")
 		m.shutdownServers()
 	}

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1308,7 +1308,6 @@ func (h *SHostInfo) PutHostOnline() error {
 		if err != nil {
 			log.Fatalf("Init host health manager failed %s", err)
 		}
-		data.Set("update_health_status", jsonutils.JSONTrue)
 	}
 
 	_, err := modules.Hosts.PerformAction(

--- a/pkg/hostman/hostinfo/hostpinger.go
+++ b/pkg/hostman/hostinfo/hostpinger.go
@@ -128,10 +128,10 @@ func (p *SHostPingTask) ping(div int, hostId string) error {
 			return errors.Wrap(err, "ping")
 		}
 	} else {
-		name, err := res.GetString("name")
-		if err != nil {
-			Instance().setHostname(name)
-		}
+		// name, err := res.GetString("name")
+		// if err != nil {
+		// 	Instance().setHostname(name)
+		// }
 		catalog, err := res.Get("catalog")
 		if err == nil {
 			cl := make(mcclient.KeystoneServiceCatalogV3, 0)


### PR DESCRIPTION
Before this patch, host guests will not migrate on host manual shutdown.
This patch from k8s node status check host still on line, if node status
not ready, region will migrate guests on host.

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
