### PR TITLE
fix(climc): always net vlan_id to 1 when updating network

### DIFF
--- a/pkg/mcclient/options/network.go
+++ b/pkg/mcclient/options/network.go
@@ -68,7 +68,7 @@ type NetworkUpdateOptions struct {
 	Domain      string `help:"Domain"`
 	Dhcp        string `help:"DHCP server IP"`
 	Ntp         string `help:"Ntp server domain names"`
-	VlanId      int64  `help:"Vlan ID" default:"1"`
+	VlanId      int64  `help:"Vlan ID"`
 	ExternalId  string `help:"External ID"`
 	AllocPolicy string `help:"Address allocation policy" choices:"none|stepdown|stepup|random"`
 	IsAutoAlloc *bool  `help:"Add network into auto-allocation pool" negative:"no_auto_alloc"`


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area climc
- 3.8
@ioito @swordqiu 