### PR TITLE
Automated cherry pick of #14967: fix: set vfs_cache_pressure to 350

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -601,9 +601,11 @@ func (h *SHostInfo) PreventArpFlux() {
 
 // Any system wide optimizations
 // set swappiness=0 to avoid swap
+// set vfs_cache_pressure=300 to avoid stale pagecache
 func (h *SHostInfo) tuneSystem() {
 	kv := map[string]string{
 		"/proc/sys/vm/swappiness":                        "0",
+		"/proc/sys/vm/vfs_cache_pressure":                "350",
 		"/proc/sys/net/ipv4/tcp_mtu_probing":             "2",
 		"/proc/sys/net/ipv4/neigh/default/gc_thresh1":    "1024",
 		"/proc/sys/net/ipv4/neigh/default/gc_thresh2":    "4096",


### PR DESCRIPTION
Cherry pick of #14967 on release/3.7.

#14967: fix: set vfs_cache_pressure to 350