### PR TITLE
fix: policy cache get/set with atomic ops

### DIFF
--- a/pkg/cloudcommon/policy/policy.go
+++ b/pkg/cloudcommon/policy/policy.go
@@ -239,14 +239,14 @@ type policyTask struct {
 }
 
 func (t *policyTask) Run() {
-	val := t.manager.policyCache.Get(t.key)
+	val := t.manager.policyCache.AtomicGet(t.key)
 	result := fetchResult{}
 	if gotypes.IsNil(val) {
 		pg, err := DefaultPolicyFetcher(context.Background(), t.userCred)
 		if err != nil {
 			result.err = errors.Wrap(err, "DefaultPolicyFetcher")
 		} else {
-			t.manager.policyCache.Set(t.key, pg)
+			t.manager.policyCache.AtomicSet(t.key, pg)
 			result.output = pg
 		}
 	} else {
@@ -297,7 +297,7 @@ func (manager *SPolicyManager) allow(scope rbacutils.TRbacScope, userCred mcclie
 		policySet = rbacutils.TPolicySet{}
 	}
 	result := manager.allowWithoutCache(policySet, scope, userCred, service, resource, action, extra...)
-	manager.permissionCache.Set(key, result)
+	manager.permissionCache.AtomicSet(key, result)
 	return result
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: policy cache get/set with atomic ops

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8
- release/3.7

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito @wanyaoqi 