### PR TITLE
Automated cherry pick of #15204: fix(ansibleserver): force sleep 50s before running

### DIFF
--- a/pkg/ansibleserver/models/ansibleplaybooks_v2.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks_v2.go
@@ -157,8 +157,8 @@ func (apb *SAnsiblePlaybookV2) runPlaybook(ctx context.Context, userCred mcclien
 		return fmt.Errorf("playbook is already running")
 	}
 
-	// hack: force Sleep 15s to wait some host ssh service started
-	time.Sleep(15 * time.Second)
+	// hack: force Sleep 50s to wait some host ssh service started
+	time.Sleep(50 * time.Second)
 
 	var (
 		privateKey string


### PR DESCRIPTION
Cherry pick of #15204 on release/3.8.

#15204: fix(ansibleserver): force sleep 50s before running