### PR TITLE
Automated cherry pick of #15348: fix: scheduler ignore storage capacity constraint if migrating

### DIFF
--- a/pkg/scheduler/algorithm/predicates/guest/storage_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/guest/storage_predicate.go
@@ -134,7 +134,8 @@ func (p *StoragePredicate) Execute(ctx context.Context, u *core.Unit, c core.Can
 		} else if len(disk.DiskId) > 0 && len(disk.Storage) > 0 {
 			// server attach to an existing disk
 			storeRequest[disk.Storage] = 1
-		} else {
+		} else if !isMigrate() || (isMigrate() && isLocalhostBackend(disk.Backend)) {
+			// if migrate, only local storage need check capacity constraint
 			if _, ok := sizeRequest[disk.Backend]; !ok {
 				sizeRequest[disk.Backend] = map[string]int64{"max": -1, "total": 0}
 			}


### PR DESCRIPTION
Cherry pick of #15348 on release/3.9.

#15348: fix: scheduler ignore storage capacity constraint if migrating