### PR TITLE
Automated cherry pick of #15163: fix: ssd(rotation_rate=1) option only applicable to scsi-hd device

### DIFF
--- a/pkg/hostman/guestman/qemu/generate.go
+++ b/pkg/hostman/guestman/qemu/generate.go
@@ -363,7 +363,9 @@ func getDiskDeviceOption(optDrv QemuOptions, disk api.GuestdiskJsonDesc, isArm b
 	}
 	opt += fmt.Sprintf(",id=drive_%d", diskIndex)
 	if isSsd {
-		opt += ",rotation_rate=1"
+		if diskDriver == DISK_DRIVER_SCSI {
+			opt += ",rotation_rate=1"
+		}
 	}
 	return optDrv.Device(opt)
 


### PR DESCRIPTION
Cherry pick of #15163 on release/3.9.

#15163: fix: ssd(rotation_rate=1) option only applicable to scsi-hd device