### PR TITLE
fix(host): generate pci address for guests created

### DIFF
--- a/pkg/hostman/guestman/desc/desc.go
+++ b/pkg/hostman/guestman/desc/desc.go
@@ -20,32 +20,6 @@ import (
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 )
 
-type SGuestProjectDesc struct {
-	Tenant        string
-	TenantId      string
-	DomainId      string
-	ProjectDomain string
-}
-
-type SGuestRegionDesc struct {
-	Zone     string
-	Domain   string
-	HostId   string
-	Hostname string
-}
-
-type SGuestControlDesc struct {
-	IsDaemon bool
-	IsMaster bool
-	IsSlave  bool
-
-	ScalingGroupId     string
-	SecurityRules      string
-	AdminSecurityRules string
-
-	EncryptKeyId string
-}
-
 type SGuestCpu struct {
 	Cpus    uint
 	Sockets uint
@@ -112,6 +86,8 @@ type SGuestHardwareDesc struct {
 
 	Usb            *UsbController   `json:",omitempty"`
 	PCIControllers []*PCIController `json:",omitempty"`
+
+	AnonymousPCIDevs []*PCIDevice `json:",omitempty"`
 }
 
 type SGuestIsaSerial struct {
@@ -294,12 +270,33 @@ type SGuestPvScsi struct {
 	*PCIDevice
 }
 
-type SGuestDesc struct {
-	SGuestProjectDesc
-	SGuestRegionDesc
-	SGuestControlDesc
-	SGuestHardwareDesc
+type SGuestProjectDesc struct {
+	Tenant        string
+	TenantId      string
+	DomainId      string
+	ProjectDomain string
+}
 
+type SGuestRegionDesc struct {
+	Zone     string
+	Domain   string
+	HostId   string
+	Hostname string
+}
+
+type SGuestControlDesc struct {
+	IsDaemon bool
+	IsMaster bool
+	IsSlave  bool
+
+	ScalingGroupId     string
+	SecurityRules      string
+	AdminSecurityRules string
+
+	EncryptKeyId string
+}
+
+type SGuestMetaDesc struct {
 	Name         string
 	Uuid         string
 	OsName       string
@@ -310,4 +307,12 @@ type SGuestDesc struct {
 	UserData     string
 	Metadata     map[string]string
 	ExtraOptions map[string]jsonutils.JSONObject
+}
+
+type SGuestDesc struct {
+	SGuestProjectDesc
+	SGuestRegionDesc
+	SGuestControlDesc
+	SGuestHardwareDesc
+	SGuestMetaDesc
 }

--- a/pkg/hostman/guestman/pci_test.go
+++ b/pkg/hostman/guestman/pci_test.go
@@ -177,7 +177,7 @@ func TestSKVMGuestInstance_initGuestDesc(t *testing.T) {
 
 	//s.initIsolatedDevices(pciRoot, pciBridge)
 	s.initUsbController(pciRoot)
-	s.initRandomDevice(pciRoot)
+	s.initRandomDevice(pciRoot, true)
 	//s.initQgaDesc()
 	s.initPvpanicDesc()
 	s.initIsaSerialDesc()

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -186,10 +186,6 @@ func (s *SKVMGuestInstance) disablePvpanicDev() bool {
 	return s.Desc.Metadata["disable_pvpanic"] == "true"
 }
 
-func (s *SKVMGuestInstance) GetDiskAddr(idx int) int {
-	return qemu.GetDiskAddr(idx, s.IsVdiSpice())
-}
-
 func (s *SKVMGuestInstance) getNicUpScriptPath(nic *desc.SGuestNetwork) string {
 	dev := s.manager.GetHost().GetBridgeDev(nic.Bridge)
 	return path.Join(s.HomeDir(), fmt.Sprintf("if-up-%s-%s.sh", dev.Bridge(), nic.Ifname))
@@ -218,10 +214,6 @@ func (s *SKVMGuestInstance) generateNicScripts(nic *desc.SGuestNetwork) error {
 
 func (s *SKVMGuestInstance) getNicDeviceModel(name string) string {
 	return qemu.GetNicDeviceModel(name)
-}
-
-func (s *SKVMGuestInstance) getNicAddr(index int) int {
-	return qemu.GetNicAddr(index, len(s.Desc.Disks), len(s.Desc.IsolatedDevices), s.IsVdiSpice())
 }
 
 func (s *SKVMGuestInstance) extraOptions() string {

--- a/pkg/hostman/monitor/hmp.go
+++ b/pkg/hostman/monitor/hmp.go
@@ -515,3 +515,7 @@ func (m *HmpMonitor) SaveState(stateFilePath string, callback StringCallback) {
 	cmd := fmt.Sprintf(`migrate -d "%s"`, getSaveStatefileUri(stateFilePath))
 	m.Query(cmd, callback)
 }
+
+func (m *HmpMonitor) QueryPci(callback QueryPciCallback) {
+	go callback(nil, "unsupported query pci for hmp")
+}

--- a/pkg/hostman/monitor/monitor.go
+++ b/pkg/hostman/monitor/monitor.go
@@ -156,6 +156,7 @@ type Monitor interface {
 	GetVersion(StringCallback)
 	GetBlockJobCounts(func(jobs int))
 	GetBlockJobs(func([]BlockJob))
+	QueryPci(callback QueryPciCallback)
 
 	GetCpuCount(func(count int))
 	AddCpu(cpuIndex int, callback StringCallback)

--- a/pkg/hostman/monitor/pci.go
+++ b/pkg/hostman/monitor/pci.go
@@ -1,0 +1,96 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+// PciBridgeInfo -> PCIBridgeInfo (struct)
+
+// PCIBridgeInfo implements the "PciBridgeInfo" QMP API type.
+type PCIBridgeInfo struct {
+	Bus     PCIBusInfo      `json:"bus"`
+	Devices []PCIDeviceInfo `json:"devices,omitempty"`
+}
+
+// PciBusInfo -> PCIBusInfo (struct)
+
+// PCIBusInfo implements the "PciBusInfo" QMP API type.
+type PCIBusInfo struct {
+	Number            int64          `json:"number"`
+	Secondary         int64          `json:"secondary"`
+	Subordinate       int64          `json:"subordinate"`
+	IORange           PCIMemoryRange `json:"io_range"`
+	MemoryRange       PCIMemoryRange `json:"memory_range"`
+	PrefetchableRange PCIMemoryRange `json:"prefetchable_range"`
+}
+
+// PciDeviceClass -> PCIDeviceClass (struct)
+
+// PCIDeviceClass implements the "PciDeviceClass" QMP API type.
+type PCIDeviceClass struct {
+	Desc  *string `json:"desc,omitempty"`
+	Class int64   `json:"class"`
+}
+
+// PciDeviceId -> PCIDeviceID (struct)
+
+// PCIDeviceID implements the "PciDeviceId" QMP API type.
+type PCIDeviceID struct {
+	Device int64 `json:"device"`
+	Vendor int64 `json:"vendor"`
+}
+
+// PciDeviceInfo -> PCIDeviceInfo (struct)
+
+// PCIDeviceInfo implements the "PciDeviceInfo" QMP API type.
+type PCIDeviceInfo struct {
+	Bus       int64             `json:"bus"`
+	Slot      int64             `json:"slot"`
+	Function  int64             `json:"function"`
+	ClassInfo PCIDeviceClass    `json:"class_info"`
+	ID        PCIDeviceID       `json:"id"`
+	Irq       *int64            `json:"irq,omitempty"`
+	QdevID    string            `json:"qdev_id"`
+	PCIBridge *PCIBridgeInfo    `json:"pci_bridge,omitempty"`
+	Regions   []PCIMemoryRegion `json:"regions"`
+}
+
+// PciInfo -> PCIInfo (struct)
+
+// PCIInfo implements the "PciInfo" QMP API type.
+type PCIInfo struct {
+	Bus     int64           `json:"bus"`
+	Devices []PCIDeviceInfo `json:"devices"`
+}
+
+// PciMemoryRange -> PCIMemoryRange (struct)
+
+// PCIMemoryRange implements the "PciMemoryRange" QMP API type.
+type PCIMemoryRange struct {
+	Base  int64 `json:"base"`
+	Limit int64 `json:"limit"`
+}
+
+// PciMemoryRegion -> PCIMemoryRegion (struct)
+
+// PCIMemoryRegion implements the "PciMemoryRegion" QMP API type.
+type PCIMemoryRegion struct {
+	Bar       int64  `json:"bar"`
+	Type      string `json:"type"`
+	Address   int64  `json:"address"`
+	Size      int64  `json:"size"`
+	Prefetch  *bool  `json:"prefetch,omitempty"`
+	MemType64 *bool  `json:"mem_type_64,omitempty"`
+}
+
+type QueryPciCallback func(pciInfoList []PCIInfo, err string)

--- a/pkg/hostman/monitor/qmp.go
+++ b/pkg/hostman/monitor/qmp.go
@@ -1056,3 +1056,25 @@ func (m *QmpMonitor) SaveState(stateFilePath string, callback StringCallback) {
 	)
 	m.Query(cmd, cb)
 }
+
+func (m *QmpMonitor) QueryPci(callback QueryPciCallback) {
+	var (
+		cb = func(res *Response) {
+			if res.ErrorVal != nil {
+				callback(nil, res.ErrorVal.Error())
+			} else {
+				pciInfoList := make([]PCIInfo, 0)
+				err := json.Unmarshal(res.Return, &pciInfoList)
+				if err != nil {
+					callback(nil, err.Error())
+				} else {
+					callback(pciInfoList, "")
+				}
+			}
+		}
+		cmd = &Command{
+			Execute: "query-pci",
+		}
+	)
+	m.Query(cmd, cb)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Generate pci addresses for guests create before structure desc.
Read guest pci info from qmp query-pci command and fill guest
description.
Guest desc add field AnonymousPCIDevs to save unidentified pci devices
address.

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
