### PR TITLE
fix: automatically set disk is_ssd according to storage medium_type

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -680,6 +680,7 @@ func (disk *SDisk) SetStorageByHost(hostId string, diskConfig *api.DiskConfig, s
 	}
 	_, err = db.Update(disk, func() error {
 		disk.StorageId = storage.Id
+		disk.IsSsd = (storage.MediumType == api.DISK_TYPE_SSD)
 		return nil
 	})
 	return err
@@ -2553,6 +2554,10 @@ func (self *SDisk) GetShortDesc(ctx context.Context) *jsonutils.JSONDict {
 
 	if len(self.ExternalId) > 0 {
 		desc.Add(jsonutils.NewString(self.ExternalId), "externalId")
+	}
+
+	if self.IsSsd {
+		desc.Add(jsonutils.JSONTrue, "is_ssd")
 	}
 
 	fs := self.GetFsFormat()

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -1254,6 +1254,12 @@ func (self *SStorage) createDisk(ctx context.Context, name string, diskConfig *a
 	disk.DomainId = ownerId.GetProjectDomainId()
 	disk.IsSystem = isSystem
 
+	if self.MediumType == api.DISK_TYPE_SSD {
+		disk.IsSsd = true
+	} else {
+		disk.IsSsd = false
+	}
+
 	disk.BillingType = billingType
 	disk.BillingCycle = billingCycle
 
@@ -1263,7 +1269,7 @@ func (self *SStorage) createDisk(ctx context.Context, name string, diskConfig *a
 	if err != nil {
 		return nil, err
 	}
-	db.OpsLog.LogEvent(&disk, db.ACT_CREATE, nil, userCred)
+	db.OpsLog.LogEvent(&disk, db.ACT_CREATE, disk.GetShortDesc(ctx), userCred)
 	return &disk, nil
 }
 

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -158,12 +158,12 @@ func (h *SHostInfo) GetZoneId() string {
 	return h.ZoneId
 }
 
-func (h *SHostInfo) GetMediumType() string {
+/*func (h *SHostInfo) GetMediumType() string {
 	if h.sysinfo != nil {
 		return h.sysinfo.StorageType
 	}
 	return ""
-}
+}*/
 
 func (h *SHostInfo) IsKvmSupport() bool {
 	return sysutils.IsKvmSupport()
@@ -538,9 +538,16 @@ func (h *SHostInfo) checkSystemServices() error {
 }
 
 func (h *SHostInfo) detectStorageSystem() {
-	var stype = api.DISK_TYPE_ROTATE
-	if options.HostOptions.DiskIsSsd {
+	stype, _ := sysutils.DetectStorageType()
+	switch stype {
+	case "hdd":
+		stype = api.DISK_TYPE_ROTATE
+	case "ssd":
 		stype = api.DISK_TYPE_SSD
+	case "hybird":
+		stype = api.DISK_TYPE_HYBRID
+	default:
+		stype = ""
 	}
 	h.sysinfo.StorageType = stype
 }

--- a/pkg/hostman/hostutils/hostutils.go
+++ b/pkg/hostman/hostutils/hostutils.go
@@ -40,7 +40,6 @@ import (
 type IHost interface {
 	GetZoneId() string
 	GetHostId() string
-	GetMediumType() string
 	GetMasterIp() string
 	GetCpuArchitecture() string
 	GetKernelVersion() string

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -101,7 +101,6 @@ type SHostOptions struct {
 	CheckSystemServices bool `help:"Check system services (ntpd, telegraf) on startup" default:"true"`
 
 	DhcpServerPort     int    `help:"Host dhcp server bind port" default:"67"`
-	DiskIsSsd          bool   `default:"false"`
 	FetcherfsPath      string `default:"/opt/yunion/fetchclient/bin/fetcherfs" help:"Fuse fetcherfs path"`
 	FetcherfsBlockSize int    `default:"16" help:"Fuse fetcherfs fetch chunk_size MB"`
 

--- a/pkg/hostman/storageman/core.go
+++ b/pkg/hostman/storageman/core.go
@@ -122,9 +122,9 @@ func (s *SStorageManager) GetHostId() string {
 	return s.host.GetHostId()
 }
 
-func (s *SStorageManager) GetMediumType() string {
+/*func (s *SStorageManager) GetMediumType() string {
 	return s.host.GetMediumType()
-}
+}*/
 
 func (s *SStorageManager) GetKubeletConfig() kubelet.KubeletConfig {
 	return s.host.GetKubeletConfig()

--- a/pkg/hostman/storageman/storage_base.go
+++ b/pkg/hostman/storageman/storage_base.go
@@ -233,9 +233,9 @@ func (s *SBaseStorage) GetUsedSizeMb() int {
 	return size
 }
 
-func (s *SBaseStorage) GetMediumType() string {
+/*func (s *SBaseStorage) GetMediumType() string {
 	return s.Manager.GetMediumType()
-}
+}*/
 
 func (s *SBaseStorage) GetFreeSizeMb() int {
 	size, err := storageutils.GetFreeSizeMb(s.Path)

--- a/pkg/hostman/storageman/storage_local.go
+++ b/pkg/hostman/storageman/storage_local.go
@@ -229,7 +229,7 @@ func (s *SLocalStorage) SyncStorageInfo() (jsonutils.JSONObject, error) {
 	content.Set("capacity", jsonutils.NewInt(int64(s.GetAvailSizeMb())))
 	content.Set("actual_capacity_used", jsonutils.NewInt(int64(s.GetUsedSizeMb())))
 	content.Set("storage_type", jsonutils.NewString(s.StorageType()))
-	content.Set("medium_type", jsonutils.NewString(s.GetMediumType()))
+	// content.Set("medium_type", jsonutils.NewString(s.GetMediumType()))
 	content.Set("zone", jsonutils.NewString(s.GetZoneId()))
 	if len(s.Manager.LocalStorageImagecacheManager.GetId()) > 0 {
 		content.Set("storagecache_id",

--- a/pkg/util/sysutils/storages.go
+++ b/pkg/util/sysutils/storages.go
@@ -1,0 +1,115 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysutils
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+
+	"yunion.io/x/pkg/errors"
+)
+
+type SStorage struct {
+	Device     string
+	Rotational bool
+	Size       int64
+	ReadOnly   bool
+	Removable  bool
+	Partition  bool
+	Scheduler  string
+}
+
+const (
+	sysBlockDir = "/sys/class/block"
+)
+
+func DetectStorageType() (string, error) {
+	ss, err := DetectStorages()
+	if err != nil {
+		return "", errors.Wrap(err, "DetectStorages")
+	}
+	var hdd, ssd int
+	for _, s := range ss {
+		if s.Partition {
+			continue
+		}
+		if s.Removable {
+			continue
+		}
+		if s.Rotational {
+			hdd++
+		} else {
+			ssd++
+		}
+	}
+	if hdd > 0 && ssd > 0 {
+		return "hybrid", nil
+	} else if hdd > 0 {
+		return "hdd", nil
+	} else if ssd > 0 {
+		return "ssd", nil
+	} else {
+		return "", nil
+	}
+}
+
+func DetectStorages() ([]SStorage, error) {
+	files, err := ioutil.ReadDir(sysBlockDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "ReadDir /sys/class/block")
+	}
+	ret := make([]SStorage, 0)
+	for _, f := range files {
+		s := detectStorage(filepath.Join(sysBlockDir, f.Name()), f.Name())
+		ret = append(ret, s)
+	}
+	return ret, nil
+}
+
+func detectStorage(path string, name string) SStorage {
+	s := SStorage{
+		Device: name,
+	}
+	sizeBytes, _ := ioutil.ReadFile(filepath.Join(path, "size"))
+	s.Size, _ = strconv.ParseInt(string(sizeBytes), 10, 64)
+	removableBytes, _ := ioutil.ReadFile(filepath.Join(path, "removable"))
+	if len(removableBytes) > 0 && removableBytes[0] == '0' {
+		s.Removable = false
+	} else {
+		s.Removable = true
+	}
+	roBytes, _ := ioutil.ReadFile(filepath.Join(path, "ro"))
+	if len(roBytes) > 0 && roBytes[0] == '0' {
+		s.ReadOnly = false
+	} else {
+		s.ReadOnly = true
+	}
+	partitionBytes, _ := ioutil.ReadFile(filepath.Join(path, "partition"))
+	if len(partitionBytes) > 0 && partitionBytes[0] == '1' {
+		s.Partition = true
+	} else {
+		s.Partition = false
+	}
+	rotationalBytes, _ := ioutil.ReadFile(filepath.Join(path, "queue/rotational"))
+	if len(rotationalBytes) > 0 && rotationalBytes[0] == '0' {
+		s.Rotational = false
+	} else {
+		s.Rotational = true
+	}
+	schedulerBytes, _ := ioutil.ReadFile(filepath.Join(path, "queue/scheduler"))
+	s.Scheduler = string(schedulerBytes)
+	return s
+}

--- a/pkg/util/sysutils/storages_test.go
+++ b/pkg/util/sysutils/storages_test.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysutils
+
+import "testing"
+
+func TestDetectStorageType(t *testing.T) {
+	s, err := DetectStorageType()
+	if err != nil {
+		t.Errorf("DetectStorageType fail %s", err)
+	} else {
+		t.Logf("%s", s)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: automatically set disk is_ssd according to storage medium_type
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi 