### PR TITLE
fix: debian 11 support missing at release/3.8

### DIFF
--- a/pkg/util/imagetools/image_test.go
+++ b/pkg/util/imagetools/image_test.go
@@ -101,6 +101,14 @@ func TestNormalizeImageInfo(t *testing.T) {
 			OsLang:    "",
 			OsArch:    "x86_64",
 		},
+		{
+			Name:      "Debian 11.4 64位",
+			OsDistro:  "Debian",
+			OsType:    osprofile.OS_TYPE_LINUX,
+			OsVersion: "11.4",
+			OsLang:    "",
+			OsArch:    "x86_64",
+		},
 	}
 
 	for _, image := range images {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: debian 11 support missing at release/3.8

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @ioito @zexi 