### PR TITLE
Automated cherry pick of #14976: fix(host): no vm_scaling_group_id in hostmetrics

### DIFF
--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -779,7 +779,7 @@ type GuestJsonDesc struct {
 	UserData       string            `json:"user_data"`
 	PendingDeleted bool              `json:"pending_deleted"`
 
-	ScallingGroupId string `json:"scalling_group_id"`
+	ScalingGroupId string `json:"scaling_group_id"`
 
 	// baremetal
 	DiskConfig  jsonutils.JSONObject    `json:"disk_config"`

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4476,7 +4476,7 @@ func (self *SGuest) GetJsonDescAtHypervisor(ctx context.Context, host *SHost) *a
 	// add scaling group
 	sggs, err := ScalingGroupGuestManager.Fetch("", self.Id)
 	if err == nil && len(sggs) > 0 {
-		desc.ScallingGroupId = sggs[0].ScalingGroupId
+		desc.ScalingGroupId = sggs[0].ScalingGroupId
 	}
 
 	return desc

--- a/pkg/hostman/hostmetrics/hostmetrics.go
+++ b/pkg/hostman/hostmetrics/hostmetrics.go
@@ -188,7 +188,7 @@ func (s *SGuestMonitorCollector) GetGuests() map[string]*SGuestMonitor {
 				delete(s.monitors, guestId)
 				gm, err = NewGuestMonitor(guestName, guestId, pid, nicsDesc, int(vcpuCount))
 				if err != nil {
-					log.Errorln(err)
+					log.Errorf("NewGuestMonitor for %s(%s), pid: %d, nics: %s", guestName, guestId, pid, jsonutils.Marshal(nics).String())
 					return true
 				}
 			}


### PR DESCRIPTION
Cherry pick of #14976 on master.

#14976: fix(host): no vm_scaling_group_id in hostmetrics