### PR TITLE
Automated cherry pick of #15497: fix(host): don't set ovs interface external id on migrating

### DIFF
--- a/pkg/hostman/hostinfo/hostbridge/hostbridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/hostbridge.go
@@ -53,12 +53,14 @@ type IBridgeDriver interface {
 	PersistentConfig() error
 	DisableDHCPClient() (bool, error)
 
-	GenerateIfupScripts(scriptPath string, nic *desc.SGuestNetwork, isSlave bool) error
-	GenerateIfdownScripts(scriptPath string, nic *desc.SGuestNetwork, isSlave bool) error
+	GenerateIfupScripts(scriptPath string, nic *desc.SGuestNetwork, isVolatileHost bool) error
+	GenerateIfdownScripts(scriptPath string, nic *desc.SGuestNetwork, isVolatileHost bool) error
 	RegisterHostlocalServer(mac, ip string) error
 
-	getUpScripts(nic *desc.SGuestNetwork, isSlave bool) (string, error)
-	getDownScripts(nic *desc.SGuestNetwork, isSlave bool) (string, error)
+	getUpScripts(nic *desc.SGuestNetwork, isVolatileHost bool) (string, error)
+	getDownScripts(nic *desc.SGuestNetwork, isVolatileHost bool) (string, error)
+
+	OnVolatileGuestResume(nic *desc.SGuestNetwork) error
 
 	Bridge() string
 }
@@ -358,16 +360,16 @@ func (d *SBaseBridgeDriver) saveFileExecutable(scriptPath, script string) error 
 	return os.Chmod(scriptPath, syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR)
 }
 
-func (d *SBaseBridgeDriver) generateIfdownScripts(driver IBridgeDriver, scriptPath string, nic *desc.SGuestNetwork, isSlave bool) error {
-	script, err := driver.getDownScripts(nic, isSlave)
+func (d *SBaseBridgeDriver) generateIfdownScripts(driver IBridgeDriver, scriptPath string, nic *desc.SGuestNetwork, isVolatileHost bool) error {
+	script, err := driver.getDownScripts(nic, isVolatileHost)
 	if err != nil {
 		return errors.Wrap(err, "getDownScripts")
 	}
 	return d.saveFileExecutable(scriptPath, script)
 }
 
-func (d *SBaseBridgeDriver) generateIfupScripts(driver IBridgeDriver, scriptPath string, nic *desc.SGuestNetwork, isSlave bool) error {
-	script, err := driver.getUpScripts(nic, isSlave)
+func (d *SBaseBridgeDriver) generateIfupScripts(driver IBridgeDriver, scriptPath string, nic *desc.SGuestNetwork, isVolatileHost bool) error {
+	script, err := driver.getUpScripts(nic, isVolatileHost)
 	if err != nil {
 		log.Errorln(err)
 		return err

--- a/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
@@ -83,15 +83,19 @@ func (l *SLinuxBridgeDriver) Interfaces() ([]string, error) {
 	return infs, nil
 }
 
-func (l *SLinuxBridgeDriver) GenerateIfdownScripts(scriptPath string, nic *desc.SGuestNetwork, isSlave bool) error {
-	return l.generateIfdownScripts(l, scriptPath, nic, isSlave)
+func (l *SLinuxBridgeDriver) GenerateIfdownScripts(scriptPath string, nic *desc.SGuestNetwork, isVolatileHost bool) error {
+	return l.generateIfdownScripts(l, scriptPath, nic, isVolatileHost)
 }
 
-func (l *SLinuxBridgeDriver) GenerateIfupScripts(scriptPath string, nic *desc.SGuestNetwork, isSlave bool) error {
-	return l.generateIfupScripts(l, scriptPath, nic, isSlave)
+func (l *SLinuxBridgeDriver) GenerateIfupScripts(scriptPath string, nic *desc.SGuestNetwork, isVolatileHost bool) error {
+	return l.generateIfupScripts(l, scriptPath, nic, isVolatileHost)
 }
 
-func (l *SLinuxBridgeDriver) getUpScripts(nic *desc.SGuestNetwork, isSlave bool) (string, error) {
+func (l *SLinuxBridgeDriver) OnVolatileGuestResume(nic *desc.SGuestNetwork) error {
+	return nil
+}
+
+func (l *SLinuxBridgeDriver) getUpScripts(nic *desc.SGuestNetwork, isVolatileHost bool) (string, error) {
 	s := "#!/bin/bash\n\n"
 	s += fmt.Sprintf("switch='%s'\n", l.bridge)
 	if options.HostOptions.TunnelPaddingBytes > 0 {
@@ -103,7 +107,7 @@ func (l *SLinuxBridgeDriver) getUpScripts(nic *desc.SGuestNetwork, isSlave bool)
 	return s, nil
 }
 
-func (l *SLinuxBridgeDriver) getDownScripts(nic *desc.SGuestNetwork, isSlave bool) (string, error) {
+func (l *SLinuxBridgeDriver) getDownScripts(nic *desc.SGuestNetwork, isVolatileHost bool) (string, error) {
 	s := "#!/bin/sh\n\n"
 	s += fmt.Sprintf("switch='%s'\n", l.bridge)
 	s += "brctl show ${switch} | grep $1\n"


### PR DESCRIPTION
Cherry pick of #15497 on release/3.10.

#15497: fix(host): don't set ovs interface external id on migrating