### PR TITLE
fix(cloudmon): qcloud redis metric

### DIFF
--- a/pkg/multicloud/qcloud/monitor.go
+++ b/pkg/multicloud/qcloud/monitor.go
@@ -213,7 +213,7 @@ func (self *SQcloudClient) GetRedisMetrics(opts *cloudprovider.MetricListOptions
 			"OutFlowMin": "",
 		},
 		cloudprovider.REDIS_METRIC_TYPE_USED_CONN: {
-			"ConnectionsUsMin": "",
+			"ConnectionsMin": "",
 		},
 		cloudprovider.REDIS_METRIC_TYPE_OPT_SES: {
 			"QpsMin": "",


### PR DESCRIPTION
**What this PR does / why we need it**:


- [ ] Smoke testing completed


If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.9

/area cloudmon
/cc @zexi 
