### PR TITLE
Automated cherry pick of #14603: fix: recover opslog roles definition

### DIFF
--- a/pkg/cloudcommon/db/opslog.go
+++ b/pkg/cloudcommon/db/opslog.go
@@ -65,12 +65,7 @@ type SOpsLog struct {
 	User     string `width:"128" charset:"utf8" list:"user" create:"required"`
 	DomainId string `width:"128" charset:"ascii" list:"user" create:"optional"`
 	Domain   string `width:"128" charset:"utf8" list:"user" create:"optional"`
-
-	// Deprecated
-	// swager:ignore
-	RolesOld string `name:"roles" width:"64" charset:"ascii" list:"user" create:"optional"`
-
-	Roles string `name:"roles2" width:"64" charset:"utf8" list:"user" create:"optional"`
+	Roles    string `width:"64" charset:"utf8" list:"user" create:"optional"`
 
 	OpsTime time.Time `nullable:"false" list:"user" clickhouse_ttl:"6m"`
 


### PR DESCRIPTION
Cherry pick of #14603 on release/3.9.

#14603: fix: recover opslog roles definition