### PR TITLE
Automated cherry pick of #15160: fix: debian 11 support missing at release/3.8

### DIFF
--- a/pkg/util/imagetools/image_test.go
+++ b/pkg/util/imagetools/image_test.go
@@ -101,6 +101,14 @@ func TestNormalizeImageInfo(t *testing.T) {
 			OsLang:    "",
 			OsArch:    "x86_64",
 		},
+		{
+			Name:      "Debian 11.4 64位",
+			OsDistro:  "Debian",
+			OsType:    osprofile.OS_TYPE_LINUX,
+			OsVersion: "11.4",
+			OsLang:    "",
+			OsArch:    "x86_64",
+		},
 	}
 
 	for _, image := range images {


### PR DESCRIPTION
Cherry pick of #15160 on release/3.9.

#15160: fix: debian 11 support missing at release/3.8