### PR TITLE
fix: allow baremetal to specify external tftp server and file

### DIFF
--- a/pkg/baremetal/options/options.go
+++ b/pkg/baremetal/options/options.go
@@ -57,6 +57,10 @@ type BaremetalOptions struct {
 	UseMegaRaidPerccli bool              `help:"Use MegaRAID perccli" default:"false"`
 
 	NfsBootRootfs string `help:"nfs root fs URL"`
+
+	TftpBootServer   string `help:"customized tftp boot server"`
+	TftpBootFilename string `help:"filename of tftp boot loader"`
+	TftpBootFilesize int64  `help:"file size of tftp boot loader"`
 }
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allow baremetal to specify external tftp server and file

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 