### PR TITLE
Automated cherry pick of #15097: fix(ansibleserver): force sleep 15s before running playbook

### DIFF
--- a/pkg/ansibleserver/models/ansibleplaybooks_v2.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks_v2.go
@@ -157,6 +157,9 @@ func (apb *SAnsiblePlaybookV2) runPlaybook(ctx context.Context, userCred mcclien
 		return fmt.Errorf("playbook is already running")
 	}
 
+	// hack: force Sleep 15s to wait some host ssh service started
+	time.Sleep(15 * time.Second)
+
 	var (
 		privateKey string
 		err        error


### PR DESCRIPTION
Cherry pick of #15097 on release/3.8.

#15097: fix(ansibleserver): force sleep 15s before running playbook