### PR TITLE
Automated cherry pick of #15160: fix: debian 11 support missing at release/3.8

### DIFF
--- a/pkg/util/imagetools/image_test.go
+++ b/pkg/util/imagetools/image_test.go
@@ -101,6 +101,14 @@ func TestNormalizeImageInfo(t *testing.T) {
 			OsLang:    "",
 			OsArch:    "x86_64",
 		},
+		{
+			Name:      "Debian 11.4 64位",
+			OsDistro:  "Debian",
+			OsType:    osprofile.OS_TYPE_LINUX,
+			OsVersion: "11.4",
+			OsLang:    "",
+			OsArch:    "x86_64",
+		},
 	}
 
 	for _, image := range images {

--- a/pkg/util/imagetools/imagetools.go
+++ b/pkg/util/imagetools/imagetools.go
@@ -126,7 +126,7 @@ var imageVersions = map[string][]string{
 
 	"OpenSUSE": {"11", "12"},
 	"SUSE":     {"10", "11", "12", "13"},
-	"Debian":   {"6", "7", "8", "9", "10"},
+	"Debian":   {"6", "7", "8", "9", "10", "11"},
 	"CoreOS":   {"7"},
 	"EulerOS":  {"2"},
 	"Aliyun":   {},


### PR DESCRIPTION
Cherry pick of #15160 on release/3.8.

#15160: fix: debian 11 support missing at release/3.8