### PR TITLE
fix(host): x86 machine max cpus

### DIFF
--- a/pkg/hostman/guestman/arch/x86.go
+++ b/pkg/hostman/guestman/arch/x86.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	X86_MAX_CPUS = 128
+	X86_MAX_CPUS = 240
 	X86_SOCKETS  = 2
 	X86_CORES    = 64
 	X86_THREADS  = 1

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -31,6 +31,7 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/pkg/util/seclib"
+	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/apis"
 	"yunion.io/x/onecloud/pkg/apis/compute"
@@ -134,11 +135,18 @@ func (m *SGuestManager) InitQemuMaxCpus(machineCaps []monitor.MachineInfo, kvmMa
 		for i := 0; i < len(machineCaps); i++ {
 			if (machineCaps[i].Alias != nil && *machineCaps[i].Alias == machine) ||
 				machineCaps[i].Name == machine {
-				m.qemuMachineCpuMax[machine] = minFunc(uint(machineCaps[i].CPUMax), kvmMaxCpus)
+				cpuMax := minFunc(uint(machineCaps[i].CPUMax), kvmMaxCpus)
+				if utils.IsInStringArray(machine, []string{"pc", "q35"}) {
+					// Note: if max cpux exceed 255, machine requires Extended Interrupt Mode enabled.
+					// You can add an IOMMU using: -device intel-iommu,intremap=on,eim=on
+					// Set x86 machine max cpu 240 for now.
+					m.qemuMachineCpuMax[machine] = minFunc(cpuMax, m.qemuMachineCpuMax[machine])
+				}
 				log.Infof("Machine type %s max cpus: %d", machine, m.qemuMachineCpuMax[machine])
 			}
 		}
 	}
+
 }
 
 func (m *SGuestManager) InitQemuMaxMems(maxMems uint) {


### PR DESCRIPTION
if max cpux exceed 255, machine requires Extended Interrupt Mode enabled.

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
