### PR TITLE
feat(region,host): support assign bootindex for cdrom or disks

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -97,7 +97,8 @@ type DiskConfig struct {
 
 	// 挂载到虚拟机的磁盘顺序, -1代表不挂载任何虚拟机
 	// default: -1
-	Index int `json:"index"`
+	Index     int   `json:"index"`
+	BootIndex *int8 `json:"boot_index"`
 
 	// 镜像ID,通过镜像创建磁盘,创建虚拟机时第一块磁盘需要指定此参数
 	// required: false
@@ -397,7 +398,8 @@ type ServerCreateInput struct {
 
 	// 使用ISO光盘启动, 仅KVM平台支持
 	// required: false
-	Cdrom string `json:"cdrom"`
+	Cdrom          string `json:"cdrom"`
+	CdromBootIndex *int8  `json:"cdrom_boot_index"`
 
 	// enum: cirros, vmware, qxl, std
 	// default: std

--- a/pkg/apis/compute/cdrom.go
+++ b/pkg/apis/compute/cdrom.go
@@ -15,9 +15,10 @@
 package compute
 
 type GuestcdromJsonDesc struct {
-	Ordinal int    `json:"ordinal"`
-	ImageId string `json:"image_id"`
-	Path    string `json:"path"`
-	Name    string `json:"name"`
-	Size    int64  `json:"size"`
+	Ordinal   int    `json:"ordinal"`
+	ImageId   string `json:"image_id"`
+	Path      string `json:"path"`
+	Name      string `json:"name"`
+	Size      int64  `json:"size"`
+	BootIndex int8   `json:"boot_index"`
 }

--- a/pkg/apis/compute/guest_disk.go
+++ b/pkg/apis/compute/guest_disk.go
@@ -83,6 +83,7 @@ type GuestdiskJsonDesc struct {
 	Path             string `json:"path"`
 	Format           string `json:"format"`
 	Index            int8   `json:"index"`
+	BootIndex        *int8  `json:"boot_index"`
 	MergeSnapshot    bool   `json:"merge_snapshot"`
 	EsxiFlatFilePath string `json:"esxi_flat_file_path"`
 	Fs               string `json:"fs"`

--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -259,8 +259,9 @@ type Floppy struct {
 }
 
 type Cdrom struct {
-	Ordinal int    `json:"ordinal"`
-	Detail  string `json:"detail"`
+	Ordinal   int    `json:"ordinal"`
+	Detail    string `json:"detail"`
+	BootIndex int8   `json:"boot_index"`
 }
 
 func (self ServerDetails) GetMetricTags() map[string]string {
@@ -310,6 +311,7 @@ type GuestDiskInfo struct {
 	FsFormat    string `json:"fs,omitempty"`
 	DiskType    string `json:"disk_type"`
 	Index       int8   `json:"index"`
+	BootIndex   int8   `json:"boot_index"`
 	SizeMb      int    `json:"size"`
 	DiskFormat  string `json:"disk_format"`
 	Driver      string `json:"driver"`
@@ -694,6 +696,8 @@ type ServerUserDataInput struct {
 
 type ServerAttachDiskInput struct {
 	DiskId string `json:"disk_id"`
+
+	BootIndex *int8 `json:"boot_index"`
 }
 
 type ServerDetachDiskInput struct {

--- a/pkg/cloudcommon/cmdline/parser.go
+++ b/pkg/cloudcommon/cmdline/parser.go
@@ -187,6 +187,13 @@ func ParseDiskConfig(diskStr string, idx int) (*compute.DiskConfig, error) {
 			diskConfig.ImageId = str
 		case "existing_path":
 			diskConfig.ExistingPath = str
+		case "boot_index":
+			bootIndex, err := strconv.Atoi(str)
+			if err != nil {
+				return nil, errors.Wrapf(err, "parse disk boot index %s", str)
+			}
+			bootIndex8 := int8(bootIndex)
+			diskConfig.BootIndex = &bootIndex8
 		default:
 			return nil, errors.Errorf("invalid disk description %s", p)
 		}

--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -324,8 +324,8 @@ func (self *SBaremetalGuestDriver) RequestGuestHotRemoveIso(ctx context.Context,
 	return host.StartEjectIsoTask(ctx, task.GetUserCred(), task.GetTaskId())
 }
 
-func (self *SBaremetalGuestDriver) RequestGuestCreateInsertIso(ctx context.Context, imageId string, guest *models.SGuest, task taskman.ITask) error {
-	return guest.StartInsertIsoTask(ctx, 0, imageId, true, guest.HostId, task.GetUserCred(), task.GetTaskId())
+func (self *SBaremetalGuestDriver) RequestGuestCreateInsertIso(ctx context.Context, imageId string, bootIndex *int8, task taskman.ITask, guest *models.SGuest) error {
+	return guest.StartInsertIsoTask(ctx, 0, imageId, true, nil, guest.HostId, task.GetUserCred(), task.GetTaskId())
 }
 
 func (self *SBaremetalGuestDriver) RequestStartOnHost(ctx context.Context, guest *models.SGuest, host *models.SHost, userCred mcclient.TokenCredential, task taskman.ITask) error {

--- a/pkg/compute/guestdrivers/virtualization.go
+++ b/pkg/compute/guestdrivers/virtualization.go
@@ -219,8 +219,8 @@ func (self *SVirtualizedGuestDriver) ChooseHostStorage(host *models.SHost, guest
 	return models.ChooseLeastUsedStorage(candidates, ""), nil
 }
 
-func (self *SVirtualizedGuestDriver) RequestGuestCreateInsertIso(ctx context.Context, imageId string, guest *models.SGuest, task taskman.ITask) error {
-	return guest.StartInsertIsoTask(ctx, 0, imageId, true, guest.HostId, task.GetUserCred(), task.GetTaskId())
+func (self *SVirtualizedGuestDriver) RequestGuestCreateInsertIso(ctx context.Context, imageId string, bootIndex *int8, task taskman.ITask, guest *models.SGuest) error {
+	return guest.StartInsertIsoTask(ctx, 0, imageId, true, bootIndex, guest.HostId, task.GetUserCred(), task.GetTaskId())
 }
 
 func (self *SVirtualizedGuestDriver) StartGuestStopTask(guest *models.SGuest, ctx context.Context, userCred mcclient.TokenCredential, params *jsonutils.JSONDict, parentTaskId string) error {

--- a/pkg/compute/models/guest_queries.go
+++ b/pkg/compute/models/guest_queries.go
@@ -224,7 +224,7 @@ func (manager *SGuestManager) FetchCustomizeColumns(
 			for i := range rows {
 				for _, gcd := range gcds[guestIds[i]] {
 					if details := gcd.GetDetails(); len(details) > 0 {
-						t := api.Cdrom{Ordinal: gcd.Ordinal, Detail: details}
+						t := api.Cdrom{Ordinal: gcd.Ordinal, Detail: details, BootIndex: gcd.BootIndex}
 						rows[i].Cdrom = append(rows[i].Cdrom, t)
 					}
 				}
@@ -296,6 +296,7 @@ func fetchGuestDisksInfo(guestIds []string) map[string][]api.GuestDiskInfo {
 		guestdisks.Field("bps"),
 		disks.Field("template_id").Label("image_id"),
 		guestdisks.Field("guest_id"),
+		guestdisks.Field("boot_index"),
 		disks.Field("storage_id"),
 	)
 	q = q.Join(guestdisks, sqlchemy.Equals(guestdisks.Field("disk_id"), disks.Field("id")))

--- a/pkg/compute/models/guestdisks.go
+++ b/pkg/compute/models/guestdisks.go
@@ -70,7 +70,8 @@ type SGuestdisk struct {
 
 	Mountpoint string `width:"256" charset:"utf8" nullable:"true" get:"user"` // Column(VARCHAR(256, charset='utf8'), nullable=True)
 
-	Index int8 `nullable:"false" default:"0" list:"user" update:"user"` // Column(TINYINT(4), nullable=False, default=0)
+	Index     int8 `nullable:"false" default:"0" list:"user" update:"user"` // Column(TINYINT(4), nullable=False, default=0)
+	BootIndex int8 `nullable:"false" default:"-1" list:"user" update:"user"`
 }
 
 func (manager *SGuestdiskManager) GetSlaveFieldName() string {
@@ -205,6 +206,7 @@ func (self *SGuestdisk) GetJsonDescAtHost(ctx context.Context, host *SHost) *api
 	}
 	desc.Format = disk.DiskFormat
 	desc.Index = self.Index
+	desc.BootIndex = &self.BootIndex
 
 	if len(disk.SnapshotId) > 0 {
 		needMerge := disk.GetMetadata(ctx, "merge_snapshot", nil)

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -79,7 +79,7 @@ type IGuestDriver interface {
 
 	RequestGuestCreateAllDisks(ctx context.Context, guest *SGuest, task taskman.ITask) error
 
-	RequestGuestCreateInsertIso(ctx context.Context, imageId string, guest *SGuest, task taskman.ITask) error
+	RequestGuestCreateInsertIso(ctx context.Context, imageId string, bootIndex *int8, task taskman.ITask, guest *SGuest) error
 
 	StartGuestStopTask(guest *SGuest, ctx context.Context, userCred mcclient.TokenCredential, params *jsonutils.JSONDict, parentTaskId string) error
 	StartGuestResetTask(guest *SGuest, ctx context.Context, userCred mcclient.TokenCredential, isHard bool, parentTaskId string) error

--- a/pkg/compute/tasks/guest_attach_disk_task.go
+++ b/pkg/compute/tasks/guest_attach_disk_task.go
@@ -53,8 +53,14 @@ func (self *GuestAttachDiskTask) OnInit(ctx context.Context, obj db.IStandaloneM
 	driver, _ := self.Params.GetString("driver")
 	cache, _ := self.Params.GetString("cache")
 	mountpoint, _ := self.Params.GetString("mountpoint")
+	var bootIndex *int8
+	if self.Params.Contains("boot_index") {
+		bd, _ := self.Params.Int("boot_index")
+		bd8 := int8(bd)
+		bootIndex = &bd8
+	}
 
-	err = guest.AttachDisk(ctx, disk, self.UserCred, driver, cache, mountpoint)
+	err = guest.AttachDisk(ctx, disk, self.UserCred, driver, cache, mountpoint, bootIndex)
 	if err != nil {
 		self.OnTaskFail(ctx, guest, nil, jsonutils.NewString(err.Error()))
 		return

--- a/pkg/compute/tasks/guest_backup_tasks.go
+++ b/pkg/compute/tasks/guest_backup_tasks.go
@@ -359,7 +359,7 @@ func (self *GuestCreateBackupTask) StartCreateBackupDisks(ctx context.Context, g
 
 func (self *GuestCreateBackupTask) StartInsertIso(ctx context.Context, guest *models.SGuest, imageId string) {
 	self.SetStage("OnInsertIso", nil)
-	guest.StartInsertIsoTask(ctx, 0, imageId, false, guest.BackupHostId, self.UserCred, self.GetTaskId())
+	guest.StartInsertIsoTask(ctx, 0, imageId, false, nil, guest.BackupHostId, self.UserCred, self.GetTaskId())
 }
 
 func (self *GuestCreateBackupTask) OnInsertIso(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/guest_create_disk_task.go
+++ b/pkg/compute/tasks/guest_create_disk_task.go
@@ -117,7 +117,7 @@ func (self *KVMGuestCreateDiskTask) OnKvmDiskPrepared(ctx context.Context, obj d
 			diskReady = false
 			break
 		}
-		err = self.attachDisk(ctx, disk, d.Driver, d.Cache, d.Mountpoint)
+		err = self.attachDisk(ctx, disk, d.Driver, d.Cache, d.Mountpoint, d.BootIndex)
 		if err != nil {
 			self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 			return
@@ -151,7 +151,7 @@ func (self *SGuestCreateDiskBaseTask) GetInputDisks() ([]api.DiskConfig, error) 
 	return disks, err
 }
 
-func (self *SGuestCreateDiskBaseTask) attachDisk(ctx context.Context, disk *models.SDisk, driver, cache, mountpoint string) error {
+func (self *SGuestCreateDiskBaseTask) attachDisk(ctx context.Context, disk *models.SDisk, driver, cache, mountpoint string, bootIndex *int8) error {
 	guest := self.getGuest()
 	attached, err := guest.IsAttach2Disk(disk)
 	if err != nil {
@@ -160,7 +160,7 @@ func (self *SGuestCreateDiskBaseTask) attachDisk(ctx context.Context, disk *mode
 	if attached {
 		return nil
 	}
-	err = guest.AttachDisk(ctx, disk, self.UserCred, driver, cache, mountpoint)
+	err = guest.AttachDisk(ctx, disk, self.UserCred, driver, cache, mountpoint, bootIndex)
 	if err != nil {
 		return errors.Wrapf(err, "AttachDisk")
 	}
@@ -229,7 +229,7 @@ func (self *ManagedGuestCreateDiskTask) OnManagedDiskPrepared(ctx context.Contex
 			self.SetStageFailed(ctx, jsonutils.NewString(fmt.Sprintf("Attach iDisk to guest fail error: %v", err)))
 			return
 		}
-		err = self.attachDisk(ctx, disk, d.Driver, d.Cache, d.Mountpoint)
+		err = self.attachDisk(ctx, disk, d.Driver, d.Cache, d.Mountpoint, d.BootIndex)
 		if err != nil {
 			log.Debugf("Attach Disk %s to guest fail: %s", diskId, err)
 			self.SetStageFailed(ctx, jsonutils.NewString(fmt.Sprintf("Attach Disk to guest fail error: %v", err)))
@@ -307,7 +307,7 @@ func (self *ESXiGuestCreateDiskTask) OnInit(ctx context.Context, obj db.IStandal
 			return
 		}
 
-		err = self.attachDisk(ctx, disk, d.Driver, d.Cache, d.Mountpoint)
+		err = self.attachDisk(ctx, disk, d.Driver, d.Cache, d.Mountpoint, d.BootIndex)
 		if err != nil {
 			self.SetStageFailed(ctx, jsonutils.NewString(fmt.Sprintf("self.attachDisk fail %v", err)))
 			return
@@ -425,7 +425,7 @@ func (self *NutanixGuestCreateDiskTask) OnInit(ctx context.Context, obj db.IStan
 			return nil
 		})
 
-		err = self.attachDisk(ctx, disk, d.Driver, d.Cache, d.Mountpoint)
+		err = self.attachDisk(ctx, disk, d.Driver, d.Cache, d.Mountpoint, d.BootIndex)
 		if err != nil {
 			self.taskFailed(ctx, errors.Wrapf(err, "attachDisk"))
 			return

--- a/pkg/compute/tasks/guest_create_task.go
+++ b/pkg/compute/tasks/guest_create_task.go
@@ -85,9 +85,16 @@ func (self *GuestCreateTask) OnDiskPreparedFailed(ctx context.Context, obj db.IS
 func (self *GuestCreateTask) OnDiskPrepared(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	guest := obj.(*models.SGuest)
 	cdrom, _ := self.Params.GetString("cdrom")
+	var bootIndex *int8
+	if self.Params.Contains("cdrom_boot_index") {
+		bd, _ := self.Params.Int("cdrom_boot_index")
+		bd8 := int8(bd)
+		bootIndex = &bd8
+	}
+
 	if len(cdrom) > 0 {
 		self.SetStage("OnCdromPrepared", nil)
-		guest.GetDriver().RequestGuestCreateInsertIso(ctx, cdrom, guest, self)
+		guest.GetDriver().RequestGuestCreateInsertIso(ctx, cdrom, bootIndex, self, guest)
 	} else {
 		self.OnCdromPrepared(ctx, obj, data)
 	}

--- a/pkg/compute/tasks/guest_insert_iso_task.go
+++ b/pkg/compute/tasks/guest_insert_iso_task.go
@@ -83,8 +83,15 @@ func (self *GuestInsertIsoTask) OnIsoPrepareComplete(ctx context.Context, obj db
 	}
 	name, _ := data.GetString("name")
 	path, _ := data.GetString("path")
+	var bootIndex *int8
+	if self.Params.Contains("boot_index") {
+		bd, _ := self.Params.Int("boot_index")
+		bd8 := int8(bd)
+		bootIndex = &bd8
+	}
+
 	guest := obj.(*models.SGuest)
-	if guest.InsertIsoSucc(cdromOrdinal, imageId, path, size, name) {
+	if guest.InsertIsoSucc(cdromOrdinal, imageId, path, size, name, bootIndex) {
 		db.OpsLog.LogEvent(guest, db.ACT_ISO_ATTACH, guest.GetDetailsIso(cdromOrdinal, self.UserCred), self.UserCred)
 		if guest.GetDriver().NeedRequestGuestHotAddIso(ctx, guest) {
 			self.SetStage("OnConfigSyncComplete", nil)

--- a/pkg/hostman/guestman/desc/desc.go
+++ b/pkg/hostman/guestman/desc/desc.go
@@ -168,9 +168,10 @@ type SGuestDisk struct {
 // -drive id=MacDVD,if=none,snapshot=on,file=%s
 
 type SGuestCdrom struct {
-	Id      string
-	Path    string
-	Ordinal int64
+	Id        string
+	Path      string
+	Ordinal   int64
+	BootIndex *int8
 
 	Ide          *IDEDevice        `json:",omitempty"`
 	Scsi         *SCSIDevice       `json:",omitempty"`

--- a/pkg/hostman/guestman/qemu/qemu.go
+++ b/pkg/hostman/guestman/qemu/qemu.go
@@ -94,7 +94,7 @@ type QemuOptions interface {
 	MemPath(sizeMB uint64, p string) string
 	MemDev(sizeMB uint64) string
 	MemFd(sizeMB uint64) string
-	Boot(order string, enableMenu bool) string
+	Boot(order *string, enableMenu bool) string
 	BIOS(ovmfPath, homedir string) (string, error)
 	Device(devStr string) string
 	Drive(driveStr string) string
@@ -250,12 +250,18 @@ func (o baseOptions) MemFd(sizeMB uint64) string {
 	return fmt.Sprintf("-object memory-backend-memfd,id=mem,size=%dM,share=on,prealloc=on -numa node,memdev=mem", sizeMB)
 }
 
-func (o baseOptions) Boot(order string, enableMenu bool) string {
-	opt := "-boot order=" + order
-	if enableMenu {
-		opt += ",menu=on"
+func (o baseOptions) Boot(order *string, enableMenu bool) string {
+	opts := []string{}
+	if order != nil {
+		opts = append(opts, *order)
 	}
-	return opt
+	if enableMenu {
+		opts = append(opts, "menu=on")
+	}
+	if len(opts) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("-boot %s", strings.Join(opts, ","))
 }
 
 func (o baseOptions) BIOS(ovmfPath, homedir string) (string, error) {

--- a/pkg/mcclient/modules/compute/mod_serverdisks.go
+++ b/pkg/mcclient/modules/compute/mod_serverdisks.go
@@ -29,7 +29,7 @@ func init() {
 		"guestdisks",
 		[]string{"Guest_ID", "Guest",
 			"Disk_ID", "Disk", "Disk_size",
-			"Driver", "Cache_mode", "Index", "Status", "Disk_type", "Storage_type"},
+			"Driver", "Cache_mode", "Index", "BootIndex", "Status", "Disk_type", "Storage_type"},
 		[]string{},
 		&Servers,
 		&Disks)

--- a/pkg/mcclient/options/compute/servers.go
+++ b/pkg/mcclient/options/compute/servers.go
@@ -399,6 +399,7 @@ type ServerCreateOptionalOptions struct {
 	Password         string   `help:"Default user password"`
 	LoginAccount     string   `help:"Guest login account"`
 	Iso              string   `help:"ISO image ID" metavar:"IMAGE_ID" json:"cdrom"`
+	IsoBootIndex     *int8    `help:"Iso bootindex" metavar:"IMAGE_BOOT_INDEX" json:"cdrom_boot_index"`
 	VcpuCount        int      `help:"#CPU cores of VM server, default 1" default:"1" metavar:"<SERVER_CPU_COUNT>" json:"vcpu_count" token:"ncpu"`
 	InstanceType     string   `help:"instance flavor"`
 	Vga              string   `help:"VGA driver" choices:"std|vmware|cirrus|qxl|virtio"`
@@ -508,6 +509,7 @@ func (opts *ServerCreateOptionalOptions) OptionalParams() (*computeapi.ServerCre
 		Password:           opts.Password,
 		LoginAccount:       opts.LoginAccount,
 		Cdrom:              opts.Iso,
+		CdromBootIndex:     opts.IsoBootIndex,
 		Vga:                opts.Vga,
 		Vdi:                opts.Vdi,
 		Bios:               opts.Bios,


### PR DESCRIPTION
If bootindex is assigned, legacy boot order cdn/dcn will be disabled. each device bootindex is accquire uniqued. default bootindex -1 is mean bootindex not assign. If all of the devices not assigned bootindex, guest will use the legacy boot order.

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
