### PR TITLE
fix: choose available storage by server_id

### DIFF
--- a/pkg/apis/compute/storage_const.go
+++ b/pkg/apis/compute/storage_const.go
@@ -239,6 +239,9 @@ type StorageListInput struct {
 	// filter storages which attached the specified host
 	HostId string `json:"host_id"`
 
+	// filter storages which server can change disks to
+	ServerId string `json:"server_id"`
+
 	// filter storages of baremetal host
 	IsBaremetal *bool `json:"is_baremetal"`
 }

--- a/pkg/compute/guestdrivers/kvm.go
+++ b/pkg/compute/guestdrivers/kvm.go
@@ -827,7 +827,7 @@ func (self *SKVMGuestDriver) ValidateDetachNetwork(ctx context.Context, userCred
 }
 
 func (self *SKVMGuestDriver) ValidateChangeDiskStorage(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, input *api.ServerChangeDiskStorageInput) error {
-	if !utils.IsInStringArray(guest.Status, []string{api.VM_READY, api.VM_RUNNING, api.VM_BLOCK_STREAM}) {
+	if !utils.IsInStringArray(guest.Status, []string{api.VM_READY, api.VM_RUNNING, api.VM_BLOCK_STREAM, api.VM_DISK_CHANGE_STORAGE}) {
 		return httperrors.NewBadRequestError("Cannot change disk storage in status %s", guest.Status)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: choose available storage by server_id

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi 