### PR TITLE
fix(host): uefi boot firmwaire use pflash options

### DIFF
--- a/pkg/hostman/guestman/qemu/generate.go
+++ b/pkg/hostman/guestman/qemu/generate.go
@@ -151,7 +151,11 @@ func GenerateStartOptions(
 		if input.OVMFPath == "" {
 			return "", errors.Errorf("input OVMF path is empty")
 		}
-		opts = append(opts, drvOpt.BIOS(input.OVMFPath))
+		fmOpt, err := drvOpt.BIOS(input.OVMFPath, input.HomeDir)
+		if err != nil {
+			return "", errors.Wrap(err, "bios option")
+		}
+		opts = append(opts, fmOpt)
 	}
 
 	if input.OsName == OS_NAME_MACOS {


### PR DESCRIPTION
option '-bios OVMF.fd' accidental hang on uefi boot.

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.8
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
