### PR TITLE
Automated cherry pick of #15163: fix: ssd(rotation_rate=1) option only applicable to scsi-hd device

### DIFF
--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -270,7 +270,9 @@ func (s *SKVMGuestInstance) getVdiskDesc(disk api.GuestdiskJsonDesc, isArm bool)
 	}
 	cmd += fmt.Sprintf(",id=drive_%d", diskIndex)
 	if isSsd {
-		cmd += ",rotation_rate=1"
+		if diskDriver == DISK_DRIVER_SCSI {
+			cmd += ",rotation_rate=1"
+		}
 	}
 	return cmd
 }


### PR DESCRIPTION
Cherry pick of #15163 on release/3.8.

#15163: fix: ssd(rotation_rate=1) option only applicable to scsi-hd device