### PR TITLE
fix: upgrade go version to 1.16 for build docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   check:
     docker:
-      - image: yunionio/centos-build:1.1-4
+      - image: yunion/centos-build:1.1-6
         environment:
           ONECLOUD_CI_BUILD: "1"
     working_directory: /root/go/src/yunion.io/x/onecloud
@@ -18,7 +18,7 @@ jobs:
     requires:
       - check
     docker:
-      - image: yunionio/centos-build:1.1-4
+      - image: yunion/centos-build:1.1-6
         environment:
           ONECLOUD_CI_BUILD: "1"
 
@@ -38,7 +38,7 @@ jobs:
           command: |
             targets="$(circleci tests glob "cmd/*" | grep -v cmd/host-image | circleci tests split)"
             echo $targets | tr ' ' '\n'
-            make -j2 $targets
+            make $targets
             ls -lh _output/bin/
       - save_cache:
           key: onecloud-build-cache-{{ checksum "go.mod" }}-{{ checksum "Makefile" }}
@@ -51,7 +51,7 @@ jobs:
     requires:
       - check
     docker:
-      - image: yunionio/centos-build:1.1-4
+      - image: yunion/centos-build:1.1-6
         environment:
           ONECLOUD_CI_BUILD: "1"
     working_directory: /root/go/src/yunion.io/x/onecloud

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.16
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/Makefile.common.mk
+++ b/Makefile.common.mk
@@ -7,8 +7,8 @@ endif
 ModBaseName:=$(notdir $(ModName))
 
 DockerImageRegistry?=registry.cn-beijing.aliyuncs.com
-DockerImageAlpineBuild?=$(DockerImageRegistry)/yunionio/alpine-build:1.1-5
-DockerImageCentOSBuild?=$(DockerImageRegistry)/yunionio/centos-build:1.1-5
+DockerImageAlpineBuild?=$(DockerImageRegistry)/yunionio/alpine-build:1.1-6
+DockerImageCentOSBuild?=$(DockerImageRegistry)/yunionio/centos-build:1.1-6
 
 
 EnvIf=$(if $($(1)),$(1)=$($(1)))


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: update go version to 1.16 for build docker images

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 