### PR TITLE
fix(cloudmon): allow disable ping probe at 3.8

### DIFF
--- a/pkg/cloudmon/collectors/common/multiCloudMonUtils.go
+++ b/pkg/cloudmon/collectors/common/multiCloudMonUtils.go
@@ -90,6 +90,8 @@ type PingProbeOptions struct {
 	Debug         bool `help:"debug"`
 	ProbeCount    int  `help:"probe count, default is 3" default:"3"`
 	TimeoutSecond int  `help:"probe timeout in second, default is 1 second" default:"1"`
+
+	DisablePingProbe bool `help:"disable ping probe"`
 }
 
 var InstanceProviders = "Aliyun,Azure,Aws,Qcloud,VMWare,Huawei,Openstack,Ucloud,ZStack"

--- a/pkg/cloudmon/collectors/pinger.go
+++ b/pkg/cloudmon/collectors/pinger.go
@@ -34,6 +34,9 @@ import (
 )
 
 func pingProbeCoolector(s *mcclient.ClientSession, args *common.ReportOptions) error {
+	if args.DisablePingProbe {
+		return nil
+	}
 	isRoot := sysutils.IsRootPermission()
 	if !isRoot {
 		return errors.Error("require root permissions")


### PR DESCRIPTION
**What this PR does / why we need it**:
fix(cloudmon): allow disable ping probe at 3.8

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 