### PR TITLE
fix(region): use virtio replace ide on diskattach

### DIFF
--- a/pkg/apis/compute/disk_const.go
+++ b/pkg/apis/compute/disk_const.go
@@ -65,3 +65,11 @@ const (
 )
 
 const DISK_META_EXISTING_PATH = "disk_existing_path"
+
+const (
+	DISK_DRIVER_VIRTIO = "virtio"
+	DISK_DRIVER_SCSI   = "scsi"
+	DISK_DRIVER_PVSCSI = "pvscsi"
+	DISK_DRIVER_IDE    = "ide"
+	DISK_DRIVER_SATA   = "sata"
+)

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -3376,7 +3376,12 @@ func (self *SGuest) attach2Disk(ctx context.Context, disk *SDisk, userCred mccli
 		// depends the last disk of this guest
 		existingDisks, _ := self.GetGuestDisks()
 		if len(existingDisks) > 0 {
-			driver = existingDisks[len(existingDisks)-1].Driver
+			prevDisk := existingDisks[len(existingDisks)-1]
+			if prevDisk.Driver == api.DISK_DRIVER_IDE {
+				driver = api.DISK_DRIVER_VIRTIO
+			} else {
+				driver = prevDisk.Driver
+			}
 		} else {
 			osProf := self.GetOSProfile()
 			driver = osProf.DiskDriver


### PR DESCRIPTION
If disk driver not assign, default use previous disk driver.
Bus windows server can't recognize hot attached 'ide' disk,
use 'virtio' replace 'ide' driver on diskattach.

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.8
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
