### PR TITLE
Automated cherry pick of #15489: fix: allow baremetal to specify external tftp server and file

### DIFF
--- a/pkg/baremetal/options/options.go
+++ b/pkg/baremetal/options/options.go
@@ -57,6 +57,10 @@ type BaremetalOptions struct {
 	UseMegaRaidPerccli bool              `help:"Use MegaRAID perccli" default:"false"`
 
 	NfsBootRootfs string `help:"nfs root fs URL"`
+
+	TftpBootServer   string `help:"customized tftp boot server"`
+	TftpBootFilename string `help:"filename of tftp boot loader"`
+	TftpBootFilesize int64  `help:"file size of tftp boot loader"`
 }
 
 const (


### PR DESCRIPTION
Cherry pick of #15489 on release/3.9.

#15489: fix: allow baremetal to specify external tftp server and file