### PR TITLE
Automated cherry pick of #14901: fix(cloudmon): qcloud redis metric

### DIFF
--- a/pkg/multicloud/qcloud/monitor.go
+++ b/pkg/multicloud/qcloud/monitor.go
@@ -213,7 +213,7 @@ func (self *SQcloudClient) GetRedisMetrics(opts *cloudprovider.MetricListOptions
 			"OutFlowMin": "",
 		},
 		cloudprovider.REDIS_METRIC_TYPE_USED_CONN: {
-			"ConnectionsUsMin": "",
+			"ConnectionsMin": "",
 		},
 		cloudprovider.REDIS_METRIC_TYPE_OPT_SES: {
 			"QpsMin": "",


### PR DESCRIPTION
Cherry pick of #14901 on release/3.9.

#14901: fix(cloudmon): qcloud redis metric