### PR TITLE
fix: ssd(rotation_rate=1) option only applicable to scsi-hd device

### DIFF
--- a/pkg/hostman/guestman/qemu/generate.go
+++ b/pkg/hostman/guestman/qemu/generate.go
@@ -296,7 +296,9 @@ func getDiskDeviceOption(optDrv QemuOptions, disk *desc.SGuestDisk) string {
 	}
 	opt += fmt.Sprintf(",id=drive_%d", diskIndex)
 	if isSsd {
-		opt += ",rotation_rate=1"
+		if diskDriver == DISK_DRIVER_SCSI {
+			opt += ",rotation_rate=1"
+		}
 	}
 	return optDrv.Device(opt)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: ssd(rotation_rate=1) option only applicable to scsi-hd device

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi 