### PR TITLE
Automated cherry pick of #14946: fix(region): gpu_models in capabilities' response

### DIFF
--- a/pkg/compute/models/capabilities.go
+++ b/pkg/compute/models/capabilities.go
@@ -743,6 +743,7 @@ func getGPUs(region *SCloudregion, zone *SZone, domainId string) []string {
 	hosts := hostQuery.SubQuery()
 
 	q := devices.Query(devices.Field("model"))
+	q = q.Startswith("dev_type", "GPU")
 	if region != nil {
 		subq := getRegionZoneSubq(region)
 		q = q.Join(hosts, sqlchemy.Equals(devices.Field("host_id"), hosts.Field("id")))


### PR DESCRIPTION
Cherry pick of #14946 on master.

#14946: fix(region): gpu_models in capabilities' response