### PR TITLE
fix: keep schedtask_label table name

### DIFF
--- a/pkg/scheduledtask/models/scheduledtask_label.go
+++ b/pkg/scheduledtask/models/scheduledtask_label.go
@@ -28,7 +28,7 @@ func init() {
 		ScheduledTaskLabelManager = &SScheduledTaskLabelManager{
 			SResourceBaseManager: db.NewResourceBaseManager(
 				SScheduledTaskLabel{},
-				"scheduledtasklabels2_tbl",
+				"scheduledtasklabels_tbl",
 				"scheduledtasklabel",
 				"scheduledtasklabels",
 			),


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: keep schedtask_label table name
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @ioito @zexi 