### PR TITLE
fix(region,host): mount fusefs on guest start

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -722,6 +722,15 @@ func (self *SDisk) StartDiskCreateTask(ctx context.Context, userCred mcclient.To
 	return nil
 }
 
+func (self *SDisk) GetSnapshotFuseUrl() (string, error) {
+	snapObj, err := SnapshotManager.FetchById(self.SnapshotId)
+	if err != nil {
+		return "", errors.Wrapf(err, "SnapshotManager.FetchById(%s)", self.SnapshotId)
+	}
+	snapshot := snapObj.(*SSnapshot)
+	return snapshot.GetFuseUrl()
+}
+
 func (self *SDisk) GetSnapshotCount() (int, error) {
 	q := SnapshotManager.Query()
 	return q.Filter(sqlchemy.AND(sqlchemy.Equals(q.Field("disk_id"), self.Id),

--- a/pkg/compute/models/guestdisks.go
+++ b/pkg/compute/models/guestdisks.go
@@ -211,6 +211,13 @@ func (self *SGuestdisk) GetJsonDescAtHost(ctx context.Context, host *SHost) *api
 		if needMerge == "true" {
 			desc.MergeSnapshot = true
 		}
+		if desc.MergeSnapshot {
+			if url, err := disk.GetSnapshotFuseUrl(); err != nil {
+				log.Errorf("failed get snapshot fuse url: %s", err)
+			} else {
+				desc.Url = url
+			}
+		}
 	}
 	if fpath := disk.GetMetadata(ctx, api.DISK_META_ESXI_FLAT_FILE_PATH, nil); len(fpath) > 0 {
 		desc.MergeSnapshot = true

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -490,6 +490,22 @@ func (self *SSnapshot) GetHost() (*SHost, error) {
 	return storage.GetMasterHost()
 }
 
+func (self *SSnapshot) GetFuseUrl() (string, error) {
+	iStorage, err := StorageManager.FetchById(self.StorageId)
+	if err != nil {
+		return "", errors.Wrapf(err, "StorageManager.FetchById(%s)", self.StorageId)
+	}
+	storage := iStorage.(*SStorage)
+	if storage.StorageType != api.STORAGE_LOCAL {
+		return "", nil
+	}
+	host, err := storage.GetMasterHost()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/snapshots/%s/%s", host.GetFetchUrl(true), self.DiskId, self.Id), nil
+}
+
 func (self *SSnapshotManager) AddRefCount(snapshotId string, count int) {
 	iSnapshot, _ := self.FetchById(snapshotId)
 	if iSnapshot != nil {

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -746,13 +746,14 @@ func (m *SGuestManager) GuestStart(ctx context.Context, userCred mcclient.TokenC
 			guest.SaveDesc(guestDesc)
 		}
 		if guest.IsStopped() {
-			data := struct {
-				Params *jsonutils.JSONDict
-			}{
-				Params: jsonutils.NewDict(),
+			data, err := body.Get("params")
+			if err != nil {
+				data = jsonutils.NewDict()
 			}
-			body.Unmarshal(&data)
-			guest.StartGuest(ctx, userCred, data.Params)
+			err = guest.StartGuest(ctx, userCred, data.(*jsonutils.JSONDict))
+			if err != nil {
+				return nil, err
+			}
 			res := jsonutils.NewDict()
 			res.Set("vnc_port", jsonutils.NewInt(0))
 			return res, nil

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -234,7 +234,9 @@ func (s *SKVMGuestInstance) generateStartScript(data *jsonutils.JSONDict) (strin
 
 	if data.Contains("encrypt_key") {
 		key, _ := data.GetString("encrypt_key")
-		s.saveEncryptKeyFile(key)
+		if err := s.saveEncryptKeyFile(key); err != nil {
+			return "", errors.Wrap(err, "save encrypt key file")
+		}
 		input.EncryptKeyPath = s.getEncryptKeyPath()
 	}
 

--- a/pkg/hostman/storageman/disk_base.go
+++ b/pkg/hostman/storageman/disk_base.go
@@ -44,6 +44,7 @@ type IDisk interface {
 	GetSnapshotLocation() string
 	OnRebuildRoot(ctx context.Context, params api.DiskAllocateInput) error
 	DoDeleteSnapshot(snapshotId string) error
+	GetStorage() IStorage
 
 	DeleteAllSnapshot(skipRecycle bool) error
 	DiskSnapshot(ctx context.Context, params interface{}) (jsonutils.JSONObject, error)
@@ -88,6 +89,10 @@ func NewBaseDisk(storage IStorage, id string) *SBaseDisk {
 
 func (d *SBaseDisk) GetId() string {
 	return d.Id
+}
+
+func (d *SBaseDisk) GetStorage() IStorage {
+	return d.Storage
 }
 
 func (d *SBaseDisk) GetPath() string {


### PR DESCRIPTION
In case of host shutdown, fusefs will not mount on host reboot.
Add check and mount fusefs on guest start.

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
