### PR TITLE
Automated cherry pick of #14680: fix(keystone): mobile typo

### DIFF
--- a/pkg/apis/identity/input.go
+++ b/pkg/apis/identity/input.go
@@ -465,7 +465,7 @@ type UserCreateInput struct {
 
 	Email string `json:"email"`
 
-	Mobile string `json:"mobule"`
+	Mobile string `json:"mobile"`
 
 	Displayname string `json:"displayname"`
 


### PR DESCRIPTION
Cherry pick of #14680 on release/3.8.

#14680: fix(keystone): mobile typo