### PR TITLE
feat(region,host): refector guests cgroups

### DIFF
--- a/cmd/climc/shell/compute/hosts.go
+++ b/cmd/climc/shell/compute/hosts.go
@@ -59,6 +59,8 @@ func init() {
 	cmd.BatchPerform("sync-config", &options.BaseIdsOptions{})
 	cmd.BatchPerform("prepare", &options.BaseIdsOptions{})
 	cmd.BatchPerform("ipmi-probe", &options.BaseIdsOptions{})
+	cmd.BatchPerform("reserve-cpus", &compute.HostReserveCpusOptions{})
+	cmd.BatchPerform("unreserve-cpus", &options.BaseIdsOptions{})
 
 	cmd.Get("ipmi", &options.BaseIdOptions{})
 	cmd.Get("vnc", &options.BaseIdOptions{})

--- a/pkg/apis/compute/host.go
+++ b/pkg/apis/compute/host.go
@@ -477,3 +477,9 @@ type SHostPingInput struct {
 
 	StorageStats []SHostStorageStat `json:"storage_stats"`
 }
+
+type HostReserveCpusInput struct {
+	Cpus                    string
+	Mems                    string
+	DisableSchedLoadBalance *bool `json:disable_sched_load_balance`
+}

--- a/pkg/apis/compute/host_const.go
+++ b/pkg/apis/compute/host_const.go
@@ -142,3 +142,7 @@ const (
 	HOST_HEALTH_STATUS_RUNNING = "running"
 	HOST_HEALTH_LOCK_PREFIX    = "host-health"
 )
+
+const (
+	HOSTMETA_RESERVED_CPUS_INFO = "reserved_cpus_info"
+)

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -40,7 +40,6 @@ import (
 	"yunion.io/x/onecloud/pkg/apis"
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
-	hostapi "yunion.io/x/onecloud/pkg/apis/host"
 	imageapi "yunion.io/x/onecloud/pkg/apis/image"
 	noapi "yunion.io/x/onecloud/pkg/apis/notify"
 	schedapi "yunion.io/x/onecloud/pkg/apis/scheduler"
@@ -5471,44 +5470,18 @@ func (self *SGuest) PerformProbeIsolatedDevices(ctx context.Context, userCred mc
 	return jsonutils.Marshal(devs), nil
 }
 
-func (self *SGuest) getHostLogicalCores() ([]int, error) {
+func (self *SGuest) PerformCpuset(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data *api.ServerCPUSetInput) (jsonutils.JSONObject, error) {
 	host, err := self.GetHost()
 	if err != nil {
 		return nil, errors.Wrap(err, "get host model")
 	}
-	topoObj, err := host.SysInfo.Get("topology")
-	if err != nil {
-		return nil, errors.Wrap(err, "get topology from host sys_info")
-	}
-
-	hostTopo := new(hostapi.HostTopology)
-	if err := topoObj.Unmarshal(hostTopo); err != nil {
-		return nil, errors.Wrap(err, "Unmarshal host topology struct")
-	}
-
-	// get host logical cores
-	allCores := []int{}
-	for _, node := range hostTopo.Nodes {
-		for _, cores := range node.Cores {
-			allCores = append(allCores, cores.LogicalProcessors...)
-		}
-	}
-	return allCores, nil
-}
-
-func (self *SGuest) PerformCpuset(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data *api.ServerCPUSetInput) (jsonutils.JSONObject, error) {
-	allCores, err := self.getHostLogicalCores()
+	allCores, err := host.getHostLogicalCores()
 	if err != nil {
 		return nil, err
 	}
 
 	if !sets.NewInt(allCores...).HasAll(data.CPUS...) {
 		return nil, httperrors.NewInputParameterError("Host cores %v not contains input %v", allCores, data.CPUS)
-	}
-
-	host, err := self.GetHost()
-	if err != nil {
-		return nil, err
 	}
 
 	pinnedMap, err := host.GetPinnedCpusetCores(ctx, userCred)
@@ -5580,12 +5553,16 @@ func (self *SGuest) getPinnedCpusetCores(ctx context.Context, userCred mcclient.
 }
 
 func (self *SGuest) GetDetailsCpusetCores(ctx context.Context, userCred mcclient.TokenCredential, input *api.ServerGetCPUSetCoresInput) (*api.ServerGetCPUSetCoresResp, error) {
-	allCores, err := self.getHostLogicalCores()
+	host, err := self.GetHost()
 	if err != nil {
 		return nil, err
 	}
 
-	host, _ := self.GetHost()
+	allCores, err := host.getHostLogicalCores()
+	if err != nil {
+		return nil, err
+	}
+
 	usedMap, err := host.GetPinnedCpusetCores(ctx, userCred)
 	if err != nil {
 		return nil, err

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -95,7 +95,7 @@ func NewGuestManager(host hostutils.IHost, serversPath string) *SGuestManager {
 	manager.UnknownServers = new(sync.Map)
 	manager.ServersLock = &sync.Mutex{}
 	manager.GuestStartWorker = appsrv.NewWorkerManager("GuestStart", 1, appsrv.DEFAULT_BACKLOG, false)
-	manager.StartCpusetBalancer()
+	// manager.StartCpusetBalancer()
 	manager.LoadExistingGuests()
 	manager.host.StartDHCPServer()
 	manager.dirtyServersChan = make(chan struct{})

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -44,6 +44,7 @@ import (
 	"yunion.io/x/onecloud/pkg/hostman/hostdeployer/deployclient"
 	"yunion.io/x/onecloud/pkg/hostman/hostinfo"
 	"yunion.io/x/onecloud/pkg/hostman/hostinfo/hostbridge"
+	"yunion.io/x/onecloud/pkg/hostman/hostinfo/hostconsts"
 	"yunion.io/x/onecloud/pkg/hostman/hostutils"
 	"yunion.io/x/onecloud/pkg/hostman/monitor"
 	"yunion.io/x/onecloud/pkg/hostman/options"
@@ -75,7 +76,9 @@ const (
 type SKVMGuestInstance struct {
 	Id string
 
+	// TODO: add struct cgroup info
 	cgroupPid   int
+	cgroupName  string
 	QemuVersion string
 	VncPassword string
 
@@ -856,9 +859,10 @@ func (s *SKVMGuestInstance) clearCgroup(pid int) {
 	if pid == 0 && s.cgroupPid > 0 {
 		pid = s.cgroupPid
 	}
-	log.Infof("cgroup destroy %d", pid)
+	cgrupName := s.GetCgroupName()
+	log.Infof("cgroup destroy %d %s", pid, cgrupName)
 	if pid > 0 && !options.HostOptions.DisableSetCgroup {
-		cgrouputils.CgroupDestroy(strconv.Itoa(pid))
+		cgrouputils.CgroupDestroy(strconv.Itoa(pid), cgrupName)
 	}
 }
 
@@ -1194,7 +1198,7 @@ func (s *SKVMGuestInstance) ExitCleanup(clear bool) {
 }
 
 func (s *SKVMGuestInstance) CleanupCpuset() {
-	task := cgrouputils.NewCGroupCPUSetTask(strconv.Itoa(s.GetPid()), 0, "")
+	task := cgrouputils.NewCGroupCPUSetTask(strconv.Itoa(s.GetPid()), s.GetCgroupName(), 0, "")
 	if !task.RemoveTask() {
 		log.Warningf("remove cpuset cgroup error: %s, pid: %d", s.Id, s.GetPid())
 	}
@@ -1645,11 +1649,27 @@ func (s *SKVMGuestInstance) getStorageDeviceId() string {
 	return ""
 }
 
+func (s *SKVMGuestInstance) GetCgroupName() string {
+	if s.cgroupPid == 0 {
+		return ""
+	}
+
+	meta, _ := s.Desc.Get("metadata")
+	if jsonutils.QueryBoolean(meta, "__enable_cgroup_cpuset", false) {
+		return fmt.Sprintf("%s/server_%s_%d", hostconsts.HOST_CGROUP, s.Id, s.cgroupPid)
+	}
+	return ""
+}
+
 func (s *SKVMGuestInstance) SetCgroup() {
 	s.cgroupPid = s.GetPid()
 	s.setCgroupIo()
 	s.setCgroupCpu()
 	s.setCgroupCPUSet()
+}
+
+func (s *SKVMGuestInstance) setCgroupPid() {
+	s.cgroupPid = s.GetPid()
 }
 
 func (s *SKVMGuestInstance) setCgroupIo() {
@@ -1666,7 +1686,9 @@ func (s *SKVMGuestInstance) setCgroupIo() {
 		params["blkio.throttle.write_bps_device"] = options.HostOptions.DefaultWriteBpsPerCpu
 		params["blkio.throttle.write_iops_device"] = options.HostOptions.DefaultWriteIopsPerCpu
 		cpu, _ := s.Desc.Int("cpu")
-		cgrouputils.CgroupIoHardlimitSet(strconv.Itoa(s.cgroupPid), int(cpu), params, devId)
+		cgrouputils.CgroupIoHardlimitSet(
+			strconv.Itoa(s.cgroupPid), s.GetCgroupName(), int(cpu), params, devId,
+		)
 	}
 }
 
@@ -1676,27 +1698,18 @@ func (s *SKVMGuestInstance) setCgroupCpu() {
 		cpuWeight = 1024
 	)
 
-	cgrouputils.CgroupSet(strconv.Itoa(s.cgroupPid), int(cpu)*cpuWeight)
+	cgrouputils.CgroupSet(strconv.Itoa(s.cgroupPid), s.GetCgroupName(), int(cpu)*cpuWeight)
 }
 
 func (s *SKVMGuestInstance) setCgroupCPUSet() {
-	meta, _ := s.Desc.Get("metadata")
-	if meta == nil {
-		return
-	}
-	cpusetStr, _ := meta.GetString(api.VM_METADATA_CGROUP_CPUSET)
-	if len(cpusetStr) == 0 {
-		return
-	}
-	obj, err := jsonutils.ParseString(cpusetStr)
-	if err != nil {
-		log.Errorf("Parse cpusetStr %q error: %v", cpusetStr, err)
-		return
-	}
-	input := new(api.ServerCPUSetInput)
-	if err := obj.Unmarshal(input); err != nil {
-		log.Errorf("Unmarshal %q to ServerCPUSetInput: %v", obj, err)
-		return
+	var input *api.ServerCPUSetInput
+	if s.Desc.Contains("metadata", api.VM_METADATA_CGROUP_CPUSET) {
+		input = new(api.ServerCPUSetInput)
+		err := s.Desc.Unmarshal(s.Desc, "metadata", api.VM_METADATA_CGROUP_CPUSET)
+		if err != nil {
+			log.Errorf("Unmarshal %s to ServerCPUSetInput failed: %s", api.VM_METADATA_CGROUP_CPUSET, err)
+			return
+		}
 	}
 	if _, err := s.CPUSet(context.Background(), input); err != nil {
 		log.Errorf("Do CPUSet error: %v", err)
@@ -1804,6 +1817,7 @@ func (s *SKVMGuestInstance) OnResumeSyncMetadataInfo() {
 	meta := jsonutils.NewDict()
 	meta.Set("__qemu_version", jsonutils.NewString(s.GetQemuVersionStr()))
 	meta.Set("__vnc_port", jsonutils.NewInt(int64(s.GetVncPort())))
+	meta.Set("__enable_cgroup_cpuset", jsonutils.JSONTrue)
 	meta.Set("hotplug_cpu_mem", jsonutils.NewString("enable"))
 	meta.Set("hot_remove_nic", jsonutils.NewString("enable"))
 	if len(s.VncPassword) > 0 {
@@ -1812,6 +1826,7 @@ func (s *SKVMGuestInstance) OnResumeSyncMetadataInfo() {
 	if options.HostOptions.HugepagesOption == "native" {
 		meta.Set("__hugepage", jsonutils.NewString("native"))
 	}
+	// not exactly
 	if !options.HostOptions.HostCpuPassthrough || s.getOsname() == OS_NAME_MACOS {
 		meta.Set("__cpu_mode", jsonutils.NewString(api.CPU_MODE_QEMU))
 	} else {
@@ -1827,6 +1842,27 @@ func (s *SKVMGuestInstance) OnResumeSyncMetadataInfo() {
 		meta.Update(s.syncMeta)
 	}
 	s.SyncMetadata(meta)
+}
+
+func (s *SKVMGuestInstance) doBlockIoThrottle() {
+	disks, _ := s.Desc.GetArray("disks")
+	if len(disks) > 0 {
+		bps, _ := disks[0].Int("bps")
+		iops, _ := disks[0].Int("iops")
+		if bps > 0 || iops > 0 {
+			s.BlockIoThrottle(context.Background(), bps, iops)
+		}
+	}
+}
+
+func (s *SKVMGuestInstance) onGuestPrelaunch() {
+	if options.HostOptions.SetVncPassword {
+		s.SetVncPassword()
+	}
+	s.OnResumeSyncMetadataInfo()
+	s.SetCgroup()
+	s.optimizeOom()
+	s.doBlockIoThrottle()
 }
 
 func (s *SKVMGuestInstance) CleanImportMetadata() *jsonutils.JSONDict {
@@ -2166,11 +2202,19 @@ func (s *SKVMGuestInstance) CPUSet(ctx context.Context, input *api.ServerCPUSetI
 	if !s.IsRunning() {
 		return nil, nil
 	}
-	cpus := []string{}
-	for _, id := range input.CPUS {
-		cpus = append(cpus, fmt.Sprintf("%d", id))
+
+	var cpusetStr string
+	if input != nil {
+		cpus := []string{}
+		for _, id := range input.CPUS {
+			cpus = append(cpus, fmt.Sprintf("%d", id))
+		}
+		cpusetStr = strings.Join(cpus, ",")
 	}
-	task := cgrouputils.NewCGroupCPUSetTask(strconv.Itoa(s.GetPid()), 0, strings.Join(cpus, ","))
+
+	task := cgrouputils.NewCGroupCPUSetTask(
+		strconv.Itoa(s.GetPid()), s.GetCgroupName(), 0, cpusetStr,
+	)
 	if !task.SetTask() {
 		return nil, errors.Errorf("Cgroup cpuset task failed")
 	}
@@ -2190,7 +2234,9 @@ func (s *SKVMGuestInstance) CPUSetRemove(ctx context.Context) error {
 	if !s.IsRunning() {
 		return nil
 	}
-	task := cgrouputils.NewCGroupCPUSetTask(strconv.Itoa(s.GetPid()), 0, "")
+	task := cgrouputils.NewCGroupCPUSetTask(
+		strconv.Itoa(s.GetPid()), s.GetCgroupName(), 0, "",
+	)
 	if !task.RemoveTask() {
 		return errors.Errorf("Remove task error happened, please lookup host log")
 	}

--- a/pkg/hostman/guestman/qemu/generate.go
+++ b/pkg/hostman/guestman/qemu/generate.go
@@ -102,7 +102,7 @@ func GenerateStartOptions(
 		return "", errors.Wrap(err, "Get CPU option")
 	}
 
-	opts = append(opts, cpuOpt)
+	opts = append(opts, drvOpt.FreezeCPU(), cpuOpt)
 
 	if input.EnableLog {
 		opts = append(opts, drvOpt.Log(input.EnableLog, input.LogPath))

--- a/pkg/hostman/guestman/qemu/qemu.go
+++ b/pkg/hostman/guestman/qemu/qemu.go
@@ -82,6 +82,7 @@ type QemuOptions interface {
 	CPU(opt CPUOption, osName string) (string, string, error)
 	Log(enable bool, qemuLogPath string) string
 	RTC() string
+	FreezeCPU() string
 	Daemonize() string
 	Nodefaults() string
 	Nodefconfig() string
@@ -203,6 +204,10 @@ func (o baseOptions) RTC() string {
 
 func (o baseOptions) Daemonize() string {
 	return "-daemonize"
+}
+
+func (o baseOptions) FreezeCPU() string {
+	return "-S"
 }
 
 func (o baseOptions) Nodefaults() string {

--- a/pkg/hostman/hostinfo/hostconsts/hostconsts.go
+++ b/pkg/hostman/hostinfo/hostconsts/hostconsts.go
@@ -27,4 +27,7 @@ const (
 	TELEGRAF_TAG_ONECLOUD_HOST_TYPE_CONTROLLER = "controller"
 
 	SHUTDOWN_SERVERS = "shutdown-servers"
+
+	HOST_CGROUP          = "cloudpods.hostagent"
+	HOST_RESERVED_CPUSET = "cloudpods.hostagent.reserved"
 )

--- a/pkg/hostman/monitor/hmp.go
+++ b/pkg/hostman/monitor/hmp.go
@@ -193,18 +193,6 @@ func (m *HmpMonitor) QueryStatus(callback StringCallback) {
 	m.Query("info status", m.parseStatus(callback))
 }
 
-func (m *HmpMonitor) parseStatus(callback StringCallback) StringCallback {
-	return func(output string) {
-		strs := strings.Split(strings.TrimSuffix(output, "\r\n"), "\r\n")
-		for _, str := range strs {
-			if strings.HasPrefix(str, "VM status:") {
-				callback(strings.TrimSpace(str[len("VM status:"):]))
-				return
-			}
-		}
-	}
-}
-
 func (m *HmpMonitor) SimpleCommand(cmd string, callback StringCallback) {
 	m.Query(cmd, callback)
 }

--- a/pkg/hostman/monitor/monitor.go
+++ b/pkg/hostman/monitor/monitor.go
@@ -291,6 +291,20 @@ func (m *SBaseMonitor) checkWriting() bool {
 	return true
 }
 
+func (m *SBaseMonitor) parseStatus(callback StringCallback) StringCallback {
+	return func(output string) {
+		strs := strings.Split(output, "\r\n")
+		for _, str := range strs {
+			if strings.HasPrefix(str, "VM status:") {
+				callback(strings.TrimSpace(
+					strings.Trim(str[len("VM status:"):], "\\r\\n"),
+				))
+				return
+			}
+		}
+	}
+}
+
 func getSaveStatefileUri(stateFilePath string) string {
 	if strings.HasSuffix(stateFilePath, ".gz") {
 		return fmt.Sprintf("exec:gzip -c > %s", stateFilePath)

--- a/pkg/hostman/monitor/qmp.go
+++ b/pkg/hostman/monitor/qmp.go
@@ -368,30 +368,29 @@ func (m *QmpMonitor) HumanMonitorCommand(cmd string, callback StringCallback) {
 }
 
 func (m *QmpMonitor) QueryStatus(callback StringCallback) {
-	cmd := &Command{Execute: "query-status"}
-	m.Query(cmd, m.parseStatus(callback))
+	m.HumanMonitorCommand("info status", m.parseStatus(callback))
 }
 
-func (m *QmpMonitor) parseStatus(callback StringCallback) qmpMonitorCallBack {
-	return func(res *Response) {
-		if res.ErrorVal != nil {
-			callback("unknown")
-			return
-		}
-		var val map[string]interface{}
-		err := json.Unmarshal(res.Return, &val)
-		if err != nil {
-			callback("unknown")
-			return
-		}
-		if status, ok := val["status"]; !ok {
-			callback("unknown")
-		} else {
-			str, _ := status.(string)
-			callback(str)
-		}
-	}
-}
+// func (m *QmpMonitor) parseStatus(callback StringCallback) qmpMonitorCallBack {
+// 	return func(res *Response) {
+// 		if res.ErrorVal != nil {
+// 			callback("unknown")
+// 			return
+// 		}
+// 		var val map[string]interface{}
+// 		err := json.Unmarshal(res.Return, &val)
+// 		if err != nil {
+// 			callback("unknown")
+// 			return
+// 		}
+// 		if status, ok := val["status"]; !ok {
+// 			callback("unknown")
+// 		} else {
+// 			str, _ := status.(string)
+// 			callback(str)
+// 		}
+// 	}
+// }
 
 // If get version error, callback with empty string
 func (m *QmpMonitor) GetVersion(callback StringCallback) {

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -111,7 +111,7 @@ type SHostOptions struct {
 	SetVncPassword         bool `default:"true" help:"Auto set vnc password after monitor connected"`
 	UseBootVga             bool `default:"false" help:"Use boot VGA GPU for guest"`
 
-	EnableCpuBinding         bool `default:"true" help:"Enable cpu binding and rebalance"`
+	EnableCpuBinding         bool `default:"false" help:"Enable cpu binding and rebalance"`
 	EnableOpenflowController bool `default:"false"`
 
 	PingRegionInterval int      `default:"60" help:"interval to ping region, deefault is 1 minute"`

--- a/pkg/mcclient/options/compute/host.go
+++ b/pkg/mcclient/options/compute/host.go
@@ -85,6 +85,17 @@ func (opts *HostListOptions) Params() (jsonutils.JSONObject, error) {
 	return params, nil
 }
 
+type HostReserveCpusOptions struct {
+	options.BaseIdsOptions
+	Cpus                    string
+	Mems                    string
+	DisableSchedLoadBalance bool
+}
+
+func (o *HostReserveCpusOptions) Params() (jsonutils.JSONObject, error) {
+	return options.StructToParams(o)
+}
+
 type HostStatusStatisticsOptions struct {
 	HostListOptions
 	options.StatusStatisticsOptions

--- a/pkg/util/cgrouputils/cpuset/cpuset.go
+++ b/pkg/util/cgrouputils/cpuset/cpuset.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpuset
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Builder is a mutable builder for CPUSet. Functions that mutate instances
+// of this type are not thread-safe.
+type Builder struct {
+	result CPUSet
+	done   bool
+}
+
+// NewBuilder returns a mutable CPUSet builder.
+func NewBuilder() *Builder {
+	return &Builder{
+		result: CPUSet{
+			elems: map[int]struct{}{},
+		},
+	}
+}
+
+// Add adds the supplied elements to the result. Calling Add after calling
+// Result has no effect.
+func (b *Builder) Add(elems ...int) {
+	if b.done {
+		return
+	}
+	for _, elem := range elems {
+		b.result.elems[elem] = struct{}{}
+	}
+}
+
+// Result returns the result CPUSet containing all elements that were
+// previously added to this builder. Subsequent calls to Add have no effect.
+func (b *Builder) Result() CPUSet {
+	b.done = true
+	return b.result
+}
+
+// CPUSet is a thread-safe, immutable set-like data structure for CPU IDs.
+type CPUSet struct {
+	elems map[int]struct{}
+}
+
+// NewCPUSet returns a new CPUSet containing the supplied elements.
+func NewCPUSet(cpus ...int) CPUSet {
+	b := NewBuilder()
+	for _, c := range cpus {
+		b.Add(c)
+	}
+	return b.Result()
+}
+
+// NewCPUSetInt64 returns a new CPUSet containing the supplied elements, as slice of int64.
+func NewCPUSetInt64(cpus ...int64) CPUSet {
+	b := NewBuilder()
+	for _, c := range cpus {
+		b.Add(int(c))
+	}
+	return b.Result()
+}
+
+// Size returns the number of elements in this set.
+func (s CPUSet) Size() int {
+	return len(s.elems)
+}
+
+// IsEmpty returns true if there are zero elements in this set.
+func (s CPUSet) IsEmpty() bool {
+	return s.Size() == 0
+}
+
+// Contains returns true if the supplied element is present in this set.
+func (s CPUSet) Contains(cpu int) bool {
+	_, found := s.elems[cpu]
+	return found
+}
+
+// Equals returns true if the supplied set contains exactly the same elements
+// as this set (s IsSubsetOf s2 and s2 IsSubsetOf s).
+func (s CPUSet) Equals(s2 CPUSet) bool {
+	return reflect.DeepEqual(s.elems, s2.elems)
+}
+
+// Filter returns a new CPU set that contains all of the elements from this
+// set that match the supplied predicate, without mutating the source set.
+func (s CPUSet) Filter(predicate func(int) bool) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		if predicate(cpu) {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// FilterNot returns a new CPU set that contains all of the elements from this
+// set that do not match the supplied predicate, without mutating the source
+// set.
+func (s CPUSet) FilterNot(predicate func(int) bool) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		if !predicate(cpu) {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// IsSubsetOf returns true if the supplied set contains all the elements
+func (s CPUSet) IsSubsetOf(s2 CPUSet) bool {
+	result := true
+	for cpu := range s.elems {
+		if !s2.Contains(cpu) {
+			result = false
+			break
+		}
+	}
+	return result
+}
+
+// Union returns a new CPU set that contains all of the elements from this
+// set and all of the elements from the supplied set, without mutating
+// either source set.
+func (s CPUSet) Union(s2 CPUSet) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		b.Add(cpu)
+	}
+	for cpu := range s2.elems {
+		b.Add(cpu)
+	}
+	return b.Result()
+}
+
+// UnionAll returns a new CPU set that contains all of the elements from this
+// set and all of the elements from the supplied sets, without mutating
+// either source set.
+func (s CPUSet) UnionAll(s2 []CPUSet) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		b.Add(cpu)
+	}
+	for _, cs := range s2 {
+		for cpu := range cs.elems {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// Intersection returns a new CPU set that contains all of the elements
+// that are present in both this set and the supplied set, without mutating
+// either source set.
+func (s CPUSet) Intersection(s2 CPUSet) CPUSet {
+	return s.Filter(func(cpu int) bool { return s2.Contains(cpu) })
+}
+
+// Difference returns a new CPU set that contains all of the elements that
+// are present in this set and not the supplied set, without mutating either
+// source set.
+func (s CPUSet) Difference(s2 CPUSet) CPUSet {
+	return s.FilterNot(func(cpu int) bool { return s2.Contains(cpu) })
+}
+
+// ToSlice returns a slice of integers that contains all elements from
+// this set.
+func (s CPUSet) ToSlice() []int {
+	result := []int{}
+	for cpu := range s.elems {
+		result = append(result, cpu)
+	}
+	sort.Ints(result)
+	return result
+}
+
+// ToSliceNoSort returns a slice of integers that contains all elements from
+// this set.
+func (s CPUSet) ToSliceNoSort() []int {
+	result := []int{}
+	for cpu := range s.elems {
+		result = append(result, cpu)
+	}
+	return result
+}
+
+// ToSliceInt64 returns an ordered slice of int64 that contains all elements from
+// this set
+func (s CPUSet) ToSliceInt64() []int64 {
+	var result []int64
+	for cpu := range s.elems {
+		result = append(result, int64(cpu))
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	return result
+}
+
+// ToSliceNoSortInt64 returns a slice of int64 that contains all elements from
+// this set.
+func (s CPUSet) ToSliceNoSortInt64() []int64 {
+	var result []int64
+	for cpu := range s.elems {
+		result = append(result, int64(cpu))
+	}
+	return result
+}
+
+// String returns a new string representation of the elements in this CPU set
+// in canonical linux CPU list format.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func (s CPUSet) String() string {
+	if s.IsEmpty() {
+		return ""
+	}
+
+	elems := s.ToSlice()
+
+	type rng struct {
+		start int
+		end   int
+	}
+
+	ranges := []rng{{elems[0], elems[0]}}
+
+	for i := 1; i < len(elems); i++ {
+		lastRange := &ranges[len(ranges)-1]
+		// if this element is adjacent to the high end of the last range
+		if elems[i] == lastRange.end+1 {
+			// then extend the last range to include this element
+			lastRange.end = elems[i]
+			continue
+		}
+		// otherwise, start a new range beginning with this element
+		ranges = append(ranges, rng{elems[i], elems[i]})
+	}
+
+	// construct string from ranges
+	var result bytes.Buffer
+	for _, r := range ranges {
+		if r.start == r.end {
+			result.WriteString(strconv.Itoa(r.start))
+		} else {
+			result.WriteString(fmt.Sprintf("%d-%d", r.start, r.end))
+		}
+		result.WriteString(",")
+	}
+	return strings.TrimRight(result.String(), ",")
+}
+
+// Parse CPUSet constructs a new CPU set from a Linux CPU list formatted string.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func Parse(s string) (CPUSet, error) {
+	b := NewBuilder()
+
+	// Handle empty string.
+	if s == "" {
+		return b.Result(), nil
+	}
+
+	// Split CPU list string:
+	// "0-5,34,46-48" => ["0-5", "34", "46-48"]
+	ranges := strings.Split(s, ",")
+
+	for _, r := range ranges {
+		boundaries := strings.SplitN(r, "-", 2)
+		if len(boundaries) == 1 {
+			// Handle ranges that consist of only one element like "34".
+			elem, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			b.Add(elem)
+		} else if len(boundaries) == 2 {
+			// Handle multi-element ranges like "0-5".
+			start, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			end, err := strconv.Atoi(boundaries[1])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			if start > end {
+				return NewCPUSet(), fmt.Errorf("invalid range %q (%d >= %d)", r, start, end)
+			}
+			// start == end is acceptable (1-1 -> 1)
+
+			// Add all elements to the result.
+			// e.g. "0-5", "46-48" => [0, 1, 2, 3, 4, 5, 46, 47, 48].
+			for e := start; e <= end; e++ {
+				b.Add(e)
+			}
+		}
+	}
+	return b.Result(), nil
+}
+
+// Clone returns a copy of this CPU set.
+func (s CPUSet) Clone() CPUSet {
+	b := NewBuilder()
+	for elem := range s.elems {
+		b.Add(elem)
+	}
+	return b.Result()
+}

--- a/pkg/util/cgrouputils/cpuset/doc.go
+++ b/pkg/util/cgrouputils/cpuset/doc.go
@@ -12,22 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cgrouputils
-
-import (
-	"bufio"
-	"fmt"
-	"os"
-	"strings"
-	"testing"
-)
-
-func TestCgroupSet(t *testing.T) {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Enter pid: ")
-	pid, _ := reader.ReadString('\n')
-	pid = strings.TrimSpace(pid)
-	t.Logf("Start %s cgroup set", pid)
-	CgroupSet(pid, "", 1)
-	CgroupCleanAll()
-}
+package cpuset // import "yunion.io/x/onecloud/pkg/util/cgrouputils/cpuset"

--- a/pkg/util/cgrouputils/cpusetutils.go
+++ b/pkg/util/cgrouputils/cpusetutils.go
@@ -95,7 +95,7 @@ func CommitProcessCpuset(proc *ProcessCPUinfo, idx int) {
 	cpu, _ := GetSystemCpu()
 	sets := cpu.GetCpuset(idx)
 	if len(sets) > 0 {
-		cpuset := NewCGroupCPUSetTask(strconv.Itoa(proc.Pid), 0, sets)
+		cpuset := NewCGroupCPUSetTask(strconv.Itoa(proc.Pid), "", 0, sets)
 		cpuset.SetTask()
 	}
 }

--- a/pkg/util/cgrouputils/cpuutils.go
+++ b/pkg/util/cgrouputils/cpuutils.go
@@ -231,7 +231,7 @@ func NewProcessCPUinfo(pid int) (*ProcessCPUinfo, error) {
 	cpuinfo.Pid = pid
 	spid := strconv.Itoa(pid)
 
-	cpuTask := NewCGroupCPUTask(spid, 0)
+	cpuTask := NewCGroupCPUTask(spid, "", 0)
 	if cpuTask.taskIsExist() {
 		share := cpuTask.GetParam("cpu.shares")
 		ishare, err := strconv.ParseFloat(share, 64)
@@ -243,7 +243,7 @@ func NewProcessCPUinfo(pid int) (*ProcessCPUinfo, error) {
 		}
 	}
 
-	cpusetTask := NewCGroupCPUSetTask(fmt.Sprintf("%d", pid), 0, "")
+	cpusetTask := NewCGroupCPUSetTask(fmt.Sprintf("%d", pid), "", 0, "")
 	if cpusetTask.taskIsExist() {
 		cpuset := cpusetTask.GetParam("cpuset.cpus")
 		if len(cpuset) > 0 {


### PR DESCRIPTION
hostagent will create a root group cloudpods.hostagent at init.
guests group under cloudpods.hostagent. Qemu start params add '-S'
option freeze guest at first, after guest set cgroup or other initialize
hostagent will resume guest.

host support reserve cpus. if has reserved cpus, hostagent will create a
group cloudpods.hostagent.reserved, one thing to note is set host
reserved cpus must ensure host no guests running.

climc usage:
  climc host-reserve-cpus --cpus '2-3,32-33' --mems '0-1' \
    --disable-sched-load-balance <IDS>

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
