### PR TITLE
Automated cherry pick of #15433: fix: keep schedtask_label table name

### DIFF
--- a/pkg/scheduledtask/models/scheduledtask_label.go
+++ b/pkg/scheduledtask/models/scheduledtask_label.go
@@ -28,7 +28,7 @@ func init() {
 		ScheduledTaskLabelManager = &SScheduledTaskLabelManager{
 			SResourceBaseManager: db.NewResourceBaseManager(
 				SScheduledTaskLabel{},
-				"scheduledtasklabels2_tbl",
+				"scheduledtasklabels_tbl",
 				"scheduledtasklabel",
 				"scheduledtasklabels",
 			),


### PR DESCRIPTION
Cherry pick of #15433 on master.

#15433: fix: keep schedtask_label table name