### PR TITLE
fix(baremetal): Physical server installation OS optimization

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -2945,7 +2945,7 @@ func (s *SBaremetalServer) reIndexDescNics(term *ssh.Client, desc *deployapi.Gue
 	}
 	reIndexNics := func(nics []*deployapi.Nic) ([]*deployapi.Nic, error) {
 		for idx, nic := range nics {
-			if nic.GetNicType() == api.NIC_TYPE_IPMI {
+			if nic.GetNicType() == api.NIC_TYPE_IPMI || nic.GetIndex() >= 0 {
 				continue
 			}
 			rIdx, rNic := findRemoteNic(nic.GetMac())


### PR DESCRIPTION
**What this PR does / why we need it**:

1. 当nics_standby中mac地址没有Index或者nic_type时会导致panic
2. 会导致“物理服务器”转换“裸金属”失败

**Does this PR need to be backport to the previous release branch?**:
是的
