### PR TITLE
fix: choose host storage without considering storage capacity

### DIFF
--- a/pkg/compute/guestdrivers/virtualization.go
+++ b/pkg/compute/guestdrivers/virtualization.go
@@ -202,14 +202,19 @@ func (self *SVirtualizedGuestDriver) ChooseHostStorage(host *models.SHost, guest
 	if err != nil {
 		return nil, errors.Wrapf(err, "fetch storages by ids: %v", storageIds)
 	}
-	// try to find mediumType matched storage
-	for _, s := range ss {
-		tmp := s
-		if s.MediumType == diskConfig.Medium {
-			return &tmp, nil
+	var candidates []models.SStorage
+	if len(diskConfig.Medium) > 0 {
+		// try to find mediumType matched storage
+		for i := range ss {
+			if ss[i].MediumType == diskConfig.Medium {
+				candidates = append(candidates, ss[i])
+			}
+		}
+		if len(candidates) == 0 {
+			candidates = ss
 		}
 	}
-	return &ss[0], nil
+	return models.ChooseLeastUsedStorage(candidates, ""), nil
 }
 
 func (self *SVirtualizedGuestDriver) RequestGuestCreateInsertIso(ctx context.Context, imageId string, guest *models.SGuest, task taskman.ITask) error {

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1433,7 +1433,7 @@ func _getLeastUsedStorage(storages []SStorage, backends []string) *SStorage {
 	return best
 }
 
-func getLeastUsedStorage(storages []SStorage, backend string) *SStorage {
+func ChooseLeastUsedStorage(storages []SStorage, backend string) *SStorage {
 	var backends []string
 	if backend == api.STORAGE_LOCAL {
 		backends = []string{api.STORAGE_NAS, api.STORAGE_LOCAL}
@@ -1448,7 +1448,7 @@ func getLeastUsedStorage(storages []SStorage, backend string) *SStorage {
 func (self *SHost) GetLeastUsedStorage(backend string) *SStorage {
 	storages := self.GetAttachedEnabledHostStorages(nil)
 	if storages != nil {
-		return getLeastUsedStorage(storages, backend)
+		return ChooseLeastUsedStorage(storages, backend)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: 选择宿主机存储的时候，会总是选择host的第一个存储，忽视存储的有效空间

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 