### PR TITLE
fix: climc detach disk ignore keep_disk param

### DIFF
--- a/cmd/climc/shell/compute/serverdisks.go
+++ b/cmd/climc/shell/compute/serverdisks.go
@@ -156,7 +156,9 @@ func init() {
 		params := jsonutils.NewDict()
 		params.Add(jsonutils.NewString(args.DISK), "disk_id")
 		if args.DeleteDisk {
-			params.Add(jsonutils.NewInt(0), "keep_disk")
+			params.Add(jsonutils.JSONFalse, "keep_disk")
+		} else {
+			params.Add(jsonutils.JSONTrue, "keep_disk")
 		}
 		srv, err := modules.Servers.PerformAction(s, args.SERVER, "detachdisk", params)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: climc detach disk ignore keep_disk param
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 