### PR TITLE
feat(region,host): custom usb controller type

### DIFF
--- a/cmd/climc/shell/compute/servers.go
+++ b/cmd/climc/shell/compute/servers.go
@@ -685,10 +685,11 @@ func init() {
 	})
 
 	type ServerQemuParams struct {
-		ID               string `help:"ID or name of VM"`
-		DisableIsaSerial string `help:"disable isa serial device" choices:"true|false"`
-		DisablePvpanic   string `help:"disable pvpanic device" choices:"true|false"`
-		DisableUsbKbd    string `help:"disable usb kbd" choices:"true|false"`
+		ID                string `help:"ID or name of VM"`
+		DisableIsaSerial  string `help:"disable isa serial device" choices:"true|false"`
+		DisablePvpanic    string `help:"disable pvpanic device" choices:"true|false"`
+		DisableUsbKbd     string `help:"disable usb kbd" choices:"true|false"`
+		UsbControllerType string `help:"usb controller type" choices:"usb-ehci|qemu-xhci"`
 	}
 
 	R(&ServerQemuParams{}, "server-set-qemu-params", "config qemu params", func(s *mcclient.ClientSession,
@@ -702,6 +703,9 @@ func init() {
 		}
 		if len(opts.DisableUsbKbd) > 0 {
 			params.Set("disable_usb_kbd", jsonutils.NewString(opts.DisableUsbKbd))
+		}
+		if len(opts.UsbControllerType) > 0 {
+			params.Set("usb_controller_type", jsonutils.NewString(opts.UsbControllerType))
 		}
 		result, err := modules.Servers.PerformAction(s, opts.ID, "set-qemu-params", params)
 		if err != nil {

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -3249,6 +3249,13 @@ func (self *SGuest) PerformSetQemuParams(ctx context.Context, userCred mcclient.
 			return nil, err
 		}
 	}
+	usbContType, err := data.GetString("usb_controller_type")
+	if err == nil {
+		err = self.SetMetadata(ctx, "usb_controller_type", usbContType, userCred)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return nil, nil
 }
 

--- a/pkg/hostman/guestman/pci.go
+++ b/pkg/hostman/guestman/pci.go
@@ -200,12 +200,15 @@ func (s *SKVMGuestInstance) initRandomDevice(pciRoot *desc.PCIController) {
 }
 
 func (s *SKVMGuestInstance) initUsbController(pciRoot *desc.PCIController) {
+	contType := s.getUsbControllerType()
 	s.Desc.Usb = &desc.UsbController{
-		PCIDevice: desc.NewPCIDevice(pciRoot.CType, " qemu-xhci", "usb"),
+		PCIDevice: desc.NewPCIDevice(pciRoot.CType, contType, "usb"),
 	}
-	s.Desc.Usb.Options = map[string]string{
-		"p2": "8", // usb2 port count
-		"p3": "8", // usb3 port count
+	if contType == "qemu-xhci" {
+		s.Desc.Usb.Options = map[string]string{
+			"p2": "8", // usb2 port count
+			"p3": "8", // usb3 port count
+		}
 	}
 }
 

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -99,6 +99,15 @@ func (s *SKVMGuestInstance) setPcieExtendBus() {
 	s.Desc.Metadata["__pcie_extend_bus"] = "true"
 }
 
+func (s *SKVMGuestInstance) getUsbControllerType() string {
+	usbContType := s.Desc.Metadata["usb_controller_type"]
+	if usbContType == "usb-ehci" {
+		return usbContType
+	} else {
+		return "qemu-xhci"
+	}
+}
+
 // is windows prioer to windows server 2003
 func (s *SKVMGuestInstance) isOldWindows() bool {
 	if s.getOsname() == OS_NAME_WINDOWS {


### PR DESCRIPTION
support usb controller type: qemu-xhci, usb-ehci.
qemu-xhci is much more virtualization-friendly when compared to EHCI and UHCI.
but guest supports XHCI which should be the case for any operating system
released around 2010 or later.
So sometimes wo need use usb controller type EHCI.

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.9
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
