### PR TITLE
Automated cherry pick of #15314: fix(host-deployer): check /etc/network dir is esixt

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -758,6 +758,13 @@ func (d *sDebianLikeRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics 
 	if err := d.sLinuxRootFs.DeployNetworkingScripts(rootFs, nics); err != nil {
 		return err
 	}
+	if !rootFs.Exists("/etc/network", false) {
+		if err := rootFs.Mkdir("/etc/network",
+			syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR, false); err != nil {
+			return errors.Wrap(err, "mkdir /etc/network")
+		}
+	}
+
 	fn := "/etc/network/interfaces"
 	var cmds strings.Builder
 	cmds.WriteString("auto lo\n")


### PR DESCRIPTION
Cherry pick of #15314 on release/3.9.

#15314: fix(host-deployer): check /etc/network dir is esixt