### PR TITLE
Automated cherry pick of #14737: fix: climc detach disk ignore keep_disk param

### DIFF
--- a/cmd/climc/shell/compute/serverdisks.go
+++ b/cmd/climc/shell/compute/serverdisks.go
@@ -156,7 +156,9 @@ func init() {
 		params := jsonutils.NewDict()
 		params.Add(jsonutils.NewString(args.DISK), "disk_id")
 		if args.DeleteDisk {
-			params.Add(jsonutils.NewInt(0), "keep_disk")
+			params.Add(jsonutils.JSONFalse, "keep_disk")
+		} else {
+			params.Add(jsonutils.JSONTrue, "keep_disk")
 		}
 		srv, err := modules.Servers.PerformAction(s, args.SERVER, "detachdisk", params)
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #14737 on release/3.8.

#14737: fix: climc detach disk ignore keep_disk param