### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/climc/entry/climc.go
+++ b/cmd/climc/entry/climc.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -177,7 +177,7 @@ func newClientSession(options *BaseOptions) (*mcclient.ClientSession, error) {
 			fileInfo, _ := cacheFile.Stat()
 			dur, err := time.ParseDuration("-24h")
 			if fileInfo != nil && err == nil && fileInfo.ModTime().After(time.Now().Add(dur)) {
-				bytesToken, err := ioutil.ReadAll(cacheFile)
+				bytesToken, err := io.ReadAll(cacheFile)
 				if err == nil {
 					token := client.NewAuthTokenCredential()
 					err := json.Unmarshal(bytesToken, token)

--- a/cmd/climc/promputils/option_arguments.go
+++ b/cmd/climc/promputils/option_arguments.go
@@ -15,8 +15,8 @@
 package promputils
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -70,7 +70,7 @@ func fileCompleter(d prompt.Document) []prompt.Suggest {
 		return cached
 	}
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		log.Print("[ERROR] catch error " + err.Error())
 		return []prompt.Suggest{}

--- a/cmd/climc/shell/compute/keypairs.go
+++ b/cmd/climc/shell/compute/keypairs.go
@@ -16,7 +16,7 @@ package compute
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 
@@ -140,7 +140,7 @@ func init() {
 		params := jsonutils.NewDict()
 		params.Add(jsonutils.NewString(args.NAME), "name")
 		if len(args.PublicKey) > 0 {
-			content, e := ioutil.ReadFile(args.PublicKey)
+			content, e := os.ReadFile(args.PublicKey)
 			if e != nil {
 				params.Add(jsonutils.NewString(args.PublicKey), "public_key")
 			} else {

--- a/cmd/climc/shell/compute/servers.go
+++ b/cmd/climc/shell/compute/servers.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -298,7 +297,7 @@ func init() {
 
 		params := jsonutils.NewDict()
 		if len(opts.Key) > 0 {
-			privateKey, e := ioutil.ReadFile(opts.Key)
+			privateKey, e := os.ReadFile(opts.Key)
 			if e != nil {
 				return e
 			}
@@ -359,7 +358,7 @@ func init() {
 	}
 	R(&ServerUserDataOptions{}, "server-set-user-data", "Update server user_data", func(s *mcclient.ClientSession, args *ServerUserDataOptions) error {
 		params := jsonutils.NewDict()
-		content, err := ioutil.ReadFile(args.FILE)
+		content, err := os.ReadFile(args.FILE)
 		if err != nil {
 			return err
 		}
@@ -449,7 +448,7 @@ func init() {
 		}
 
 		importF := func(desc string) error {
-			ret, err := ioutil.ReadFile(desc)
+			ret, err := os.ReadFile(desc)
 			if err != nil {
 				return fmt.Errorf("Read file %s: %v", desc, err)
 			}
@@ -508,7 +507,7 @@ func init() {
 			err       error
 		)
 
-		rawConfig, err = ioutil.ReadFile(args.CONFIG_FILE)
+		rawConfig, err = os.ReadFile(args.CONFIG_FILE)
 		if err != nil {
 			return fmt.Errorf("Read config file %s error: %s", args.CONFIG_FILE, err)
 		}
@@ -844,7 +843,7 @@ func init() {
 		privateKey := ""
 		params := jsonutils.NewDict()
 		if len(opts.Key) > 0 {
-			key, e := ioutil.ReadFile(opts.Key)
+			key, e := os.ReadFile(opts.Key)
 			if e != nil {
 				return e
 			}

--- a/cmd/climc/shell/identity/policies.go
+++ b/cmd/climc/shell/identity/policies.go
@@ -17,7 +17,7 @@ package identity
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -142,7 +142,7 @@ func init() {
 		ObjectTags  string `help:"object tags"`
 	}
 	R(&PolicyCreateOptions{}, "policy-create", "Create a new policy", func(s *mcclient.ClientSession, args *PolicyCreateOptions) error {
-		policyBytes, err := ioutil.ReadFile(args.FILE)
+		policyBytes, err := os.ReadFile(args.FILE)
 		if err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ func init() {
 		Domain string `help:"domain of the policy"`
 	}
 	R(&PolicyImportOptions{}, "policy-import", "Import a policy", func(s *mcclient.ClientSession, args *PolicyImportOptions) error {
-		cont, err := ioutil.ReadFile(args.FILE)
+		cont, err := os.ReadFile(args.FILE)
 		if err != nil {
 			return err
 		}
@@ -223,7 +223,7 @@ func init() {
 			params.Add(jsonutils.NewString(args.Type), "type")
 		}
 		if len(args.File) > 0 {
-			policyBytes, err := ioutil.ReadFile(args.File)
+			policyBytes, err := os.ReadFile(args.File)
 			if err != nil {
 				return err
 			}

--- a/cmd/climc/shell/k8s/clusters.go
+++ b/cmd/climc/shell/k8s/clusters.go
@@ -16,7 +16,6 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -346,7 +345,7 @@ func initKubeCluster() {
 		writeFile := func(name, content string) error {
 			fp := filepath.Join(args.OUTPUT, name)
 			log.Infof("Write file: %s", fp)
-			if err := ioutil.WriteFile(fp, []byte(content), 0644); err != nil {
+			if err := os.WriteFile(fp, []byte(content), 0644); err != nil {
 				return errors.Wrap(err, "write file")
 			}
 			if err := os.Chmod(fp, 0600); err != nil {

--- a/cmd/climc/shell/k8s/helper.go
+++ b/cmd/climc/shell/k8s/helper.go
@@ -16,7 +16,6 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -58,7 +57,7 @@ func (cmd *K8sResourceCmd) ShowEvent() *K8sResourceCmd {
 }
 
 func FileTempEdit(prefix, suffix string, input string) (string, error) {
-	tempfile, err := ioutil.TempFile("", fmt.Sprintf("k8s-%s*.%s", prefix, suffix))
+	tempfile, err := os.CreateTemp("", fmt.Sprintf("k8s-%s*.%s", prefix, suffix))
 	if err != nil {
 		return "", errors.Wrap(err, "New tempfile")
 	}
@@ -75,7 +74,7 @@ func FileTempEdit(prefix, suffix string, input string) (string, error) {
 	if err := cmd.Run(); err != nil {
 		return "", err
 	}
-	content, err := ioutil.ReadFile(tempfile.Name())
+	content, err := os.ReadFile(tempfile.Name())
 	if err != nil {
 		return "", errors.Wrapf(err, "read file %s", tempfile.Name())
 	}
@@ -94,7 +93,7 @@ func (cmd *K8sResourceCmd) EditRaw(opt shell.IGetOpt) *K8sResourceCmd {
 			return err
 		}
 		yamlBytes := rawData.YAMLString()
-		tempfile, err := ioutil.TempFile("", fmt.Sprintf("k8s-%s*.yaml", args.GetId()))
+		tempfile, err := os.CreateTemp("", fmt.Sprintf("k8s-%s*.yaml", args.GetId()))
 		if err != nil {
 			return err
 		}
@@ -112,7 +111,7 @@ func (cmd *K8sResourceCmd) EditRaw(opt shell.IGetOpt) *K8sResourceCmd {
 		if err := cmd.Run(); err != nil {
 			return err
 		}
-		content, err := ioutil.ReadFile(tempfile.Name())
+		content, err := os.ReadFile(tempfile.Name())
 		if err != nil {
 			return err
 		}

--- a/cmd/climc/shell/k8s/raw.go
+++ b/cmd/climc/shell/k8s/raw.go
@@ -16,7 +16,6 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -72,7 +71,7 @@ func initRaw() {
 	})
 
 	doPut := func(s *mcclient.ClientSession, args *rawPutOpt) error {
-		content, err := ioutil.ReadFile(args.File)
+		content, err := os.ReadFile(args.File)
 		if err != nil {
 			return err
 		}
@@ -100,7 +99,7 @@ func initRaw() {
 		if err != nil {
 			return err
 		}
-		tempfile, err := ioutil.TempFile("", fmt.Sprintf("k8s-%s-%s.yaml", args.KIND, args.NAME))
+		tempfile, err := os.CreateTemp("", fmt.Sprintf("k8s-%s-%s.yaml", args.KIND, args.NAME))
 		if err != nil {
 			return err
 		}

--- a/cmd/climc/shell/misc/pprof.go
+++ b/cmd/climc/shell/misc/pprof.go
@@ -17,7 +17,6 @@ package misc
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"syscall"
 
@@ -40,7 +39,7 @@ func init() {
 	}
 
 	downloadToTemp := func(input io.Reader, pattern string) (string, error) {
-		tmpfile, err := ioutil.TempFile("", pattern)
+		tmpfile, err := os.CreateTemp("", pattern)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/fetcherfs/fs.go
+++ b/cmd/fetcherfs/fs.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -69,7 +68,7 @@ func initFetcherFs() (*FetcherFs, error) {
 	if len(segs[len(segs)-1]) == 0 {
 		return nil, errors.Errorf("bad url: %s", opt.Url)
 	}
-	fd, err := ioutil.TempFile(opt.Tmpdir, fmt.Sprintf("%s.*", segs[len(segs)-1]))
+	fd, err := os.CreateTemp(opt.Tmpdir, fmt.Sprintf("%s.*", segs[len(segs)-1]))
 	if err != nil {
 		return nil, errors.Wrap(err, "create tempfile")
 	}
@@ -222,7 +221,7 @@ func (fs *FetcherFs) doFetchData(idx int64) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode >= 300 {
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		return errors.Errorf("failed fetch data: %d %s", res.StatusCode, body)
 	}
 
@@ -231,7 +230,7 @@ func (fs *FetcherFs) doFetchData(idx int64) error {
 		return errors.Errorf("Apply lz4 option: %v", err)
 	}
 
-	buf, err := ioutil.ReadAll(lz4Reader)
+	buf, err := io.ReadAll(lz4Reader)
 	if len(buf) != int(end-start+1) {
 		return errors.Wrap(err, "written local file")
 	}

--- a/cmd/memclean/main.go
+++ b/cmd/memclean/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"syscall"
@@ -128,7 +127,7 @@ func main() {
 }
 
 func findMemBackendFd(fdDir string) (string, error) {
-	files, err := ioutil.ReadDir(fdDir)
+	files, err := os.ReadDir(fdDir)
 	if err != nil {
 		return "", errors.Wrapf(err, "read dir %s", fdDir)
 	}

--- a/cmd/torrent/main.go
+++ b/cmd/torrent/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"crypto/sha1"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -206,7 +206,7 @@ func main() {
 							log.Errorf("callback fail %s", err)
 						} else {
 							defer resp.Body.Close()
-							respBody, _ := ioutil.ReadAll(resp.Body)
+							respBody, _ := io.ReadAll(resp.Body)
 							log.Errorf("callback response error %s", string(respBody))
 						}
 						time.Sleep(time.Duration(tried+1) * 10 * time.Second)

--- a/pkg/apigateway/clientman/clientman.go
+++ b/pkg/apigateway/clientman/clientman.go
@@ -17,7 +17,7 @@ package clientman
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -27,9 +27,9 @@ import (
 
 func InitClient() error {
 	if options.Options.EnableSsl {
-		privData, err := ioutil.ReadFile(options.Options.SslKeyfile)
+		privData, err := os.ReadFile(options.Options.SslKeyfile)
 		if err != nil {
-			return errors.Wrapf(err, "ioutil.ReadFile %s", options.Options.SslKeyfile)
+			return errors.Wrapf(err, "os.ReadFile %s", options.Options.SslKeyfile)
 		}
 		privateKey, err := seclib2.DecodePrivateKey(privData)
 		if err != nil {

--- a/pkg/apigateway/handler/oidc.go
+++ b/pkg/apigateway/handler/oidc.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -483,9 +483,9 @@ func fetchOIDCRPInitLogoutParam(req *http.Request) (*SOIDCRPInitLogoutRequest, e
 			return nil, errors.Wrap(err, "GetBody")
 		}
 		defer b.Close()
-		qsBytes, err := ioutil.ReadAll(b)
+		qsBytes, err := io.ReadAll(b)
 		if err != nil {
-			return nil, errors.Wrap(err, "ioutil.ReadAll")
+			return nil, errors.Wrap(err, "io.ReadAll")
 		}
 		qs = string(qsBytes)
 	}

--- a/pkg/appsrv/fetch.go
+++ b/pkg/appsrv/fetch.go
@@ -16,7 +16,7 @@ package appsrv
 
 import (
 	"encoding/xml"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -26,7 +26,7 @@ import (
 
 func Fetch(req *http.Request) ([]byte, error) {
 	defer req.Body.Close()
-	return ioutil.ReadAll(req.Body)
+	return io.ReadAll(req.Body)
 }
 
 func FetchStruct(req *http.Request, v interface{}) error {

--- a/pkg/baremetal/pxe/tftp.go
+++ b/pkg/baremetal/pxe/tftp.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -99,7 +98,7 @@ func (h *TFTPHandler) sendPxeLinuxCfgResponse(mac net.HardwareAddr, _ net.Addr) 
 	size := int64(len(bs))
 	buffer := bytes.NewBufferString(respStr)
 
-	return ioutil.NopCloser(buffer), size, nil
+	return io.NopCloser(buffer), size, nil
 }
 
 func (h *TFTPHandler) sendFile(filename string, _ net.Addr) (io.ReadCloser, int64, error) {

--- a/pkg/cloudcommon/notifyclient/template.go
+++ b/pkg/cloudcommon/notifyclient/template.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -115,7 +114,7 @@ func hasTemplateOfTopic(topic string) bool {
 		return ok
 	}
 	path := filepath.Join(consts.NotifyTemplateDir, consts.GetServiceType(), "content@cn")
-	fileInfoList, err := ioutil.ReadDir(path)
+	fileInfoList, err := os.ReadDir(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			checkTemplates = true
@@ -136,13 +135,13 @@ func getTemplateString(suffix string, topic string, contType string, channel npk
 	contType = contType + "@" + suffix
 	if len(channel) > 0 {
 		path := filepath.Join(consts.NotifyTemplateDir, consts.GetServiceType(), contType, fmt.Sprintf("%s.%s", topic, string(channel)))
-		cont, err := ioutil.ReadFile(path)
+		cont, err := os.ReadFile(path)
 		if err == nil {
 			return cont, nil
 		}
 	}
 	path := filepath.Join(consts.NotifyTemplateDir, consts.GetServiceType(), contType, topic)
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func getTemplate(suffix string, topic string, contType string, channel npk.TNotifyChannel) (*template.Template, error) {

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -200,7 +200,7 @@ func (opt *EtcdOptions) GetEtcdTLSConfig() (*tls.Config, error) {
 		opt.EtcdUseTLS = true
 	}
 	if opt.EtcdCacert != "" {
-		data, err := ioutil.ReadFile(opt.EtcdCacert)
+		data, err := os.ReadFile(opt.EtcdCacert)
 		if err != nil {
 			return nil, errors.Wrap(err, "read cacert file")
 		}
@@ -341,7 +341,7 @@ func ParseOptions(optStruct interface{}, args []string, configFileName string, s
 		h.Init()
 		log.DisableColors()
 		log.Logger().AddHook(h)
-		log.Logger().Out = ioutil.Discard
+		log.Logger().Out = io.Discard
 		atexit.Register(atexit.ExitHandler{
 			Prio:   atexit.PRIO_LOG_CLOSE,
 			Reason: "deinit log rotate hook",

--- a/pkg/cloudcommon/userdata/userdata.go
+++ b/pkg/cloudcommon/userdata/userdata.go
@@ -19,7 +19,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/pkg/errors"
 )
@@ -51,7 +51,7 @@ func Decode(encodeUserdata string) (string, error) {
 		return "", errors.Wrap(err, "new reader")
 	}
 	defer gr.Close()
-	data, err := ioutil.ReadAll(gr)
+	data, err := io.ReadAll(gr)
 	if err != nil {
 		return "", errors.Wrap(err, "read data")
 	}

--- a/pkg/cloudid/models/samldriver.go
+++ b/pkg/cloudid/models/samldriver.go
@@ -16,7 +16,8 @@ package models
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
+	"os"
 	"path"
 
 	"yunion.io/x/log"
@@ -70,7 +71,7 @@ func AllDrivers() map[string]ICloudSAMLLoginDriver {
 
 func GetMetadata(driver ICloudSAMLLoginDriver) ([]byte, error) {
 	filePath := path.Join(options.Options.CloudSAMLMetadataPath, driver.GetMetadataFilename())
-	metaBytes, err := ioutil.ReadFile(filePath)
+	metaBytes, err := os.ReadFile(filePath)
 	if err != nil || len(metaBytes) == 0 {
 		metaUrl := driver.GetMetadataUrl()
 		if len(metaUrl) > 0 {
@@ -80,7 +81,7 @@ func GetMetadata(driver ICloudSAMLLoginDriver) ([]byte, error) {
 			if err != nil {
 				return nil, errors.Wrapf(err, "http get %s fail", metaUrl)
 			}
-			metaBytes, err = ioutil.ReadAll(resp.Body)
+			metaBytes, err = io.ReadAll(resp.Body)
 			if err != nil {
 				return nil, errors.Wrapf(err, "read body %s fail", metaUrl)
 			}

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -16,7 +16,6 @@ package service
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -237,7 +236,7 @@ func initEtcdLockOpts(opts *options.ComputeOptions) error {
 	if etcdEndpoint != nil {
 		opts.EtcdEndpoints = []string{etcdEndpoint.Url}
 		if len(etcdEndpoint.CertId) > 0 {
-			dir, err := ioutil.TempDir("", "etcd-cluster-tls")
+			dir, err := os.MkdirTemp("", "etcd-cluster-tls")
 			if err != nil {
 				return errors.Wrap(err, "create dir etcd cluster tls")
 			}
@@ -261,5 +260,5 @@ func initEtcdLockOpts(opts *options.ComputeOptions) error {
 
 func writeFile(dir, file string, data []byte) (string, error) {
 	p := filepath.Join(dir, file)
-	return p, ioutil.WriteFile(p, data, 0600)
+	return p, os.WriteFile(p, data, 0600)
 }

--- a/pkg/hostman/diskutils/fsutils/fsutils.go
+++ b/pkg/hostman/diskutils/fsutils/fsutils.go
@@ -17,7 +17,6 @@ package fsutils
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path"
 	"regexp"
 	"strconv"
@@ -164,11 +163,11 @@ func ResizeDiskFs(diskPath string, sizeMb int) error {
 		for _, s := range []string{"r", "e", "Y", "w", "Y", "Y"} {
 			io.WriteString(stdin, fmt.Sprintf("%s\n", s))
 		}
-		stdoutPut, err := ioutil.ReadAll(outb)
+		stdoutPut, err := io.ReadAll(outb)
 		if err != nil {
 			return err
 		}
-		stderrOutPut, err := ioutil.ReadAll(errb)
+		stderrOutPut, err := io.ReadAll(errb)
 		if err != nil {
 			return err
 		}

--- a/pkg/hostman/diskutils/kvm.go
+++ b/pkg/hostman/diskutils/kvm.go
@@ -15,7 +15,6 @@
 package diskutils
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -43,10 +42,10 @@ func NewKVMGuestDisk(imageInfo qemuimg.SImageInfo, driver string, readOnly bool)
 	imagePath := imageInfo.Path
 	if readOnly {
 		// if readonly, create a top image over the original image, open device as RW
-		tmpFileDir, err := ioutil.TempDir(cloudconsts.DeployTempDir(), "kvm_disks")
+		tmpFileDir, err := os.MkdirTemp(cloudconsts.DeployTempDir(), "kvm_disks")
 		if err != nil {
 			log.Errorf("fail to obtain tempFile for readonly kvm disk: %s", err)
-			return nil, errors.Wrap(err, "ioutil.TempDir")
+			return nil, errors.Wrap(err, "os.MkdirTemp")
 		}
 		tmpFileName := filepath.Join(tmpFileDir, "disk")
 		img, err := qemuimg.NewQemuImage(tmpFileName)

--- a/pkg/hostman/diskutils/libguestfs/driver.go
+++ b/pkg/hostman/diskutils/libguestfs/driver.go
@@ -16,8 +16,8 @@ package libguestfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -159,7 +159,7 @@ func (d *SLibguestfsDriver) findNbdPartitions() ([]fsdriver.IDiskPartition, erro
 	}
 	dev := filepath.Base(d.nbddev)
 	devpath := filepath.Dir(d.nbddev)
-	files, err := ioutil.ReadDir(devpath)
+	files, err := os.ReadDir(devpath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "read dir %s", devpath)
 	}

--- a/pkg/hostman/diskutils/libguestfs/guestfish/guestfish.go
+++ b/pkg/hostman/diskutils/libguestfs/guestfish/guestfish.go
@@ -17,7 +17,7 @@ package guestfish
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"runtime/debug"
@@ -134,7 +134,7 @@ func (fish *Guestfish) fetch() ([]string, error) {
 	}
 
 	fish.stderr.SetReadDeadline(time.Now().Add(time.Second * 1))
-	output, err := ioutil.ReadAll(fish.stderr)
+	output, err := io.ReadAll(fish.stderr)
 	if err != nil && !strings.Contains(err.Error(), "i/o timeout") {
 		log.Errorf("scan guestfish stderrScanner error %s", err)
 		fish.Quit()

--- a/pkg/hostman/diskutils/nbd/driver.go
+++ b/pkg/hostman/diskutils/nbd/driver.go
@@ -16,7 +16,7 @@ package nbd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"runtime/debug"
@@ -109,7 +109,7 @@ func (d *NBDDriver) findPartitions() error {
 	}
 	dev := filepath.Base(d.nbdDev)
 	devpath := filepath.Dir(d.nbdDev)
-	files, err := ioutil.ReadDir(devpath)
+	files, err := os.ReadDir(devpath)
 	if err != nil {
 		return errors.Wrapf(err, "read dir %s", devpath)
 	}

--- a/pkg/hostman/diskutils/nbd/lvmutils.go
+++ b/pkg/hostman/diskutils/nbd/lvmutils.go
@@ -16,7 +16,6 @@ package nbd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -172,7 +171,7 @@ func (p *SKVMGuestLVMPartition) SetupDevice() bool {
 func (p *SKVMGuestLVMPartition) FindPartitions() []*kvmpart.SKVMGuestDiskPartition {
 	parts := []*kvmpart.SKVMGuestDiskPartition{}
 	// try /dev/{vgname}/{lvname}
-	files, err := ioutil.ReadDir("/dev/" + p.vgname)
+	files, err := os.ReadDir("/dev/" + p.vgname)
 	if err == nil {
 		for _, f := range files {
 			partPath := fmt.Sprintf("/dev/%s/%s", p.vgname, f.Name())

--- a/pkg/hostman/diskutils/vddk.go
+++ b/pkg/hostman/diskutils/vddk.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -192,9 +191,9 @@ func (vd *VDDKDisk) ParsePartitions(buf string) error {
 	if len(ms) != 0 {
 		vd.FUseDir = ms[0][1]
 		diskId := filepath.Base(vd.FUseDir)
-		files, err := ioutil.ReadDir(TMPDIR)
+		files, err := os.ReadDir(TMPDIR)
 		if err != nil {
-			return errors.Wrapf(err, "ioutil.ReadDir for %s", TMPDIR)
+			return errors.Wrapf(err, "os.ReadDir for %s", TMPDIR)
 		}
 		for _, f := range files {
 			if strings.HasPrefix(f.Name(), diskId) {

--- a/pkg/hostman/guestfs/kvmpart/localfs.go
+++ b/pkg/hostman/guestfs/kvmpart/localfs.go
@@ -17,7 +17,6 @@ package kvmpart
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -56,7 +55,7 @@ func (f *SLocalGuestFS) GetLocalPath(sPath string, caseInsensitive bool) string 
 	for _, seg := range pathSegs {
 		if len(seg) > 0 {
 			var realSeg string
-			files, _ := ioutil.ReadDir(fullPath)
+			files, _ := os.ReadDir(fullPath)
 			for _, file := range files {
 				var f = file.Name()
 				if f == seg || (caseInsensitive && strings.ToLower(f) == strings.ToLower(seg)) ||
@@ -108,7 +107,7 @@ func (f *SLocalGuestFS) Mkdir(sPath string, mode int, caseInsensitive bool) erro
 func (f *SLocalGuestFS) ListDir(sPath string, caseInsensitive bool) []string {
 	sPath = f.GetLocalPath(sPath, caseInsensitive)
 	if len(sPath) > 0 {
-		files, err := ioutil.ReadDir(sPath)
+		files, err := os.ReadDir(sPath)
 		if err != nil {
 			log.Errorln(err)
 			return nil
@@ -163,11 +162,11 @@ func (f *SLocalGuestFS) Passwd(account, password string, caseInsensitive bool) e
 	}
 	io.WriteString(stdin, fmt.Sprintf("%s\n", password))
 	io.WriteString(stdin, fmt.Sprintf("%s\n", password))
-	stdoutPut, err := ioutil.ReadAll(outb)
+	stdoutPut, err := io.ReadAll(outb)
 	if err != nil {
 		return err
 	}
-	stderrOutPut, err := ioutil.ReadAll(errb)
+	stderrOutPut, err := io.ReadAll(errb)
 	if err != nil {
 		return err
 	}
@@ -289,7 +288,7 @@ func (f *SLocalGuestFS) FileGetContents(sPath string, caseInsensitive bool) ([]b
 
 func (f *SLocalGuestFS) FileGetContentsByPath(sPath string) ([]byte, error) {
 	if len(sPath) > 0 {
-		return ioutil.ReadFile(sPath)
+		return os.ReadFile(sPath)
 	}
 	return nil, fmt.Errorf("Cann't find local path")
 }

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -17,7 +17,6 @@ package guestman
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -289,11 +288,11 @@ func (m *SGuestManager) CPUSetRemove(ctx context.Context, sid string) error {
 	return guest.CPUSetRemove(ctx)
 }
 
-func (m *SGuestManager) IsGuestDir(f os.FileInfo) bool {
+func (m *SGuestManager) IsGuestDir(f os.DirEntry) bool {
 	if !regutils.MatchUUID(f.Name()) {
 		return false
 	}
-	if !f.Mode().IsDir() && f.Mode()&os.ModeSymlink == 0 {
+	if !f.IsDir() && f.Type()&os.ModeSymlink == 0 {
 		return false
 	}
 	descFile := path.Join(m.ServersPath, f.Name(), "desc")
@@ -312,7 +311,7 @@ func (m *SGuestManager) IsGuestExist(sid string) bool {
 }
 
 func (m *SGuestManager) LoadExistingGuests() {
-	files, err := ioutil.ReadDir(m.ServersPath)
+	files, err := os.ReadDir(m.ServersPath)
 	if err != nil {
 		log.Errorf("List servers path %s error %s", m.ServersPath, err)
 	}

--- a/pkg/hostman/guestman/libvirt.go
+++ b/pkg/hostman/guestman/libvirt.go
@@ -17,7 +17,7 @@ package guestman
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -166,9 +166,9 @@ func setAttributeFromLibvirtConfig(
 			}
 			log.Infof("config monitor path is %s, guest config id %s", libvirtConfig.MonitorPath, guestConfig.Id)
 			if len(libvirtConfig.MonitorPath) > 0 {
-				files, _ := ioutil.ReadDir(libvirtConfig.MonitorPath)
+				files, _ := os.ReadDir(libvirtConfig.MonitorPath)
 				for i := 0; i < len(files); i++ {
-					if files[i].Mode().IsDir() &&
+					if files[i].IsDir() &&
 						strings.HasPrefix(files[i].Name(), "domain") &&
 						strings.HasSuffix(files[i].Name(), guestConfig.Name) {
 						monitorPath := path.Join(libvirtConfig.MonitorPath, files[i].Name(), "monitor.sock")

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -17,7 +17,6 @@ package guestman
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -263,9 +262,9 @@ func (s *SKVMGuestInstance) GetPid() int {
 }
 
 /*
- pid -> running qemu's pid
- -1 -> pid file does not exists
- -2 -> pid file ok but content does not match any qemu process
+pid -> running qemu's pid
+-1 -> pid file does not exists
+-2 -> pid file ok but content does not match any qemu process
 */
 func (s *SKVMGuestInstance) getPid(pidFile, uuid string) int {
 	if !fileutils2.Exists(pidFile) {
@@ -310,7 +309,7 @@ func (s *SKVMGuestInstance) isSelfQemuPid(pid, uuid string) bool {
 	if !fi.Mode().IsRegular() {
 		return false
 	}
-	cmdline, err := ioutil.ReadFile(cmdlineFile)
+	cmdline, err := os.ReadFile(cmdlineFile)
 	if err != nil {
 		log.Warningf("IsSelfQemuPid Read File %s error %s", cmdlineFile, err)
 		return false
@@ -334,7 +333,7 @@ func (s *SKVMGuestInstance) GetSourceDescFilePath() string {
 
 func (s *SKVMGuestInstance) LoadDesc() error {
 	descPath := s.GetDescFilePath()
-	descStr, err := ioutil.ReadFile(descPath)
+	descStr, err := os.ReadFile(descPath)
 	if err != nil {
 		return errors.Wrap(err, "read desc")
 	}
@@ -350,7 +349,7 @@ func (s *SKVMGuestInstance) LoadDesc() error {
 		}
 		srcDescStr = descStr
 	} else {
-		srcDescStr, err = ioutil.ReadFile(srcDescPath)
+		srcDescStr, err = os.ReadFile(srcDescPath)
 		if err != nil {
 			return errors.Wrap(err, "read source desc")
 		}
@@ -1204,7 +1203,7 @@ func (s *SKVMGuestInstance) GetQmpMonitorPort(vncPort int) int {
 
 func (s *SKVMGuestInstance) GetVncPort() int {
 	if s.IsRunning() {
-		vncPort, err := ioutil.ReadFile(s.GetVncFilePath())
+		vncPort, err := os.ReadFile(s.GetVncFilePath())
 		if err != nil {
 			return -1
 		}
@@ -2192,7 +2191,7 @@ func (s *SKVMGuestInstance) CleanImportMetadata() *jsonutils.JSONDict {
 func (s *SKVMGuestInstance) ListStateFilePaths() []string {
 	var ret = []string{}
 	if fileutils2.Exists(s.HomeDir()) {
-		files, err := ioutil.ReadDir(s.HomeDir())
+		files, err := os.ReadDir(s.HomeDir())
 		if err != nil {
 			log.Errorln(err)
 			return nil

--- a/pkg/hostman/guestman/qemu/certs/certlist_test.go
+++ b/pkg/hostman/guestman/qemu/certs/certlist_test.go
@@ -34,8 +34,6 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -118,11 +116,7 @@ func TestMakeCertTree(t *testing.T) {
 }
 
 func TestCreateCertificateChain(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	caCfg := Certificates{
 		{

--- a/pkg/hostman/host_services.go
+++ b/pkg/hostman/host_services.go
@@ -15,7 +15,6 @@
 package hostman
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -176,7 +175,7 @@ func (host *SHostService) initEtcdConfig() error {
 	if len(options.HostOptions.EtcdEndpoints) == 0 {
 		options.HostOptions.EtcdEndpoints = []string{etcdEndpoint.Url}
 		if len(etcdEndpoint.CertId) > 0 {
-			dir, err := ioutil.TempDir("", "etcd-cluster-tls")
+			dir, err := os.MkdirTemp("", "etcd-cluster-tls")
 			if err != nil {
 				return errors.Wrap(err, "create dir etcd cluster tls")
 			}
@@ -200,5 +199,5 @@ func (host *SHostService) initEtcdConfig() error {
 
 func writeFile(dir, file string, data []byte) (string, error) {
 	p := filepath.Join(dir, file)
-	return p, ioutil.WriteFile(p, data, 0600)
+	return p, os.WriteFile(p, data, 0600)
 }

--- a/pkg/hostman/storageman/backupstorage/backup_storage_nfs.go
+++ b/pkg/hostman/storageman/backupstorage/backup_storage_nfs.go
@@ -17,7 +17,7 @@ package backupstorage
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -264,7 +264,7 @@ func (s *SNFSBackupStorage) InstancePack(ctx context.Context, packageName string
 	}
 	defer s.unMount()
 
-	tmpFileDir, err := ioutil.TempDir(options.HostOptions.LocalBackupTempPath, "pack")
+	tmpFileDir, err := os.MkdirTemp(options.HostOptions.LocalBackupTempPath, "pack")
 	if err != nil {
 		return "", errors.Wrap(err, "create tempdir")
 	}
@@ -310,7 +310,7 @@ func (s *SNFSBackupStorage) InstancePack(ctx context.Context, packageName string
 	}
 	// save snapshot metadata
 	packageMetadataPath := path.Join(packagePath, PackageMetadataFilename)
-	err = ioutil.WriteFile(packageMetadataPath, []byte(jsonutils.Marshal(metadata).PrettyString()), 0644)
+	err = os.WriteFile(packageMetadataPath, []byte(jsonutils.Marshal(metadata).PrettyString()), 0644)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to write to %s", packageMetadataPath)
 	}
@@ -352,7 +352,7 @@ func (s *SNFSBackupStorage) InstanceUnpack(ctx context.Context, packageName stri
 	defer s.unMount()
 
 	// create temp working dir
-	tmpFileDir, err := ioutil.TempDir(options.HostOptions.LocalBackupTempPath, "unpack")
+	tmpFileDir, err := os.MkdirTemp(options.HostOptions.LocalBackupTempPath, "unpack")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "create tempdir")
 	}
@@ -390,7 +390,7 @@ func (s *SNFSBackupStorage) InstanceUnpack(ctx context.Context, packageName stri
 	}
 	// unpack metadata
 	packageMetadataPath := path.Join(packagePath, PackageMetadataFilename)
-	metadataBytes, err := ioutil.ReadFile(packageMetadataPath)
+	metadataBytes, err := os.ReadFile(packageMetadataPath)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to read metadata file")
 	}

--- a/pkg/hostman/storageman/core.go
+++ b/pkg/hostman/storageman/core.go
@@ -17,7 +17,7 @@ package storageman
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -340,7 +340,7 @@ func cleanDailyFiles(storagePath, subDir string, keepDay int) {
 
 	// before mark should be deleted
 	markTime := timeutils.UtcNow().Add(time.Hour * 24 * -1 * time.Duration(keepDay))
-	files, err := ioutil.ReadDir(recycleDir)
+	files, err := os.ReadDir(recycleDir)
 	if err != nil {
 		log.Errorln(err)
 		return

--- a/pkg/hostman/storageman/disk_local.go
+++ b/pkg/hostman/storageman/disk_local.go
@@ -17,7 +17,6 @@ package storageman
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -116,7 +115,7 @@ func (d *SLocalDisk) UmountFuseImage() {
 	procutils.NewCommand("umount", mntPath).Run()
 	procutils.NewCommand("rm", "-rf", mntPath).Run()
 	tmpPath := d.Storage.GetFuseTmpPath()
-	tmpFiles, err := ioutil.ReadDir(tmpPath)
+	tmpFiles, err := os.ReadDir(tmpPath)
 	if err != nil {
 		for _, f := range tmpFiles {
 			if strings.HasPrefix(f.Name(), d.Id) {
@@ -391,7 +390,7 @@ func (d *SLocalDisk) PostCreateFromImageFuse() {
 		log.Errorf("rm %s failed: %s, %s", mntPath, err, output)
 	}
 	tmpPath := d.Storage.GetFuseTmpPath()
-	tmpFiles, err := ioutil.ReadDir(tmpPath)
+	tmpFiles, err := os.ReadDir(tmpPath)
 	if err != nil {
 		for _, f := range tmpFiles {
 			if strings.HasPrefix(f.Name(), d.Id) {

--- a/pkg/hostman/storageman/imagecachemanager_local.go
+++ b/pkg/hostman/storageman/imagecachemanager_local.go
@@ -16,7 +16,6 @@ package storageman
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	"yunion.io/x/jsonutils"
@@ -61,7 +60,7 @@ func (c *SLocalImageCacheManager) loadCache(ctx context.Context) {
 	}
 	c.lock.LockRawObject(ctx, "LOCAL", "image-cache")
 	defer c.lock.ReleaseRawObject(ctx, "LOCAL", "image-cache")
-	files, _ := ioutil.ReadDir(c.cachePath)
+	files, _ := os.ReadDir(c.cachePath)
 	for _, f := range files {
 		if regutils.MatchUUIDExact(f.Name()) {
 			c.LoadImageCache(f.Name())

--- a/pkg/hostman/storageman/storage_base.go
+++ b/pkg/hostman/storageman/storage_base.go
@@ -17,7 +17,7 @@ package storageman
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"regexp"
 	"runtime/debug"
@@ -502,7 +502,7 @@ func snapshotRecycle(ctx context.Context, userCred mcclient.TokenCredential, isS
 		log.Errorln("Request region get snapshot max count failed")
 		return
 	}
-	files, err := ioutil.ReadDir(storage.GetSnapshotDir())
+	files, err := os.ReadDir(storage.GetSnapshotDir())
 	if err != nil {
 		log.Errorln(err)
 		return
@@ -534,7 +534,7 @@ func checkSnapshots(storage IStorage, snapshotDir string, maxSnapshotCount int) 
 		return
 	}
 
-	snapshots, err := ioutil.ReadDir(snapshotPath)
+	snapshots, err := os.ReadDir(snapshotPath)
 	if err != nil {
 		log.Errorln(err)
 		return

--- a/pkg/lbagent/haproxy.go
+++ b/pkg/lbagent/haproxy.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -186,7 +185,7 @@ func (h *HaproxyHelper) handleUseCorpusCmd(ctx context.Context, cmd *LbagentCmd)
 			if err == nil {
 				d := buf.Bytes()
 				p := filepath.Join(dir, "telegraf.conf")
-				err := ioutil.WriteFile(p, d, agentutils.FileModeFile)
+				err := os.WriteFile(p, d, agentutils.FileModeFile)
 				if err == nil {
 					err := h.reloadTelegraf(ctx)
 					if err != nil {

--- a/pkg/lbagent/hastate.go
+++ b/pkg/lbagent/hastate.go
@@ -17,7 +17,6 @@ package lbagent
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -131,7 +130,7 @@ func (hsw *HaStateWatcher) loadHaState() (err error) {
 			hsw.CurrentState = api.LB_HA_STATE_UNKNOWN
 		}
 	}()
-	data, err := ioutil.ReadFile(hsw.HaStatePath)
+	data, err := os.ReadFile(hsw.HaStatePath)
 	if err != nil {
 		return err
 	}
@@ -171,7 +170,7 @@ func NewHaStateWatcher(opts *Options) (hsw *HaStateWatcher, err error) {
 		content := fmt.Sprintf(HA_STATE_SCRIPT_CONTENT, haStatePath)
 		content = strings.TrimLeftFunc(content, unicode.IsSpace)
 		mode := agentutils.FileModeFileExec
-		err = ioutil.WriteFile(haStateScriptPath, []byte(content), mode)
+		err = os.WriteFile(haStateScriptPath, []byte(content), mode)
 		if err != nil {
 			return
 		}

--- a/pkg/lbagent/models/corpus.go
+++ b/pkg/lbagent/models/corpus.go
@@ -17,7 +17,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"yunion.io/x/jsonutils"
@@ -53,13 +53,13 @@ func (b *LoadbalancerCorpus) SaveDir(dir string) error {
 		return err
 	}
 	p := filepath.Join(dir, "corpus")
-	err = ioutil.WriteFile(p, d, agentutils.FileModeFileSensitive)
+	err = os.WriteFile(p, d, agentutils.FileModeFileSensitive)
 	return err
 }
 
 func (b *LoadbalancerCorpus) LoadDir(dir string) error {
 	p := filepath.Join(dir, "corpus")
-	d, err := ioutil.ReadFile(p)
+	d, err := os.ReadFile(p)
 	if err != nil {
 		return err
 	}

--- a/pkg/lbagent/models/gobetween.go
+++ b/pkg/lbagent/models/gobetween.go
@@ -17,7 +17,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"yunion.io/x/log"
@@ -171,7 +171,7 @@ func (b *LoadbalancerCorpus) GenGobetweenConfigs(dir string, opts *GenGobetweenC
 			return err
 		}
 		p := filepath.Join(dir, "gobetween.json")
-		err = ioutil.WriteFile(p, d, agentutils.FileModeFile)
+		err = os.WriteFile(p, d, agentutils.FileModeFile)
 		if err != nil {
 			return err
 		}

--- a/pkg/lbagent/models/haproxy.go
+++ b/pkg/lbagent/models/haproxy.go
@@ -17,7 +17,6 @@ package models
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +45,7 @@ func (b *LoadbalancerCorpus) GenHaproxyToplevelConfig(dir string, opts *AgentPar
 	}
 	data := buf.Bytes()
 	p := filepath.Join(dir, "00-haproxy.cfg")
-	err = ioutil.WriteFile(p, data, agentutils.FileModeFile)
+	err = os.WriteFile(p, data, agentutils.FileModeFile)
 	if err != nil {
 		return err
 	}
@@ -69,7 +68,7 @@ func (b *LoadbalancerCorpus) GenHaproxyConfigs(dir string, opts *AgentParams) (*
 				"",
 			}
 			s := strings.Join(lines, "\n")
-			err := ioutil.WriteFile(p, []byte(s), agentutils.FileModeFile)
+			err := os.WriteFile(p, []byte(s), agentutils.FileModeFile)
 			if err != nil {
 				return nil, fmt.Errorf("write 01-haproxy.cfg: %s", err)
 			}
@@ -82,7 +81,7 @@ func (b *LoadbalancerCorpus) GenHaproxyConfigs(dir string, opts *AgentParams) (*
 			d = append(d, []byte(lbcert.PrivateKey)...)
 			fn := fmt.Sprintf("%s.pem", lbcert.Id)
 			p := filepath.Join(certsBase, fn)
-			err := ioutil.WriteFile(p, d, agentutils.FileModeFileSensitive)
+			err := os.WriteFile(p, d, agentutils.FileModeFileSensitive)
 			if err != nil {
 				return nil, fmt.Errorf("write cert %s: %s", lbcert.Id, err)
 			}
@@ -100,7 +99,7 @@ func (b *LoadbalancerCorpus) GenHaproxyConfigs(dir string, opts *AgentParams) (*
 			s += strings.Join(cidrs, "\n")
 			s += "\n"
 			p := filepath.Join(dir, "acl-"+lbacl.Id)
-			err := ioutil.WriteFile(p, []byte(s), agentutils.FileModeFile)
+			err := os.WriteFile(p, []byte(s), agentutils.FileModeFile)
 			if err != nil {
 				return nil, err
 			}
@@ -161,7 +160,7 @@ func (b *LoadbalancerCorpus) GenHaproxyConfigs(dir string, opts *AgentParams) (*
 			}
 			fn := fmt.Sprintf("%s.%s", lb.Id, agentutils.HaproxyCfgExt)
 			p := filepath.Join(dir, fn)
-			err := ioutil.WriteFile(p, d, agentutils.FileModeFile)
+			err := os.WriteFile(p, d, agentutils.FileModeFile)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/lbagent/models/keepalived.go
+++ b/pkg/lbagent/models/keepalived.go
@@ -16,7 +16,7 @@ package models
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"text/template"
 
@@ -62,7 +62,7 @@ func (b *LoadbalancerCorpus) GenKeepalivedConfigs(dir string, opts *GenKeepalive
 		// write keepalived.conf
 		d := buf.Bytes()
 		p := filepath.Join(dir, "keepalived.conf")
-		err := ioutil.WriteFile(p, d, agentutils.FileModeFile)
+		err := os.WriteFile(p, d, agentutils.FileModeFile)
 		if err != nil {
 			return err
 		}

--- a/pkg/lbagent/ovn.go
+++ b/pkg/lbagent/ovn.go
@@ -19,7 +19,6 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -380,7 +379,7 @@ func (ovnHost *OvnHost) ensureNs(ctx context.Context) {
 	netnsName := ovnHost.netnsName()
 	{
 		p := path.Join("/var/run/netns", netnsName)
-		if _, err := ioutil.ReadFile(p); err == nil {
+		if _, err := os.ReadFile(p); err == nil {
 			err := os.Remove(p)
 			log.Warningf("removing possible leftover file: %s: %v", p, err)
 		}

--- a/pkg/lbagent/utils/configdir.go
+++ b/pkg/lbagent/utils/configdir.go
@@ -16,7 +16,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -42,7 +41,7 @@ type ConfigDirManager struct {
 
 // TODO
 //
-//  - set active
+//   - set active
 func NewConfigDirManager(baseDir string) *ConfigDirManager {
 	return &ConfigDirManager{
 		baseDir: baseDir,
@@ -80,7 +79,7 @@ func (m *ConfigDirManager) NewDir(f DirFunc) (finalDir string, err error) {
 
 func (m *ConfigDirManager) subdirs() []string {
 	dirs := []string{}
-	fis, err := ioutil.ReadDir(m.baseDir)
+	fis, err := os.ReadDir(m.baseDir)
 	if err != nil {
 		return dirs
 	}

--- a/pkg/lbagent/utils/pidfile.go
+++ b/pkg/lbagent/utils/pidfile.go
@@ -16,7 +16,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -41,7 +40,7 @@ func NewPidFile(path, comm string) *PidFile {
 }
 
 func (pf *PidFile) findProcess() (*os.Process, error) {
-	data, err := ioutil.ReadFile(pf.Path)
+	data, err := os.ReadFile(pf.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +61,7 @@ func (pf *PidFile) findProcess() (*os.Process, error) {
 
 func (pf *PidFile) findComm(pid int) (string, error) {
 	fp := fmt.Sprintf("/proc/%d/comm", pid)
-	data, err := ioutil.ReadFile(fp)
+	data, err := os.ReadFile(fp)
 	if err != nil {
 		return "", err
 	}
@@ -101,6 +100,6 @@ func (pf *PidFile) ConfirmOrUnlink() (proc *os.Process, confirmed bool, err erro
 
 func WritePidFile(pid int, pidFile string) error {
 	data := fmt.Sprintf("%d\n", pid)
-	err := ioutil.WriteFile(pidFile, []byte(data), FileModeFile)
+	err := os.WriteFile(pidFile, []byte(data), FileModeFile)
 	return err
 }

--- a/pkg/mcclient/modulebase/misc.go
+++ b/pkg/mcclient/modulebase/misc.go
@@ -15,7 +15,7 @@
 package modulebase
 
 import (
-	"io/ioutil"
+	"io"
 
 	"yunion.io/x/jsonutils"
 
@@ -29,7 +29,7 @@ func GetVersion(s *mcclient.ClientSession, serviceType string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -43,7 +43,7 @@ func ListWorkers(s *mcclient.ClientSession, serviceType string) (*ListResult, er
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcclient/modulebase/scoperesources.go
+++ b/pkg/mcclient/modulebase/scoperesources.go
@@ -15,7 +15,7 @@
 package modulebase
 
 import (
-	"io/ioutil"
+	"io"
 
 	"yunion.io/x/jsonutils"
 
@@ -29,7 +29,7 @@ func GetScopeResources(s *mcclient.ClientSession, serviceType string) (jsonutils
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcclient/modulebase/stats.go
+++ b/pkg/mcclient/modulebase/stats.go
@@ -15,7 +15,7 @@
 package modulebase
 
 import (
-	"io/ioutil"
+	"io"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
@@ -31,9 +31,9 @@ func GetStats(s *mcclient.ClientSession, path string, serviceType string) (jsonu
 		return nil, errors.Wrap(err, "man.rawBaseUrlRequest")
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "ioutil.ReadAll")
+		return nil, errors.Wrap(err, "io.ReadAll")
 	}
 	return jsonutils.Parse(body)
 }

--- a/pkg/mcclient/modules/k8s/raw.go
+++ b/pkg/mcclient/modules/k8s/raw.go
@@ -16,7 +16,7 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"yunion.io/x/jsonutils"
@@ -97,7 +97,7 @@ func (m *RawResourceManager) GetYAML(s *mcclient.ClientSession, kind string, nam
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (m *RawResourceManager) Put(s *mcclient.ClientSession, kind string, namespace string, name string, body jsonutils.JSONObject, cluster string) error {

--- a/pkg/mcclient/options/ansibleplaybooks.go
+++ b/pkg/mcclient/options/ansibleplaybooks.go
@@ -16,7 +16,7 @@ package options
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"yunion.io/x/jsonutils"
@@ -76,7 +76,7 @@ func (opts *AnsiblePlaybookCommonOptions) ToPlaybook() (*ansible.Playbook, error
 		v := s[i+1:]
 		if len(v) > 0 && v[0] == '@' {
 			path := v[1:]
-			d, err := ioutil.ReadFile(path)
+			d, err := os.ReadFile(path)
 			if err != nil {
 				return nil, fmt.Errorf("read file %s: %v", path, err)
 			}

--- a/pkg/mcclient/options/cloudaccounts.go
+++ b/pkg/mcclient/options/cloudaccounts.go
@@ -16,7 +16,7 @@ package options
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 
@@ -203,7 +203,7 @@ type SGoogleCloudAccountCreateOptions struct {
 }
 
 func parseGcpCredential(filename string) (jsonutils.JSONObject, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcclient/options/cloudnet/routers.go
+++ b/pkg/mcclient/options/cloudnet/routers.go
@@ -15,7 +15,7 @@
 package cloudnet
 
 import (
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 
@@ -40,7 +40,7 @@ func (opts *RouterCreateOptions) Params() (jsonutils.JSONObject, error) {
 		return nil, err
 	}
 	if opts.PrivateKey != "" && opts.PrivateKey[0] == '@' {
-		data, err := ioutil.ReadFile(opts.PrivateKey[1:])
+		data, err := os.ReadFile(opts.PrivateKey[1:])
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +73,7 @@ func (opts *RouterUpdateOptions) Params() (jsonutils.JSONObject, error) {
 		return nil, err
 	}
 	if opts.PrivateKey != "" && opts.PrivateKey[0] == '@' {
-		data, err := ioutil.ReadFile(opts.PrivateKey[1:])
+		data, err := os.ReadFile(opts.PrivateKey[1:])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/mcclient/options/cloudproxy/proxy_endpoints.go
+++ b/pkg/mcclient/options/cloudproxy/proxy_endpoints.go
@@ -15,7 +15,7 @@
 package cloudproxy
 
 import (
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 
@@ -39,7 +39,7 @@ func (opts *ProxyEndpointCreateOptions) Params() (jsonutils.JSONObject, error) {
 		return nil, err
 	}
 	if opts.PrivateKey != "" && opts.PrivateKey[0] == '@' {
-		data, err := ioutil.ReadFile(opts.PrivateKey[1:])
+		data, err := os.ReadFile(opts.PrivateKey[1:])
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +82,7 @@ func (opts *ProxyEndpointUpdateOptions) Params() (jsonutils.JSONObject, error) {
 		return nil, err
 	}
 	if opts.PrivateKey != "" && opts.PrivateKey[0] == '@' {
-		data, err := ioutil.ReadFile(opts.PrivateKey[1:])
+		data, err := os.ReadFile(opts.PrivateKey[1:])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/mcclient/options/compute/loadbalancercertificates.go
+++ b/pkg/mcclient/options/compute/loadbalancercertificates.go
@@ -16,7 +16,7 @@ package compute
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 
@@ -37,7 +37,7 @@ func loadbalancerCertificateLoadFiles(cert, pkey string, allowEmpty bool) (*json
 				return nil, fmt.Errorf("%s: empty path", fieldName)
 			}
 		}
-		d, err := ioutil.ReadFile(path)
+		d, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("%s: read %s: %s", fieldName, path, err)
 		}

--- a/pkg/mcclient/options/compute/project_mappings.go
+++ b/pkg/mcclient/options/compute/project_mappings.go
@@ -15,7 +15,7 @@
 package compute
 
 import (
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 
@@ -38,7 +38,7 @@ type ProjectMappingCreateOption struct {
 func (opts *ProjectMappingCreateOption) Params() (jsonutils.JSONObject, error) {
 	ret := jsonutils.NewDict()
 	ret.Update(jsonutils.Marshal(opts.BaseCreateOptions))
-	data, err := ioutil.ReadFile(opts.RULES_FILE)
+	data, err := os.ReadFile(opts.RULES_FILE)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (opts *ProjectMappingUpdateOption) Params() (jsonutils.JSONObject, error) {
 	ret := jsonutils.NewDict()
 	ret.Update(jsonutils.Marshal(opts.BaseUpdateOptions))
 	if len(opts.RulesFile) > 0 {
-		data, err := ioutil.ReadFile(opts.RulesFile)
+		data, err := os.ReadFile(opts.RulesFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/mcclient/options/compute/servers.go
+++ b/pkg/mcclient/options/compute/servers.go
@@ -17,7 +17,7 @@ package compute
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -207,7 +207,7 @@ func ParseServerDeployInfo(info string) (*computeapi.DeployConfig, error) {
 		sdi.Path = info[:colon]
 	}
 	nameOrContent := info[colon+1:]
-	data, err := ioutil.ReadFile(nameOrContent)
+	data, err := os.ReadFile(nameOrContent)
 	if err != nil {
 		sdi.Content = nameOrContent
 	} else {
@@ -567,7 +567,7 @@ func (opts *ServerCreateOptionalOptions) OptionalParams() (*computeapi.ServerCre
 	}
 
 	if len(opts.UserDataFile) > 0 {
-		userdata, err := ioutil.ReadFile(opts.UserDataFile)
+		userdata, err := os.ReadFile(opts.UserDataFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/mcclient/options/compute/waf_rules.go
+++ b/pkg/mcclient/options/compute/waf_rules.go
@@ -15,7 +15,7 @@
 package compute
 
 import (
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
@@ -39,7 +39,7 @@ type WafRuleOptions struct {
 }
 
 func (opts *WafRuleOptions) Params() (jsonutils.JSONObject, error) {
-	data, err := ioutil.ReadFile(opts.RULE_FILE)
+	data, err := os.ReadFile(opts.RULE_FILE)
 	if err != nil {
 		return nil, errors.Wrapf(err, "ioutils.ReadFile")
 	}

--- a/pkg/mcclient/options/devtooltemplate.go
+++ b/pkg/mcclient/options/devtooltemplate.go
@@ -16,7 +16,7 @@ package options
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"yunion.io/x/jsonutils"
@@ -92,7 +92,7 @@ func (opts *DevtoolTemplateCommonOptions) ToPlaybook() (*ansible.Playbook, error
 		v := s[i+1:]
 		if len(v) > 0 && v[0] == '@' {
 			path := v[1:]
-			d, err := ioutil.ReadFile(path)
+			d, err := os.ReadFile(path)
 			if err != nil {
 				return nil, fmt.Errorf("read file %s: %v", path, err)
 			}

--- a/pkg/mcclient/options/k8s/app.go
+++ b/pkg/mcclient/options/k8s/app.go
@@ -16,7 +16,7 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -119,7 +119,7 @@ func (o K8sAppCreateFromFileOptions) Params() (*jsonutils.JSONDict, error) {
 	}
 	params := ret.(*jsonutils.JSONDict)
 	params.Add(jsonutils.NewString(o.NAME), "name")
-	content, err := ioutil.ReadFile(o.FILE)
+	content, err := os.ReadFile(o.FILE)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcclient/options/k8s/cluster.go
+++ b/pkg/mcclient/options/k8s/cluster.go
@@ -16,7 +16,7 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"yunion.io/x/jsonutils"
@@ -213,7 +213,7 @@ type KubeClusterImportOptions struct {
 }
 
 func (o KubeClusterImportOptions) Params() (jsonutils.JSONObject, error) {
-	kubeconfig, err := ioutil.ReadFile(o.KUBECONFIG)
+	kubeconfig, err := os.ReadFile(o.KUBECONFIG)
 	if err != nil {
 		return nil, fmt.Errorf("Read kube config %q error: %v", o.KUBECONFIG, err)
 	}
@@ -493,11 +493,11 @@ func (o ClusterEnableComponentMonitorOpt) Params() (jsonutils.JSONObject, error)
 	certFile := o.Grafana.Tls.CertificateFile
 	keyFile := o.Grafana.Tls.KeyFile
 	if certFile != "" {
-		cert, err := ioutil.ReadFile(certFile)
+		cert, err := os.ReadFile(certFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "read grafana tls certFile")
 		}
-		key, err := ioutil.ReadFile(keyFile)
+		key, err := os.ReadFile(keyFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "read grafana tls keyFile")
 		}

--- a/pkg/mcclient/options/k8s/release.go
+++ b/pkg/mcclient/options/k8s/release.go
@@ -15,7 +15,7 @@
 package k8s
 
 import (
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
@@ -89,7 +89,7 @@ func (o ReleaseCreateUpdateOptions) Params() (*jsonutils.JSONDict, error) {
 	params.Add(jsonutils.NewInt(o.Timeout), "timeout")
 	if o.Values != "" {
 		//vals, err := helm.MergeValuesF(args.Values, args.Set, []string{})
-		vals, err := ioutil.ReadFile(o.Values)
+		vals, err := os.ReadFile(o.Values)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/mcclient/options/servicecertificates.go
+++ b/pkg/mcclient/options/servicecertificates.go
@@ -16,7 +16,7 @@ package options
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 )
@@ -40,7 +40,7 @@ func serviceCertificateLoadFiles(pathM map[string]string, allowEmpty bool) (*jso
 				return nil, fmt.Errorf("%s: empty path", fieldName)
 			}
 		}
-		d, err := ioutil.ReadFile(path)
+		d, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("%s: read %s: %s", fieldName, path, err)
 		}

--- a/pkg/mcclient/session.go
+++ b/pkg/mcclient/session.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"regexp"
@@ -371,7 +370,7 @@ func (this *ClientSession) PrepareTask() {
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "ok")
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		var msg string
 		if err != nil {
 			msg = fmt.Sprintf("Read request data error: %s", err)

--- a/pkg/monitor/alerting/notifiers/util.go
+++ b/pkg/monitor/alerting/notifiers/util.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strings"
@@ -116,13 +115,13 @@ func SendWebRequestSync(ctx context.Context, webhook *monitor.SendWebhookSync) e
 
 	if resp.StatusCode/100 == 2 {
 		// flushing the body enables the transport to reuse the same connection
-		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
-			log.Errorf("Failed to copy resp.Body to ioutil.Discard: %v", err)
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			log.Errorf("Failed to copy resp.Body to io.Discard: %v", err)
 		}
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/monitor/notifydrivers/feishu/cache.go
+++ b/pkg/monitor/notifydrivers/feishu/cache.go
@@ -17,7 +17,7 @@ package feishu
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 )
 
@@ -44,13 +44,13 @@ func NewFileCache(path string) *FileCache {
 func (c *FileCache) Set(data IExpirable) error {
 	bytes, err := json.Marshal(data)
 	if err == nil {
-		ioutil.WriteFile(c.Path, bytes, 0644)
+		os.WriteFile(c.Path, bytes, 0644)
 	}
 	return err
 }
 
 func (c *FileCache) Get(data IExpirable) error {
-	bytes, err := ioutil.ReadFile(c.Path)
+	bytes, err := os.ReadFile(c.Path)
 	if err != nil {
 		return err
 	}

--- a/pkg/multicloud/aliyun/aliyun.go
+++ b/pkg/multicloud/aliyun/aliyun.go
@@ -17,7 +17,7 @@ package aliyun
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -411,11 +411,11 @@ func (self *SAliyunClient) getSdkClient(regionId string) (*sdk.Client, error) {
 				action := params.Get("Action")
 				respCheck := func(resp *http.Response) {
 					if self.cpcfg.UpdatePermission != nil && resp.StatusCode >= 400 && resp.ContentLength > 0 {
-						body, err := ioutil.ReadAll(resp.Body)
+						body, err := io.ReadAll(resp.Body)
 						if err != nil {
 							return
 						}
-						resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+						resp.Body = io.NopCloser(bytes.NewBuffer(body))
 						obj, err := jsonutils.Parse(body)
 						if err != nil {
 							return

--- a/pkg/multicloud/aliyun/storagecache.go
+++ b/pkg/multicloud/aliyun/storagecache.go
@@ -17,7 +17,6 @@ package aliyun
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -309,7 +308,7 @@ func (self *SStoragecache) downloadImage(userCred mcclient.TokenCredential, imag
 		return nil, err
 	}
 
-	tmpImageFile, err := ioutil.TempFile(path, extId)
+	tmpImageFile, err := os.CreateTemp(path, extId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/apsara/apsara.go
+++ b/pkg/multicloud/apsara/apsara.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -259,11 +259,11 @@ func (self *SApsaraClient) getDefaultClient(regionId string) (*sdk.Client, error
 				service := strings.ToLower(params.Get("Product"))
 				respCheck := func(resp *http.Response) {
 					if self.cpcfg.UpdatePermission != nil {
-						body, err := ioutil.ReadAll(resp.Body)
+						body, err := io.ReadAll(resp.Body)
 						if err != nil {
 							return
 						}
-						resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+						resp.Body = io.NopCloser(bytes.NewBuffer(body))
 						obj, err := jsonutils.Parse(body)
 						if err != nil {
 							return

--- a/pkg/multicloud/aws/aws.go
+++ b/pkg/multicloud/aws/aws.go
@@ -17,7 +17,7 @@ package aws
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -246,11 +246,11 @@ func (client *SAwsClient) getAwsSession(regionId string, assumeRole bool) (*sess
 	httpClient.Transport = cloudprovider.GetCheckTransport(transport, func(req *http.Request) (func(resp *http.Response), error) {
 		var action string
 		if req.ContentLength > 0 {
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
-				return nil, errors.Wrapf(err, "ioutil.ReadAll")
+				return nil, errors.Wrapf(err, "io.ReadAll")
 			}
-			req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+			req.Body = io.NopCloser(bytes.NewBuffer(body))
 			params, err := url.ParseQuery(string(body))
 			if err != nil {
 				return nil, errors.Wrapf(err, "ParseQuery(%s)", string(body))

--- a/pkg/multicloud/aws/aws_request.go
+++ b/pkg/multicloud/aws/aws_request.go
@@ -17,7 +17,6 @@ package aws
 import (
 	"encoding/xml"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strings"
 
@@ -45,10 +44,10 @@ func Unmarshal(r *request.Request) {
 	if r.DataFilled() {
 		var decoder *xml.Decoder
 		if DEBUG {
-			body, err := ioutil.ReadAll(r.HTTPResponse.Body)
+			body, err := io.ReadAll(r.HTTPResponse.Body)
 			if err != nil {
 				r.Error = awserr.NewRequestFailure(
-					awserr.New("ioutil.ReadAll", "read response body", err),
+					awserr.New("io.ReadAll", "read response body", err),
 					r.HTTPResponse.StatusCode,
 					r.RequestID,
 				)

--- a/pkg/multicloud/aws/shell/instance.go
+++ b/pkg/multicloud/aws/shell/instance.go
@@ -17,7 +17,7 @@ package shell
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud/aws"
@@ -51,7 +51,7 @@ func init() {
 		PUBLICKEY string `help:"PublicKey file path"`
 	}
 	shellutils.R(&InstanceCreateOptions{}, "instance-create", "Create a instance", func(cli *aws.SRegion, args *InstanceCreateOptions) error {
-		content, err := ioutil.ReadFile(args.PUBLICKEY)
+		content, err := os.ReadFile(args.PUBLICKEY)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/aws/shell/waf.go
+++ b/pkg/multicloud/aws/shell/waf.go
@@ -16,7 +16,7 @@ package shell
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
@@ -193,7 +193,7 @@ func init() {
 		if err != nil {
 			return errors.Wrapf(err, "GetWebAcl")
 		}
-		data, err := ioutil.ReadFile(args.RULE_FILE)
+		data, err := os.ReadFile(args.RULE_FILE)
 		if err != nil {
 			return errors.Wrapf(err, "ReadFile")
 		}

--- a/pkg/multicloud/azure/storagecache.go
+++ b/pkg/multicloud/azure/storagecache.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -238,7 +237,7 @@ func (self *SStoragecache) downloadImage(userCred mcclient.TokenCredential, imag
 	} else if resp, err := http.Get(uri); err != nil {
 		return nil, err
 	} else {
-		tmpImageFile, err := ioutil.TempFile(path, "temp")
+		tmpImageFile, err := os.CreateTemp(path, "temp")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/multicloud/bingocloud/bingo.go
+++ b/pkg/multicloud/bingocloud/bingo.go
@@ -21,7 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -243,7 +243,7 @@ func (self *SBingoCloudClient) invoke(action string, params map[string]string) (
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/ecloud/client.go
+++ b/pkg/multicloud/ecloud/client.go
@@ -20,7 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -267,7 +267,7 @@ func (ec *SEcloudClient) doRequest(ctx context.Context, r IRequest) (jsonutils.J
 	if err != nil {
 		return nil, err
 	}
-	rbody, err := ioutil.ReadAll(resp.Body)
+	rbody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read body of response")
 	}

--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -541,7 +540,7 @@ func (self *SDatastore) FileGetContent(ctx context.Context, remotePath string) (
 		if resp.StatusCode >= 400 {
 			return fmt.Errorf("%s", resp.Status)
 		}
-		cont, err := ioutil.ReadAll(resp.Body)
+		cont, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -776,7 +775,7 @@ func (self *SDatastore) Upload(ctx context.Context, remotePath string, body io.R
 		if resp.StatusCode >= 400 {
 			return fmt.Errorf("%s", resp.Status)
 		}
-		_, err := ioutil.ReadAll(resp.Body)
+		_, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -825,7 +824,7 @@ func (self *SDatastore) Delete(ctx context.Context, remotePath string) error {
 		if resp.StatusCode >= 400 {
 			return fmt.Errorf("%s", resp.Status)
 		}
-		_, err := ioutil.ReadAll(resp.Body)
+		_, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/google/bucket.go
+++ b/pkg/multicloud/google/bucket.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -404,7 +403,7 @@ func (region *SRegion) UploadPart(bucket, uploadId string, partIndex int, offset
 		return errors.Wrap(err, "storageUploadPart")
 	}
 	if resp.StatusCode >= 500 {
-		content, _ := ioutil.ReadAll(resp.Body)
+		content, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("status code: %d %s", resp.StatusCode, content)
 	}
 	defer resp.Body.Close()
@@ -421,7 +420,7 @@ func (region *SRegion) CheckUploadRange(bucket string, uploadId string) error {
 	}
 	defer resp.Body.Close()
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "ReadAll")
 	}

--- a/pkg/multicloud/google/google.go
+++ b/pkg/multicloud/google/google.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -541,7 +540,7 @@ func (self *SGoogleClient) storageUpload(resource string, header http.Header, bo
 		return nil, errors.Wrap(err, "rawRequest")
 	}
 	if resp.StatusCode >= 400 {
-		msg, _ := ioutil.ReadAll(resp.Body)
+		msg, _ := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		return nil, fmt.Errorf("StatusCode: %d %s", resp.StatusCode, string(msg))
 	}
@@ -554,7 +553,7 @@ func (self *SGoogleClient) storageUploadPart(resource string, header http.Header
 		return nil, errors.Wrap(err, "rawRequest")
 	}
 	if resp.StatusCode >= 400 {
-		msg, _ := ioutil.ReadAll(resp.Body)
+		msg, _ := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		return nil, fmt.Errorf("StatusCode: %d %s", resp.StatusCode, string(msg))
 	}
@@ -568,7 +567,7 @@ func (self *SGoogleClient) storageAbortUpload(resource string) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		msg, _ := ioutil.ReadAll(resp.Body)
+		msg, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("StatusCode: %d %s", resp.StatusCode, string(msg))
 	}
 	return nil
@@ -581,7 +580,7 @@ func (self *SGoogleClient) storageDownload(resource string, header http.Header) 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		msg, _ := ioutil.ReadAll(resp.Body)
+		msg, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("StatusCode: %d %s", resp.StatusCode, string(msg))
 	}
 	return resp.Body, err

--- a/pkg/multicloud/google/shell/object.go
+++ b/pkg/multicloud/google/shell/object.go
@@ -17,7 +17,6 @@ package shell
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -141,11 +140,11 @@ func init() {
 		if err != nil {
 			return errors.Wrap(err, "DownloadObjectRange")
 		}
-		content, err := ioutil.ReadAll(data)
+		content, err := io.ReadAll(data)
 		if err != nil {
-			return errors.Wrap(err, "ioutil.ReadAll")
+			return errors.Wrap(err, "io.ReadAll")
 		}
-		return ioutil.WriteFile(args.OBJECT, content, 0644)
+		return os.WriteFile(args.OBJECT, content, 0644)
 	})
 
 	type ObjectUploadCheckOptions struct {

--- a/pkg/multicloud/google/shell/skubilling.go
+++ b/pkg/multicloud/google/shell/skubilling.go
@@ -16,7 +16,7 @@ package shell
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
@@ -58,9 +58,9 @@ func init() {
 	}
 
 	shellutils.R(&SkuEstimate{}, "sku-estimate", "Estimate sku price", func(cli *google.SRegion, args *SkuEstimate) error {
-		data, err := ioutil.ReadFile(args.RATE_FAILE)
+		data, err := os.ReadFile(args.RATE_FAILE)
 		if err != nil {
-			return errors.Wrap(err, "ioutil.ReadFile")
+			return errors.Wrap(err, "os.ReadFile")
 		}
 		rate := google.SRateInfo{}
 		j, err := jsonutils.Parse(data)

--- a/pkg/multicloud/hcso/client/auth/signer.go
+++ b/pkg/multicloud/hcso/client/auth/signer.go
@@ -19,7 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -111,7 +111,7 @@ func contentSha256(request requests.IRequest) string {
 	method := strings.ToUpper(request.GetMethod())
 	content := []byte{}
 	body := request.GetBodyReader()
-	content, _ = ioutil.ReadAll(body)
+	content, _ = io.ReadAll(body)
 	if method == "POST" {
 		if len(content) == 0 {
 			// other http method use query as content

--- a/pkg/multicloud/hcso/shell/role.go
+++ b/pkg/multicloud/hcso/shell/role.go
@@ -16,7 +16,7 @@ package shell
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -86,6 +86,6 @@ func init() {
 				Status:      cloudid_api.CLOUD_POLICY_STATUS_AVAILABLE,
 			})
 		}
-		return ioutil.WriteFile(fmt.Sprintf("%s.json", api.CLOUD_PROVIDER_HCSO), []byte(jsonutils.Marshal(ret).PrettyString()), 0644)
+		return os.WriteFile(fmt.Sprintf("%s.json", api.CLOUD_PROVIDER_HCSO), []byte(jsonutils.Marshal(ret).PrettyString()), 0644)
 	})
 }

--- a/pkg/multicloud/huawei/client/auth/signer.go
+++ b/pkg/multicloud/huawei/client/auth/signer.go
@@ -19,7 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sort"
 	"strings"
 	"sync"
@@ -112,7 +112,7 @@ func contentSha256(request requests.IRequest) string {
 	method := strings.ToUpper(request.GetMethod())
 	content := []byte{}
 	body := request.GetBodyReader()
-	content, _ = ioutil.ReadAll(body)
+	content, _ = io.ReadAll(body)
 	if method == "POST" {
 		if len(content) == 0 {
 			// other http method use query as content

--- a/pkg/multicloud/huawei/obs/convert.go
+++ b/pkg/multicloud/huawei/obs/convert.go
@@ -30,7 +30,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -785,7 +784,7 @@ func ParseResponseToBaseModel(resp *http.Response, baseModel IBaseModel, xmlResu
 				doLog(LEVEL_WARN, "Failed to close response with reason: %v", errMsg)
 			}
 		}()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err == nil && len(body) > 0 {
 			if xmlResult {
 				err = ParseXml(body, baseModel)

--- a/pkg/multicloud/qcloud/qcloud.go
+++ b/pkg/multicloud/qcloud/qcloud.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -614,11 +614,11 @@ func (client *SQcloudClient) getSdkClient(regionId string) (*common.Client, erro
 	httpClient := client.cpcfg.AdaptiveTimeoutHttpClient()
 	ts, _ := httpClient.Transport.(*http.Transport)
 	cli.WithHttpTransport(cloudprovider.GetCheckTransport(ts, func(req *http.Request) (func(resp *http.Response), error) {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
-			return nil, errors.Wrapf(err, "ioutil.ReadAll")
+			return nil, errors.Wrapf(err, "io.ReadAll")
 		}
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		req.Body = io.NopCloser(bytes.NewBuffer(body))
 		params, err := url.ParseQuery(string(body))
 		if err != nil {
 			return nil, errors.Wrapf(err, "ParseQuery(%s)", string(body))

--- a/pkg/multicloud/qcloud/shell/loadbalancer.go
+++ b/pkg/multicloud/qcloud/shell/loadbalancer.go
@@ -15,7 +15,7 @@
 package shell
 
 import (
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/onecloud/pkg/multicloud/qcloud"
 	"yunion.io/x/onecloud/pkg/util/shellutils"
@@ -78,7 +78,7 @@ func init() {
 	shellutils.R(&LbCertUploadOptions{}, "lbcert-upload", "Upload cert", func(cli *qcloud.SRegion, args *LbCertUploadOptions) error {
 		public := ""
 		if len(args.PublicKeyPath) > 0 {
-			_public, err := ioutil.ReadFile(args.PublicKeyPath)
+			_public, err := os.ReadFile(args.PublicKeyPath)
 			if err != nil {
 				return err
 			}
@@ -88,7 +88,7 @@ func init() {
 
 		private := ""
 		if len(args.PrivateKeyPath) > 0 {
-			_private, err := ioutil.ReadFile(args.PrivateKeyPath)
+			_private, err := os.ReadFile(args.PrivateKeyPath)
 			if err != nil {
 				return err
 			}

--- a/pkg/multicloud/ucloud/ucloud.go
+++ b/pkg/multicloud/ucloud/ucloud.go
@@ -17,7 +17,7 @@ package ucloud
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -109,11 +109,11 @@ func NewUcloudClient(cfg *UcloudClientConfig) (*SUcloudClient, error) {
 	httpClient.Transport = cloudprovider.GetCheckTransport(ts, func(req *http.Request) (func(resp *http.Response), error) {
 		if cfg.cpcfg.ReadOnly {
 			if req.ContentLength > 0 {
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				if err != nil {
-					return nil, errors.Wrapf(err, "ioutil.ReadAll")
+					return nil, errors.Wrapf(err, "io.ReadAll")
 				}
-				req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+				req.Body = io.NopCloser(bytes.NewBuffer(body))
 				obj, err := jsonutils.Parse(body)
 				if err != nil {
 					return nil, errors.Wrapf(err, "Parse request body")

--- a/pkg/notify/models/event_template.go
+++ b/pkg/notify/models/event_template.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +51,7 @@ type sEvenWebhookMsg struct {
 	ResourceDetails map[string]interface{} `json:"resource_details"`
 }
 
-//templateDir = "/opt/yunion/share/local-templates"
+// templateDir = "/opt/yunion/share/local-templates"
 type SLocalTemplateManager struct {
 	templateDir    string
 	templatesTable *sync.Map
@@ -297,7 +296,7 @@ func (lt *SLocalTemplateManager) getTemplateString(ctx context.Context, titleOrC
 	} else {
 		path = filepath.Join(lt.templateDir, titleOrContent, fmt.Sprintf("%s.tmpl", topic))
 	}
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		if _, ok := err.(*os.PathError); ok {
 			return nil, errors.ErrNotFound

--- a/pkg/notify/models/template.go
+++ b/pkg/notify/models/template.go
@@ -20,7 +20,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	ptem "text/template"
@@ -93,7 +93,7 @@ func (tm *STemplateManager) defaultTemplate() ([]STemplate, error) {
 		for _, lang := range []string{api.TEMPLATE_LANG_CN, api.TEMPLATE_LANG_EN} {
 			contactType, topic := CONTACTTYPE_ALL, ""
 			titleTemplatePath := fmt.Sprintf("%s/%s@%s", templatePath, templateType, lang)
-			files, err := ioutil.ReadDir(titleTemplatePath)
+			files, err := os.ReadDir(titleTemplatePath)
 			if err != nil {
 				return templates, errors.Wrapf(err, "Read Dir '%s'", titleTemplatePath)
 			}
@@ -107,7 +107,7 @@ func (tm *STemplateManager) defaultTemplate() ([]STemplate, error) {
 					contactType = spliteName[1]
 				}
 				fullPath := filepath.Join(titleTemplatePath, file.Name())
-				content, err := ioutil.ReadFile(fullPath)
+				content, err := os.ReadFile(fullPath)
 				if err != nil {
 					return templates, err
 				}

--- a/pkg/notify/rpc/send.go
+++ b/pkg/notify/rpc/send.go
@@ -17,7 +17,6 @@ package rpc
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -69,7 +68,7 @@ func NewSRpcService(socketFileDir string, configStore notifyv2.IServiceConfigSto
 // the name of file is the service's name; then try to dial to this rpc service
 // through corresponding socket file, if failed, only print log but not return error.
 func (self *SRpcService) InitAll() error {
-	files, err := ioutil.ReadDir(self.socketFileDir)
+	files, err := os.ReadDir(self.socketFileDir)
 	if err != nil {
 		return errors.Wrapf(err, "read dir %s failed", self.socketFileDir)
 	}
@@ -330,7 +329,7 @@ func (self *SRpcService) closeService(ctx context.Context, serviceName string) {
 }
 
 func (self *SRpcService) updateService(ctx context.Context) error {
-	files, err := ioutil.ReadDir(self.socketFileDir)
+	files, err := os.ReadDir(self.socketFileDir)
 	if err != nil {
 		return errors.Wrapf(err, "read dir %s failed", self.socketFileDir)
 	}

--- a/pkg/scheduler/service/service.go
+++ b/pkg/scheduler/service/service.go
@@ -15,7 +15,7 @@
 package service
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -103,7 +103,7 @@ func StartService() error {
 }
 
 func startHTTP(opt *o.SchedulerOptions) error {
-	gin.DefaultWriter = ioutil.Discard
+	gin.DefaultWriter = io.Discard
 
 	router := gin.Default()
 	router.Use(middleware.Logger())

--- a/pkg/util/ansible/playbook.go
+++ b/pkg/util/ansible/playbook.go
@@ -17,7 +17,6 @@ package ansible
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -126,7 +125,7 @@ func (pb *Playbook) Run(ctx context.Context) (err error) {
 	}
 
 	// make tmpdir
-	tmpdir, err = ioutil.TempDir("", "onecloud-ansible")
+	tmpdir, err = os.MkdirTemp("", "onecloud-ansible")
 	if err != nil {
 		err = errors.WithMessage(err, "making tmp dir")
 		return
@@ -143,7 +142,7 @@ func (pb *Playbook) Run(ctx context.Context) (err error) {
 
 	// write out inventory
 	inventory := filepath.Join(tmpdir, "inventory")
-	err = ioutil.WriteFile(inventory, pb.Inventory.Data(), os.FileMode(0600))
+	err = os.WriteFile(inventory, pb.Inventory.Data(), os.FileMode(0600))
 	if err != nil {
 		err = errors.WithMessagef(err, "writing inventory %s", inventory)
 		return
@@ -153,7 +152,7 @@ func (pb *Playbook) Run(ctx context.Context) (err error) {
 	var privateKey string
 	if len(pb.PrivateKey) > 0 {
 		privateKey = filepath.Join(tmpdir, "private_key")
-		err = ioutil.WriteFile(privateKey, pb.PrivateKey, os.FileMode(0600))
+		err = os.WriteFile(privateKey, pb.PrivateKey, os.FileMode(0600))
 		if err != nil {
 			err = errors.WithMessagef(err, "writing private key %s", privateKey)
 			return
@@ -169,7 +168,7 @@ func (pb *Playbook) Run(ctx context.Context) (err error) {
 			err = errors.WithMessagef(err, "mkdir -p %s", dir)
 			return
 		}
-		err = ioutil.WriteFile(path, content, os.FileMode(0600))
+		err = os.WriteFile(path, content, os.FileMode(0600))
 		if err != nil {
 			err = errors.WithMessagef(err, "writing file %s", name)
 			return

--- a/pkg/util/ansiblev2/playbook_session.go
+++ b/pkg/util/ansiblev2/playbook_session.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -64,7 +63,7 @@ func (r runnable) Run(ctx context.Context) (err error) {
 	defer r.SetStopped()
 
 	// make tmpdir
-	tmpdir, err = ioutil.TempDir("", "onecloud-ansiblev2")
+	tmpdir, err = os.MkdirTemp("", "onecloud-ansiblev2")
 	if err != nil {
 		err = errors.Wrap(err, "making tmp dir")
 		return
@@ -80,7 +79,7 @@ func (r runnable) Run(ctx context.Context) (err error) {
 
 	// write out inventory
 	inventory := filepath.Join(tmpdir, "inventory")
-	err = ioutil.WriteFile(inventory, []byte(r.GetInventory()), os.FileMode(0600))
+	err = os.WriteFile(inventory, []byte(r.GetInventory()), os.FileMode(0600))
 	if err != nil {
 		err = errors.Wrapf(err, "writing inventory %s", inventory)
 		return
@@ -90,7 +89,7 @@ func (r runnable) Run(ctx context.Context) (err error) {
 	playbook := r.GetPlaybookPath()
 	if len(playbook) == 0 {
 		playbook = filepath.Join(tmpdir, "playbook")
-		err = ioutil.WriteFile(playbook, []byte(r.GetPlaybook()), os.FileMode(0600))
+		err = os.WriteFile(playbook, []byte(r.GetPlaybook()), os.FileMode(0600))
 		if err != nil {
 			err = errors.Wrapf(err, "writing playbook %s", playbook)
 			return
@@ -101,7 +100,7 @@ func (r runnable) Run(ctx context.Context) (err error) {
 	var privateKey string
 	if len(r.GetPrivateKey()) > 0 {
 		privateKey = filepath.Join(tmpdir, "private_key")
-		err = ioutil.WriteFile(privateKey, []byte(r.GetPrivateKey()), os.FileMode(0600))
+		err = os.WriteFile(privateKey, []byte(r.GetPrivateKey()), os.FileMode(0600))
 		if err != nil {
 			err = errors.Wrapf(err, "writing private key %s", privateKey)
 			return
@@ -112,7 +111,7 @@ func (r runnable) Run(ctx context.Context) (err error) {
 	var requirements string
 	if len(r.GetRequirements()) > 0 {
 		requirements = filepath.Join(tmpdir, "requirements.yml")
-		err = ioutil.WriteFile(requirements, []byte(r.GetRequirements()), os.FileMode(0600))
+		err = os.WriteFile(requirements, []byte(r.GetRequirements()), os.FileMode(0600))
 		if err != nil {
 			err = errors.Wrapf(err, "writing requirements %s", requirements)
 			return
@@ -128,7 +127,7 @@ func (r runnable) Run(ctx context.Context) (err error) {
 			err = errors.Wrapf(err, "mkdir -p %s", dir)
 			return
 		}
-		err = ioutil.WriteFile(path, content, os.FileMode(0600))
+		err = os.WriteFile(path, content, os.FileMode(0600))
 		if err != nil {
 			err = errors.Wrapf(err, "writing file %s", name)
 			return
@@ -143,14 +142,14 @@ func (r runnable) Run(ctx context.Context) (err error) {
 			return errors.Wrap(err, "unable to marshal map to yaml")
 		}
 		config = filepath.Join(tmpdir, "config")
-		err = ioutil.WriteFile(config, yml, os.FileMode(0600))
+		err = os.WriteFile(config, yml, os.FileMode(0600))
 		if err != nil {
 			return errors.Wrapf(err, "unable to write config to file %s", config)
 		}
 	} else if r.GetConfigYaml() != "" {
 		yml := r.GetConfigYaml()
 		config = filepath.Join(tmpdir, "config")
-		err = ioutil.WriteFile(config, []byte(yml), os.FileMode(0600))
+		err = os.WriteFile(config, []byte(yml), os.FileMode(0600))
 		if err != nil {
 			return errors.Wrapf(err, "unable to write config to file %s", config)
 		}
@@ -207,7 +206,7 @@ func (r runnable) Run(ctx context.Context) (err error) {
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, "ANSIBLE_HOST_KEY_CHECKING=False")
 		// for debug
-		ioutil.WriteFile(path.Join(tmpdir, "run_cmd"), []byte(cmd.String()), os.ModePerm)
+		os.WriteFile(path.Join(tmpdir, "run_cmd"), []byte(cmd.String()), os.ModePerm)
 		stdout, _ := cmd.StdoutPipe()
 		stderr, _ := cmd.StderrPipe()
 		if err1 := cmd.Start(); err1 != nil {

--- a/pkg/util/cephutils/ceph.go
+++ b/pkg/util/cephutils/ceph.go
@@ -17,7 +17,7 @@ package cephutils
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -112,11 +112,11 @@ func (self *CephClient) output(name string, opts []string) (jsonutils.JSONObject
 		return nil, errors.Wrap(err, "start ceph process")
 	}
 
-	stdoutPut, err := ioutil.ReadAll(outb)
+	stdoutPut, err := io.ReadAll(outb)
 	if err != nil {
 		return nil, err
 	}
-	stderrPut, err := ioutil.ReadAll(errb)
+	stderrPut, err := io.ReadAll(errb)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (self *CephClient) GetCapacity() (*SCapacity, error) {
 }
 
 func writeFile(pattern string, content string) (string, error) {
-	file, err := ioutil.TempFile("", pattern)
+	file, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", errors.Wrapf(err, "TempFile")
 	}

--- a/pkg/util/cgrouputils/cgrouputils.go
+++ b/pkg/util/cgrouputils/cgrouputils.go
@@ -17,7 +17,6 @@ package cgrouputils
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -127,7 +126,7 @@ func GetRootParam(module, name, pid string) string {
 func SetRootParam(module, name, value, pid string) bool {
 	param := GetRootParam(module, name, pid)
 	if param != value {
-		err := ioutil.WriteFile(GetTaskParamPath(module, name, pid), []byte(value), 0644)
+		err := os.WriteFile(GetTaskParamPath(module, name, pid), []byte(value), 0644)
 		if err != nil {
 			if len(pid) == 0 {
 				pid = "root"
@@ -142,7 +141,7 @@ func SetRootParam(module, name, value, pid string) bool {
 // cleanup
 func CleanupNonexistPids(module string) {
 	var root = RootTaskPath(module)
-	files, err := ioutil.ReadDir(root)
+	files, err := os.ReadDir(root)
 	if err != nil {
 		log.Errorf("GetTaskIds failed: %s", err)
 		return
@@ -211,7 +210,7 @@ func (c *CGroupTask) GetTaskIds() []string {
 		return nil
 	}
 
-	files, err := ioutil.ReadDir(fmt.Sprintf("/proc/%s/task", c.pid))
+	files, err := os.ReadDir(fmt.Sprintf("/proc/%s/task", c.pid))
 	if err != nil {
 		log.Errorf("GetTaskIds failed: %s", err)
 		return nil

--- a/pkg/util/cgrouputils/cpusetutils.go
+++ b/pkg/util/cgrouputils/cpusetutils.go
@@ -16,7 +16,7 @@ package cgrouputils
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"sync"
@@ -202,7 +202,7 @@ func GetProcessesCpuinfo(pids []string) ([]*ProcessCPUinfo, error) {
 
 func GetAllPids() ([]string, error) {
 	var pids = []string{}
-	files, err := ioutil.ReadDir("/proc")
+	files, err := os.ReadDir("/proc")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/fernetool/fernet.go
+++ b/pkg/util/fernetool/fernet.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -58,14 +58,14 @@ func (m *SFernetKeyManager) SetKeys(keys []*fernet.Key) {
 }
 
 func (m *SFernetKeyManager) LoadKeys(path string) error {
-	filesInfos, err := ioutil.ReadDir(path)
+	filesInfos, err := os.ReadDir(path)
 	if err != nil {
 		return err
 	}
 	keyStrs := make([]string, 0)
 	for i := range filesInfos {
 		fn := filepath.Join(path, filesInfos[i].Name())
-		keyBytes, err := ioutil.ReadFile(fn)
+		keyBytes, err := os.ReadFile(fn)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/fileutils2/fileutils.go
+++ b/pkg/util/fileutils2/fileutils.go
@@ -17,7 +17,6 @@ package fileutils2
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -34,7 +33,7 @@ func Cleandir(sPath string, keepdir bool) error {
 	if f, _ := os.Lstat(sPath); f == nil || f.Mode()&os.ModeSymlink == os.ModeSymlink {
 		return nil
 	}
-	files, _ := ioutil.ReadDir(sPath)
+	files, _ := os.ReadDir(sPath)
 	for _, file := range files {
 		fp := path.Join(sPath, file.Name())
 		if f, _ := os.Lstat(fp); f.Mode()&os.ModeSymlink == os.ModeSymlink {
@@ -71,18 +70,18 @@ func Zerofiles(sPath string) error {
 	case f.Mode().IsRegular():
 		return FilePutContents(sPath, "", false)
 	case f.Mode().IsDir():
-		files, err := ioutil.ReadDir(sPath)
+		files, err := os.ReadDir(sPath)
 		if err != nil {
 			return err
 		}
 		for _, file := range files {
-			if file.Mode()&os.ModeSymlink == os.ModeSymlink {
+			if file.Type()&os.ModeSymlink == os.ModeSymlink {
 				continue
-			} else if file.Mode().IsRegular() {
+			} else if file.Type().IsRegular() {
 				if err := FilePutContents(path.Join(sPath, file.Name()), "", false); err != nil {
 					return err
 				}
-			} else if file.Mode().IsDir() {
+			} else if file.IsDir() {
 				return Zerofiles(path.Join(sPath, file.Name()))
 			}
 		}
@@ -142,10 +141,10 @@ func IsBlockDeviceUsed(dev string) bool {
 
 func GetAllBlkdevsIoSchedulers() ([]string, error) {
 	if _, err := os.Stat("/sys/block"); !os.IsNotExist(err) {
-		blockDevs, err := ioutil.ReadDir("/sys/block")
+		blockDevs, err := os.ReadDir("/sys/block")
 		if err != nil {
 			log.Errorf("ReadDir /sys/block error: %s", err)
-			return nil, errors.Wrap(err, "ioutil.ReadDir(/sys/block)")
+			return nil, errors.Wrap(err, "os.ReadDir(/sys/block)")
 		}
 		for _, b := range blockDevs {
 			if IsBlockDevMounted(b.Name()) {
@@ -176,7 +175,7 @@ func GetAllBlkdevsIoSchedulers() ([]string, error) {
 
 func ChangeAllBlkdevsParams(params map[string]string) {
 	if _, err := os.Stat("/sys/block"); !os.IsNotExist(err) {
-		blockDevs, err := ioutil.ReadDir("/sys/block")
+		blockDevs, err := os.ReadDir("/sys/block")
 		if err != nil {
 			log.Errorf("ReadDir /sys/block error: %s", err)
 			return
@@ -212,7 +211,7 @@ func GetBlkdevConfig(dev, key string) (string, error) {
 }
 
 func FileGetContents(file string) (string, error) {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/fileutils2/seeker.go
+++ b/pkg/util/fileutils2/seeker.go
@@ -16,7 +16,6 @@ package fileutils2
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 
 	"yunion.io/x/log"
@@ -35,7 +34,7 @@ type SReadSeeker struct {
 }
 
 func NewReadSeeker(reader io.Reader, size int64) (*SReadSeeker, error) {
-	tmpfile, err := ioutil.TempFile("", "fakeseeker")
+	tmpfile, err := os.CreateTemp("", "fakeseeker")
 	if err != nil {
 		return nil, errors.Wrap(err, "TempFile")
 	}

--- a/pkg/util/fileutils2/sparse_test.go
+++ b/pkg/util/fileutils2/sparse_test.go
@@ -16,7 +16,6 @@ package fileutils2
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,7 +24,7 @@ import (
 
 func TestSparseFileWriter(t *testing.T) {
 	writeTmp := func(t *testing.T, want []byte, partSizes []int) {
-		f, err := ioutil.TempFile("", "sparse-test-")
+		f, err := os.CreateTemp("", "sparse-test-")
 		if err != nil {
 			t.Fatalf("tmpfile: %v", err)
 		}
@@ -46,7 +45,7 @@ func TestSparseFileWriter(t *testing.T) {
 			}
 		}()
 
-		got, err := ioutil.ReadFile(f.Name())
+		got, err := os.ReadFile(f.Name())
 		if err != nil {
 			t.Fatalf("read tmpfile: %v", err)
 		}

--- a/pkg/util/httputils/httputils.go
+++ b/pkg/util/httputils/httputils.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -464,7 +463,7 @@ func Request(client sClient, ctx context.Context, method THttpMethod, urlStr str
 		var reqBody string
 		if bodySeeker, ok := body.(io.ReadSeeker); ok {
 			bodySeeker.Seek(0, io.SeekStart)
-			reqBodyBytes, _ := ioutil.ReadAll(bodySeeker)
+			reqBodyBytes, _ := io.ReadAll(bodySeeker)
 			if reqBodyBytes != nil {
 				reqBody = string(reqBodyBytes)
 			}
@@ -604,7 +603,7 @@ func CloseResponse(resp *http.Response) {
 		// Without this closing connection would disallow re-using
 		// the same connection for future uses.
 		//  - http://stackoverflow.com/a/17961593/4465767
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}
 }
@@ -632,7 +631,7 @@ func (client *JsonClient) Send(ctx context.Context, req JsonRequest, response Js
 		}
 	}
 
-	rbody, err := ioutil.ReadAll(resp.Body)
+	rbody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		ce := newJsonClientErrorFromRequest(resp.Request, bodystr)
 		ce.Code = resp.StatusCode
@@ -697,7 +696,7 @@ func ParseResponse(reqBody string, resp *http.Response, err error, debug bool) (
 			red(string(dump))
 		}
 	}
-	rbody, err := ioutil.ReadAll(resp.Body)
+	rbody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		ce := newJsonClientErrorFromRequest(resp.Request, reqBody)
 		ce.Code = 499
@@ -743,7 +742,7 @@ func ParseJSONResponse(reqBody string, resp *http.Response, err error, debug boo
 		}
 	}
 
-	rbody, err := ioutil.ReadAll(resp.Body)
+	rbody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		ce := newJsonClientErrorFromRequest(resp.Request, reqBody)
 		ce.Code = 499

--- a/pkg/util/influxdb/influxdb.go
+++ b/pkg/util/influxdb/influxdb.go
@@ -17,7 +17,7 @@ package influxdb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -74,9 +74,9 @@ func (db *SInfluxdb) Write(data string, precision string) error {
 		return errors.Wrap(err, "httputils.Request")
 	}
 	defer httputils.CloseResponse(resp)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.Wrap(err, "ioutil.ReadAll")
+		return errors.Wrap(err, "io.ReadAll")
 	}
 	if resp.StatusCode >= 300 {
 		return errors.Error(fmt.Sprintf("Status: %d Message: %s", resp.StatusCode, string(b)))
@@ -96,9 +96,9 @@ func (db *SInfluxdb) BatchWrite(data []string, precision string) error {
 		return errors.Wrap(err, "httputils.Request")
 	}
 	defer httputils.CloseResponse(resp)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.Wrap(err, "ioutil.ReadAll")
+		return errors.Wrap(err, "io.ReadAll")
 	}
 	if resp.StatusCode >= 300 {
 		return errors.Error(fmt.Sprintf("Status: %d Message: %s", resp.StatusCode, string(b)))

--- a/pkg/util/nodeid/nodeid.go
+++ b/pkg/util/nodeid/nodeid.go
@@ -20,7 +20,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -55,7 +54,7 @@ func stringToLines(s string) (lines []string, err error) {
 
 func getLinuxMacAddress() (string, error) {
 	path := "/sys/class/net/"
-	fs, e := ioutil.ReadDir(path)
+	fs, e := os.ReadDir(path)
 	if e != nil {
 		return "", e
 	}
@@ -67,7 +66,7 @@ func getLinuxMacAddress() (string, error) {
 		if e != nil || !strings.Contains(link, "/pci") {
 			continue
 		}
-		u, e := ioutil.ReadFile(path + f.Name() + "/address")
+		u, e := os.ReadFile(path + f.Name() + "/address")
 		if e == nil {
 			us := strings.TrimSpace(string(u))
 			isNew := true
@@ -101,7 +100,7 @@ func getLinuxMacAddress() (string, error) {
 }
 
 func getLinuxCpuInfo() (string, error) {
-	u, e := ioutil.ReadFile("/proc/cpuinfo")
+	u, e := os.ReadFile("/proc/cpuinfo")
 	if e != nil {
 		return "", e
 	}

--- a/pkg/util/procutils/proc.go
+++ b/pkg/util/procutils/proc.go
@@ -17,7 +17,7 @@ package procutils
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -26,7 +26,7 @@ import (
 
 func GetProcCmdline(pid uint) ([]string, error) {
 	pPath := filepath.Join("/proc", fmt.Sprintf("%d", pid), "cmdline")
-	content, err := ioutil.ReadFile(pPath)
+	content, err := os.ReadFile(pPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "ReadFile %q", pPath)
 	}

--- a/pkg/util/procutils/zombie_others.go
+++ b/pkg/util/procutils/zombie_others.go
@@ -19,7 +19,6 @@ package procutils
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -40,7 +39,7 @@ func WaitZombieLoop(ctx context.Context) {
 
 	tick := time.NewTicker(31 * time.Second)
 	for {
-		dirs, err := ioutil.ReadDir("/proc")
+		dirs, err := os.ReadDir("/proc")
 		if err != nil {
 			log.Errorf("read /proc dir: %v", err)
 		}
@@ -63,7 +62,7 @@ func WaitZombieLoop(ctx context.Context) {
 
 			// read /proc/<pid>/stat
 			statPath := filepath.Join("/proc", name, "stat")
-			data, err := ioutil.ReadFile(statPath)
+			data, err := os.ReadFile(statPath)
 			if err != nil {
 				log.Errorf("read %s: %v", statPath, err)
 				continue

--- a/pkg/util/samlutils/encrypt.go
+++ b/pkg/util/samlutils/encrypt.go
@@ -24,7 +24,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"hash"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/pkg/errors"
 
@@ -33,18 +33,18 @@ import (
 )
 
 func (saml *SSAMLInstance) parseKeys() error {
-	privData, err := ioutil.ReadFile(saml.privateKeyFile)
+	privData, err := os.ReadFile(saml.privateKeyFile)
 	if err != nil {
-		return errors.Wrapf(err, "ioutil.ReadFile %s", saml.privateKeyFile)
+		return errors.Wrapf(err, "os.ReadFile %s", saml.privateKeyFile)
 	}
 	saml.privateKey, err = seclib2.DecodePrivateKey(privData)
 	if err != nil {
 		return errors.Wrap(err, "decodePrivateKey")
 	}
 
-	certData, err := ioutil.ReadFile(saml.certFile)
+	certData, err := os.ReadFile(saml.certFile)
 	if err != nil {
-		return errors.Wrapf(err, "ioutil.Readfile %s", saml.certFile)
+		return errors.Wrapf(err, "os.Readfile %s", saml.certFile)
 	}
 
 	var block *pem.Block

--- a/pkg/util/samlutils/idp/idp.go
+++ b/pkg/util/samlutils/idp/idp.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/xml"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	"yunion.io/x/log"
@@ -111,9 +111,9 @@ func (idp *SSAMLIdpInstance) SetHtmlTemplate(entry i18n.TableEntry) error {
 }
 
 func (idp *SSAMLIdpInstance) AddSPMetadataFile(filename string) error {
-	metadata, err := ioutil.ReadFile(filename)
+	metadata, err := os.ReadFile(filename)
 	if err != nil {
-		return errors.Wrap(err, "ioutil.ReadFile")
+		return errors.Wrap(err, "os.ReadFile")
 	}
 	return idp.AddSPMetadata(metadata)
 }

--- a/pkg/util/samlutils/sp/sp.go
+++ b/pkg/util/samlutils/sp/sp.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/xml"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	"yunion.io/x/jsonutils"
@@ -83,9 +83,9 @@ func (sp *SSAMLSpInstance) GetIdentityProviders() []*SSAMLIdentityProvider {
 }
 
 func (sp *SSAMLSpInstance) AddIdpMetadataFile(filename string) error {
-	metadata, err := ioutil.ReadFile(filename)
+	metadata, err := os.ReadFile(filename)
 	if err != nil {
-		return errors.Wrap(err, "ioutil.ReadFile")
+		return errors.Wrap(err, "os.ReadFile")
 	}
 	return sp.AddIdpMetadata(metadata)
 }

--- a/pkg/util/seclib2/certfile.go
+++ b/pkg/util/seclib2/certfile.go
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -37,13 +37,13 @@ const (
 //
 // Callers are responsible for removing the returned tmpfile
 func MergeCaCertFiles(cafile string, certfile string) (string, error) {
-	tmpfile, err := ioutil.TempFile("", "cerfile.*.crt")
+	tmpfile, err := os.CreateTemp("", "cerfile.*.crt")
 	if err != nil {
 		return "", fmt.Errorf("fail to open tempfile for ca cerfile: %s", err)
 	}
 	defer tmpfile.Close()
 
-	cont, err := ioutil.ReadFile(certfile)
+	cont, err := os.ReadFile(certfile)
 	if err != nil {
 		return "", fmt.Errorf("fail to read certfile %s", err)
 	}
@@ -55,7 +55,7 @@ func MergeCaCertFiles(cafile string, certfile string) (string, error) {
 		offset -= 1
 	}
 	tmpfile.Write(cont[offset:])
-	cont, err = ioutil.ReadFile(cafile)
+	cont, err = os.ReadFile(cafile)
 	if err != nil {
 		return "", fmt.Errorf("fail to read cafile %s", err)
 	}

--- a/pkg/util/seclib2/tls.go
+++ b/pkg/util/seclib2/tls.go
@@ -19,7 +19,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
@@ -78,7 +78,7 @@ func NewCertPool(CAFiles []string) (*x509.CertPool, error) {
 	certPool := x509.NewCertPool()
 
 	for _, CAFile := range CAFiles {
-		pemByte, err := ioutil.ReadFile(CAFile)
+		pemByte, err := os.ReadFile(CAFile)
 		if err != nil {
 			return nil, err
 		}
@@ -102,12 +102,12 @@ func NewCertPool(CAFiles []string) (*x509.CertPool, error) {
 
 // NewCert generates TLS cert by using the given cert,key and parse function.
 func NewCert(certfile, keyfile string, parseFunc func([]byte, []byte) (tls.Certificate, error)) (*tls.Certificate, error) {
-	cert, err := ioutil.ReadFile(certfile)
+	cert, err := os.ReadFile(certfile)
 	if err != nil {
 		return nil, err
 	}
 
-	key, err := ioutil.ReadFile(keyfile)
+	key, err := os.ReadFile(keyfile)
 	if err != nil {
 		return nil, err
 	}
@@ -124,13 +124,13 @@ func NewCert(certfile, keyfile string, parseFunc func([]byte, []byte) (tls.Certi
 }
 
 func InitTLSConfig(certFile, keyFile string) (*tls.Config, error) {
-	allCertPEM, err := ioutil.ReadFile(certFile)
+	allCertPEM, err := os.ReadFile(certFile)
 	if err != nil {
 		log.Errorf("read tls certfile fail %s", err)
 		return nil, err
 	}
 	certPEMs := splitCert(allCertPEM)
-	keyPEM, err := ioutil.ReadFile(keyFile)
+	keyPEM, err := os.ReadFile(keyFile)
 	if err != nil {
 		log.Errorf("read tls keyfile fail %s", err)
 		return nil, err

--- a/pkg/util/shellutils/edit.go
+++ b/pkg/util/shellutils/edit.go
@@ -15,7 +15,6 @@
 package shellutils
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -23,9 +22,9 @@ import (
 )
 
 func Edit(yaml string) (string, error) {
-	tmpfile, err := ioutil.TempFile("", "policy-blob")
+	tmpfile, err := os.CreateTemp("", "policy-blob")
 	if err != nil {
-		return "", errors.Wrap(err, "ioutil.TempFile")
+		return "", errors.Wrap(err, "os.CreateTemp")
 	}
 	defer os.Remove(tmpfile.Name()) // clean up
 
@@ -44,9 +43,9 @@ func Edit(yaml string) (string, error) {
 		return "", errors.Wrap(err, "cmd.Run")
 	}
 
-	policyBytes, err := ioutil.ReadFile(tmpfile.Name())
+	policyBytes, err := os.ReadFile(tmpfile.Name())
 	if err != nil {
-		return "", errors.Wrap(err, "ioutil.ReadFile")
+		return "", errors.Wrap(err, "os.ReadFile")
 	}
 
 	if yaml == string(policyBytes) {

--- a/pkg/util/sysutils/hugepages.go
+++ b/pkg/util/sysutils/hugepages.go
@@ -15,7 +15,7 @@
 package sysutils
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -64,12 +64,12 @@ func fetchHugepageInfo(sizeKb int, dir string) (SHugepageInfo, error) {
 	info := SHugepageInfo{
 		SizeKb: sizeKb,
 	}
-	cont, err := ioutil.ReadFile(filepath.Join(dir, "nr_hugepages"))
+	cont, err := os.ReadFile(filepath.Join(dir, "nr_hugepages"))
 	if err != nil {
 		return info, errors.Wrap(err, "FileGetContents nr_hugepages")
 	}
 	total, _ := strconv.Atoi(strings.TrimSpace(string(cont)))
-	cont, err = ioutil.ReadFile(filepath.Join(dir, "free_hugepages"))
+	cont, err = os.ReadFile(filepath.Join(dir, "free_hugepages"))
 	if err != nil {
 		return info, errors.Wrap(err, "FileGetContents free_hugepages")
 	}
@@ -81,7 +81,7 @@ func fetchHugepageInfo(sizeKb int, dir string) (SHugepageInfo, error) {
 
 func GetHugepages() (THugepages, error) {
 	const hugepageDir = "/sys/kernel/mm/hugepages"
-	files, err := ioutil.ReadDir(hugepageDir)
+	files, err := os.ReadDir(hugepageDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "ReadDir %s", hugepageDir)
 	}

--- a/pkg/util/sysutils/kvm.go
+++ b/pkg/util/sysutils/kvm.go
@@ -15,7 +15,6 @@
 package sysutils
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -217,7 +216,7 @@ func IsKernelModuleLoaded(name string) bool {
 
 func SetSysConfig(cpath, val string) bool {
 	if fileutils2.Exists(cpath) {
-		oval, err := ioutil.ReadFile(cpath)
+		oval, err := os.ReadFile(cpath)
 		if err != nil {
 			log.Errorln(err)
 			return false

--- a/pkg/util/sysutils/nics.go
+++ b/pkg/util/sysutils/nics.go
@@ -15,7 +15,6 @@
 package sysutils
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -34,10 +33,10 @@ const (
 
 func Nics() ([]*types.SNicDevInfo, error) {
 	if _, err := os.Stat(sysNetPath); !os.IsNotExist(err) {
-		nicDevs, err := ioutil.ReadDir(sysNetPath)
+		nicDevs, err := os.ReadDir(sysNetPath)
 		if err != nil {
 			log.Errorf("ReadDir %s error: %s", sysNetPath, err)
-			return nil, errors.Wrapf(err, "ioutil.ReadDir(%s)", sysNetPath)
+			return nil, errors.Wrapf(err, "os.ReadDir(%s)", sysNetPath)
 		}
 		nics := make([]*types.SNicDevInfo, 0)
 		for _, nic := range nicDevs {

--- a/pkg/util/tls/cert/cert.go
+++ b/pkg/util/tls/cert/cert.go
@@ -39,9 +39,9 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -113,9 +113,9 @@ func GenerateSelfSignedCertKeyWithFixtures(host string, alternateIPs []net.IP, a
 	certFixturePath := filepath.Join(fixtureDirectory, baseName+".crt")
 	keyFixturePath := filepath.Join(fixtureDirectory, baseName+".key")
 	if len(fixtureDirectory) > 0 {
-		cert, err := ioutil.ReadFile(certFixturePath)
+		cert, err := os.ReadFile(certFixturePath)
 		if err == nil {
-			key, err := ioutil.ReadFile(keyFixturePath)
+			key, err := os.ReadFile(keyFixturePath)
 			if err == nil {
 				return cert, key, nil
 			}
@@ -200,10 +200,10 @@ func GenerateSelfSignedCertKeyWithFixtures(host string, alternateIPs []net.IP, a
 	}
 
 	if len(fixtureDirectory) > 0 {
-		if err := ioutil.WriteFile(certFixturePath, certBuffer.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(certFixturePath, certBuffer.Bytes(), 0644); err != nil {
 			return nil, nil, fmt.Errorf("failed to write cert fixture to %s: %v", certFixturePath, err)
 		}
-		if err := ioutil.WriteFile(keyFixturePath, keyBuffer.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(keyFixturePath, keyBuffer.Bytes(), 0644); err != nil {
 			return nil, nil, fmt.Errorf("failed to write key fixture to %s: %v", certFixturePath, err)
 		}
 	}

--- a/pkg/util/tls/cert/csr_test.go
+++ b/pkg/util/tls/cert/csr_test.go
@@ -34,8 +34,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"net"
+	"os"
 	"testing"
 
 	keyutil "yunion.io/x/onecloud/pkg/util/tls/key"
@@ -49,7 +49,7 @@ func TestMakeCSR(t *testing.T) {
 	dnsSANs := []string{"localhost"}
 	ipSANs := []net.IP{net.ParseIP("127.0.0.1")}
 
-	keyData, err := ioutil.ReadFile(keyFile)
+	keyData, err := os.ReadFile(keyFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/tls/cert/io.go
+++ b/pkg/util/tls/cert/io.go
@@ -33,7 +33,6 @@ package cert
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -80,13 +79,13 @@ func WriteCert(certPath string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(certPath), os.FileMode(0755)); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(certPath, data, os.FileMode(0644))
+	return os.WriteFile(certPath, data, os.FileMode(0644))
 }
 
 // NewPool returns an x509.CertPool containing the certificates in the given PEM-encoded file.
 // Returns an error if the file could not be read, a certificate could not be parsed, or if the file does not contain any certificates
 func NewPool(filename string) (*x509.CertPool, error) {
-	pemBlock, err := ioutil.ReadFile(filename)
+	pemBlock, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +114,7 @@ func NewPoolFromBytes(pemBlock []byte) (*x509.CertPool, error) {
 // CertsFromFile returns the x509.Certificates contained in the given PEM-encoded file.
 // Returns an error if the file could not be read, a certificate could not be parsed, or if the file does not contain any certificates
 func CertsFromFile(file string) ([]*x509.Certificate, error) {
-	pemBlock, err := ioutil.ReadFile(file)
+	pemBlock, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/tls/key/key.go
+++ b/pkg/util/tls/key/key.go
@@ -40,7 +40,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -83,13 +82,13 @@ func WriteKey(keyPath string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(keyPath), os.FileMode(0755)); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(keyPath, data, os.FileMode(0600))
+	return os.WriteFile(keyPath, data, os.FileMode(0600))
 }
 
 // LoadOrGenerateKeyFile looks for a key in the file at the given path. If it
 // can't find one, it will generate a new key and store it there.
 func LoadOrGenerateKeyFile(keyPath string) (data []byte, wasGenerated bool, err error) {
-	loadedData, err := ioutil.ReadFile(keyPath)
+	loadedData, err := os.ReadFile(keyPath)
 	// Call verifyKeyData to ensure the file wasn't empty/corrupt.
 	if err == nil && verifyKeyData(loadedData) {
 		return loadedData, false, err
@@ -136,7 +135,7 @@ func MarshalPrivateKeyToPEM(privateKey crypto.PrivateKey) ([]byte, error) {
 // PrivateKeyFromFile returns the private key in rsa.PrivateKey or ecdsa.PrivateKey format from a given PEM-encoded file.
 // Returns an error if the file could not be read or if the private key could not be parsed.
 func PrivateKeyFromFile(file string) (interface{}, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +149,7 @@ func PrivateKeyFromFile(file string) (interface{}, error) {
 // PublicKeysFromFile returns the public keys in rsa.PublicKey or ecdsa.PublicKey format from a given PEM-encoded file.
 // Reads public keys from both public and private key files.
 func PublicKeysFromFile(file string) ([]interface{}, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/tls/key/key_test.go
+++ b/pkg/util/tls/key/key_test.go
@@ -31,7 +31,6 @@ limitations under the License.
 package key
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -129,7 +128,7 @@ q2bbtE7r1JMK+/sQA5sNAp+7Vdc3psr1OaNzyTyuhTECyRdFKXm63cMnGg==
 )
 
 func TestReadPrivateKey(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("error creating tmpfile: %v", err)
 	}
@@ -139,21 +138,21 @@ func TestReadPrivateKey(t *testing.T) {
 		t.Fatalf("Expected error reading key from empty file, got none")
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte(rsaPrivateKey), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(rsaPrivateKey), os.FileMode(0600)); err != nil {
 		t.Fatalf("error writing private key to tmpfile: %v", err)
 	}
 	if _, err := PrivateKeyFromFile(f.Name()); err != nil {
 		t.Fatalf("error reading private RSA key: %v", err)
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte(ecdsaPrivateKey), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(ecdsaPrivateKey), os.FileMode(0600)); err != nil {
 		t.Fatalf("error writing private key to tmpfile: %v", err)
 	}
 	if _, err := PrivateKeyFromFile(f.Name()); err != nil {
 		t.Fatalf("error reading private ECDSA key: %v", err)
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte(ecdsaPrivateKeyWithParams), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(ecdsaPrivateKeyWithParams), os.FileMode(0600)); err != nil {
 		t.Fatalf("error writing private key to tmpfile: %v", err)
 	}
 	if _, err := PrivateKeyFromFile(f.Name()); err != nil {
@@ -162,7 +161,7 @@ func TestReadPrivateKey(t *testing.T) {
 }
 
 func TestReadPublicKeys(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("error creating tmpfile: %v", err)
 	}
@@ -172,7 +171,7 @@ func TestReadPublicKeys(t *testing.T) {
 		t.Fatalf("Expected error reading keys from empty file, got none")
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte(rsaPublicKey), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(rsaPublicKey), os.FileMode(0600)); err != nil {
 		t.Fatalf("error writing public key to tmpfile: %v", err)
 	}
 	if keys, err := PublicKeysFromFile(f.Name()); err != nil {
@@ -181,7 +180,7 @@ func TestReadPublicKeys(t *testing.T) {
 		t.Fatalf("expected 1 key, got %d", len(keys))
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte(ecdsaPublicKey), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(ecdsaPublicKey), os.FileMode(0600)); err != nil {
 		t.Fatalf("error writing public key to tmpfile: %v", err)
 	}
 	if keys, err := PublicKeysFromFile(f.Name()); err != nil {
@@ -190,7 +189,7 @@ func TestReadPublicKeys(t *testing.T) {
 		t.Fatalf("expected 1 key, got %d", len(keys))
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte(rsaPublicKey+"\n"+ecdsaPublicKey), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(rsaPublicKey+"\n"+ecdsaPublicKey), os.FileMode(0600)); err != nil {
 		t.Fatalf("error writing public key to tmpfile: %v", err)
 	}
 	if keys, err := PublicKeysFromFile(f.Name()); err != nil {
@@ -199,7 +198,7 @@ func TestReadPublicKeys(t *testing.T) {
 		t.Fatalf("expected 2 keys, got %d", len(keys))
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte(certificate), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(certificate), os.FileMode(0600)); err != nil {
 		t.Fatalf("error writing certificate to tmpfile: %v", err)
 	}
 	if keys, err := PublicKeysFromFile(f.Name()); err != nil {

--- a/pkg/util/tls/pki/pki_helpers.go
+++ b/pkg/util/tls/pki/pki_helpers.go
@@ -40,7 +40,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"net"
@@ -207,7 +206,7 @@ func WriteCSR(csrDir, name string, csr *x509.CertificateRequest) error {
 		return errors.Wrapf(err, "failed to make directory %s", filepath.Dir(csrPath))
 	}
 
-	if err := ioutil.WriteFile(csrPath, EncodeCSRPEM(csr), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(csrPath, EncodeCSRPEM(csr), os.FileMode(0600)); err != nil {
 		return errors.Wrapf(err, "unable to write CSR to file %s", csrPath)
 	}
 
@@ -355,7 +354,7 @@ func TryLoadCSRFromDisk(pkiPath, name string) (*x509.CertificateRequest, error) 
 // CertificateRequestFromFile returns the CertificateRequest from a given PEM-encoded file.
 // Returns an error if the file could not be read or if the CSR could not be parsed.
 func CertificateRequestFromFile(file string) (*x509.CertificateRequest, error) {
-	pemBlock, err := ioutil.ReadFile(file)
+	pemBlock, err := os.ReadFile(file)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read file")
 	}

--- a/pkg/util/winutils/winutils.go
+++ b/pkg/util/winutils/winutils.go
@@ -18,7 +18,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"regexp"
 	"strconv"
@@ -71,7 +71,7 @@ type SWinRegTool struct {
 }
 
 func (w *SWinRegTool) CheckPath() bool {
-	files, err := ioutil.ReadDir(w.ConfigPath)
+	files, err := os.ReadDir(w.ConfigPath)
 	if err != nil {
 		log.Errorln(err)
 		return false
@@ -148,11 +148,11 @@ func (w *SWinRegTool) samChange(user string, seq ...string) error {
 		io.WriteString(stdin, s+"\n")
 	}
 	io.WriteString(stdin, CONFIRM+"\n")
-	stdoutPut, err := ioutil.ReadAll(outb)
+	stdoutPut, err := io.ReadAll(outb)
 	if err != nil {
 		return err
 	}
-	stderrOutPut, err := ioutil.ReadAll(errb)
+	stderrOutPut, err := io.ReadAll(errb)
 	if err != nil {
 		return err
 	}
@@ -243,7 +243,7 @@ func (w *SWinRegTool) showRegistry(spath string, keySeg []string, verb string) (
 	keypath := strings.Join(keySeg, "\\")
 	io.WriteString(stdin, fmt.Sprintf("%s %s\n", verb, keypath))
 	io.WriteString(stdin, "q\n")
-	stdoutPut, err := ioutil.ReadAll(outb)
+	stdoutPut, err := io.ReadAll(outb)
 	if err != nil {
 		return nil, err
 	}
@@ -346,12 +346,12 @@ func (w *SWinRegTool) cmdRegistry(spath string, ops []string, retcode []int) boo
 	}
 	io.WriteString(stdin, "q\n")
 	io.WriteString(stdin, CONFIRM+"\n")
-	stdoutPut, err := ioutil.ReadAll(outb)
+	stdoutPut, err := io.ReadAll(outb)
 	if err != nil {
 		log.Errorln(err)
 		return false
 	}
-	stderrOutPut, err := ioutil.ReadAll(errb)
+	stderrOutPut, err := io.ReadAll(errb)
 	if err != nil {
 		log.Errorln(err)
 		return false

--- a/pkg/webconsole/command/ssh_command.go
+++ b/pkg/webconsole/command/ssh_command.go
@@ -17,7 +17,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -78,7 +77,7 @@ func getCommand(ctx context.Context, us *mcclient.ClientSession, ip string, port
 	if err != nil {
 		return "", nil, err
 	}
-	file, err := ioutil.TempFile("", fmt.Sprintf("id_rsa.%s.", ip))
+	file, err := os.CreateTemp("", fmt.Sprintf("id_rsa.%s.", ip))
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/webconsole/handlers.go
+++ b/pkg/webconsole/handlers.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
@@ -102,7 +102,7 @@ func fetchK8sEnv(ctx context.Context, w http.ResponseWriter, r *http.Request) (*
 	if err != nil {
 		return nil, httperrors.NewNotFoundError("Not found cluster %q kubeconfig", k8sReq.Cluster)
 	}
-	f, err := ioutil.TempFile("", "kubeconfig-")
+	f, err := os.CreateTemp("", "kubeconfig-")
 	if err != nil {
 		return nil, fmt.Errorf("Save kubeconfig error: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

NONE

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
