### PR TITLE
Automated cherry pick of #14753: fix(region): use virtio replace ide on diskattach

### DIFF
--- a/pkg/apis/compute/disk_const.go
+++ b/pkg/apis/compute/disk_const.go
@@ -65,3 +65,11 @@ const (
 )
 
 const DISK_META_EXISTING_PATH = "disk_existing_path"
+
+const (
+	DISK_DRIVER_VIRTIO = "virtio"
+	DISK_DRIVER_SCSI   = "scsi"
+	DISK_DRIVER_PVSCSI = "pvscsi"
+	DISK_DRIVER_IDE    = "ide"
+	DISK_DRIVER_SATA   = "sata"
+)

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -3376,7 +3376,12 @@ func (self *SGuest) attach2Disk(ctx context.Context, disk *SDisk, userCred mccli
 		// depends the last disk of this guest
 		existingDisks, _ := self.GetGuestDisks()
 		if len(existingDisks) > 0 {
-			driver = existingDisks[len(existingDisks)-1].Driver
+			prevDisk := existingDisks[len(existingDisks)-1]
+			if prevDisk.Driver == api.DISK_DRIVER_IDE {
+				driver = api.DISK_DRIVER_VIRTIO
+			} else {
+				driver = prevDisk.Driver
+			}
 		} else {
 			osProf := self.GetOSProfile()
 			driver = osProf.DiskDriver


### PR DESCRIPTION
Cherry pick of #14753 on release/3.9.

#14753: fix(region): use virtio replace ide on diskattach