### PR TITLE
fix: format version for rpm spec

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -44,7 +44,12 @@ echo "Build root ${BUILDROOT}"
 if [ -z "$VERSION" ]; then
 	TAG=$(git describe --abbrev=0 --tags || echo testing)
 	VERSION=${TAG/\//-}
-	VERSION=${VERSION/v/}
+	if [[ "$VERSION" =~ ^v0. ]]; then
+		VERSION=${VERSION/v0./}
+	elif [[ "$VERSION" =~ ^v ]]; then
+		VERSION=${VERSION/v/}
+	fi
+	VERSION=${VERSION//-/.}
 fi
 RELEASE=`date +"%y%m%d%H"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: format version for rpm spec

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 