### PR TITLE
Automated cherry pick of #14933: fix: fail to create ceph disk, missing disk credential

### DIFF
--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -1217,7 +1217,7 @@ func (s *SKVMGuestInstance) DeployFs(ctx context.Context, userCred mcclient.Toke
 		if err != nil {
 			return nil, errors.Wrapf(err, "GetDiskByPath(%s)", diskPath)
 		}
-		diskInfo.Path = diskPath
+		diskInfo.Path = disk.GetPath()
 		return disk.DeployGuestFs(&diskInfo, s.Desc, deployInfo)
 	} else {
 		return nil, fmt.Errorf("Guest dosen't have disk ??")


### PR DESCRIPTION
Cherry pick of #14933 on release/3.9.

#14933: fix: fail to create ceph disk, missing disk credential