### PR TITLE
fix: remote duplicate enable_remote_executor option

### DIFF
--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -155,9 +155,9 @@ type SHostOptions struct {
 	OvnEipBridge              string `help:"name of bridge for eip traffic management" default:"$HOST_OVN_EIP_BRIDGE|breip"`
 	OvnUnderlayMtu            int    `help:"mtu of ovn underlay network" default:"1500"`
 
-	EnableRemoteExecutor bool `help:"Enable remote executor" default:"false"`
-	HostHealthTimeout    int  `help:"host health timeout" default:"30"`
-	HostLeaseTimeout     int  `help:"lease timeout" default:"10"`
+	// EnableRemoteExecutor bool `help:"Enable remote executor" default:"false"`
+	HostHealthTimeout int `help:"host health timeout" default:"30"`
+	HostLeaseTimeout  int `help:"lease timeout" default:"10"`
 
 	SyncStorageInfoDurationSecond int  `help:"sync storage size duration, unit is second, default is every 2 minutes" default:"120"`
 	StartHostIgnoreSysError       bool `help:"start host agent ignore sys error" default:"false"`


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: : remove duplicate enable_remote_executor option
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi 