### PR TITLE
Automated cherry pick of #15137: fix(region): snapshot time zone

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -2534,8 +2534,8 @@ func (manager *SDiskManager) CleanPendingDeleteDisks(ctx context.Context, userCr
 }
 
 func (manager *SDiskManager) getAutoSnapshotDisksId(isExternal bool) ([]SSnapshotPolicyDisk, error) {
-
-	t := time.Now()
+	tz, _ := time.LoadLocation(options.Options.TimeZone)
+	t := time.Now().In(tz)
 	week := t.Weekday()
 	if week == 0 { // sunday is zero
 		week += 7


### PR DESCRIPTION
Cherry pick of #15137 on release/3.8.

#15137: fix(region): snapshot time zone