### PR TITLE
Automated cherry pick of #14551: fix: preserve aws root account name

### DIFF
--- a/pkg/multicloud/aws/organizations.go
+++ b/pkg/multicloud/aws/organizations.go
@@ -249,7 +249,7 @@ func (self *SAwsClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 				subAccount.HealthStatus = api.CLOUD_PROVIDER_HEALTH_SUSPENDED
 			}
 			if account.IsMaster {
-				subAccount.Name = self.cpcfg.Name
+				subAccount.Name = fmt.Sprintf("%s/%s", account.Name, self.cpcfg.Name)
 				subAccount.Account = self.accessKey
 			} else {
 				if isRootAccount {


### PR DESCRIPTION
Cherry pick of #14551 on release/3.9.

#14551: fix: preserve aws root account name