### PR TITLE
Automated cherry pick of #15497: fix(host): don't set ovs interface external id on migrating

### DIFF
--- a/pkg/hostman/guestman/guesttasks.go
+++ b/pkg/hostman/guestman/guesttasks.go
@@ -1092,6 +1092,20 @@ func (s *SGuestResumeTask) onGetBlockInfo(blocks []monitor.QemuBlock) {
 }
 
 func (s *SGuestResumeTask) resumeGuest() {
+	if s.resumed {
+		s.taskFailed("resume guest twice")
+		return
+	}
+
+	if jsonutils.QueryBoolean(s.Desc, "is_volatile_host", false) {
+		if err := s.prepareNicsForVolatileGuestResume(); err != nil {
+			s.taskFailed(err.Error())
+			return
+		}
+		s.Desc.Set("is_volatile_host", jsonutils.JSONFalse)
+		s.SaveDesc(s.Desc)
+	}
+
 	s.startTime = time.Now()
 	s.Monitor.SimpleCommand("cont", s.onResumeSucc)
 }

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -201,11 +201,11 @@ func (s *SKVMGuestInstance) generateNicScripts(nic jsonutils.JSONObject) error {
 	if dev == nil {
 		return fmt.Errorf("Can't find bridge %s", bridge)
 	}
-	isSlave := s.IsSlave()
-	if err := dev.GenerateIfupScripts(s.getNicUpScriptPath(nic), nic, isSlave); err != nil {
+	isVolatileHost := s.IsSlave() || s.IsMigratingDestGuest()
+	if err := dev.GenerateIfupScripts(s.getNicUpScriptPath(nic), nic, isVolatileHost); err != nil {
 		return errors.Wrap(err, "GenerateIfupScripts")
 	}
-	if err := dev.GenerateIfdownScripts(s.getNicDownScriptPath(nic), nic, isSlave); err != nil {
+	if err := dev.GenerateIfdownScripts(s.getNicDownScriptPath(nic), nic, isVolatileHost); err != nil {
 		return errors.Wrap(err, "GenerateIfdownScripts")
 	}
 	return nil
@@ -552,10 +552,9 @@ function nic_mtu() {
 		input.EnableSerialDevice = true
 	}
 
-	liveMigratePort, _ := data.Int("live_migrate_port")
+	liveMigratePort, _ := s.Desc.Int("live_migrate_dest_port")
 	if jsonutils.QueryBoolean(data, "need_migrate", false) {
 		input.NeedMigrate = true
-		s.Desc.Set("live_migrate_dest_port", jsonutils.NewInt(int64(liveMigratePort)))
 		input.LiveMigratePort = uint(liveMigratePort)
 		if jsonutils.QueryBoolean(data, "live_migrate_use_tls", false) {
 			input.LiveMigrateUseTLS = true

--- a/pkg/hostman/hostinfo/hostbridge/hostbridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/hostbridge.go
@@ -53,12 +53,14 @@ type IBridgeDriver interface {
 	PersistentConfig() error
 	DisableDHCPClient() (bool, error)
 
-	GenerateIfupScripts(scriptPath string, nic jsonutils.JSONObject, isSlave bool) error
-	GenerateIfdownScripts(scriptPath string, nic jsonutils.JSONObject, isSlave bool) error
+	GenerateIfupScripts(scriptPath string, nic jsonutils.JSONObject, isVolatileHost bool) error
+	GenerateIfdownScripts(scriptPath string, nic jsonutils.JSONObject, isVolatileHost bool) error
 	RegisterHostlocalServer(mac, ip string) error
 
-	getUpScripts(nic jsonutils.JSONObject, isSlave bool) (string, error)
-	getDownScripts(nic jsonutils.JSONObject, isSlave bool) (string, error)
+	getUpScripts(nic jsonutils.JSONObject, isVolatileHost bool) (string, error)
+	getDownScripts(nic jsonutils.JSONObject, isVolatileHost bool) (string, error)
+
+	OnVolatileGuestResume(nic jsonutils.JSONObject) error
 
 	Bridge() string
 }
@@ -358,16 +360,16 @@ func (d *SBaseBridgeDriver) saveFileExecutable(scriptPath, script string) error 
 	return os.Chmod(scriptPath, syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR)
 }
 
-func (d *SBaseBridgeDriver) generateIfdownScripts(driver IBridgeDriver, scriptPath string, nic jsonutils.JSONObject, isSlave bool) error {
-	script, err := driver.getDownScripts(nic, isSlave)
+func (d *SBaseBridgeDriver) generateIfdownScripts(driver IBridgeDriver, scriptPath string, nic jsonutils.JSONObject, isVolatileHost bool) error {
+	script, err := driver.getDownScripts(nic, isVolatileHost)
 	if err != nil {
 		return errors.Wrap(err, "getDownScripts")
 	}
 	return d.saveFileExecutable(scriptPath, script)
 }
 
-func (d *SBaseBridgeDriver) generateIfupScripts(driver IBridgeDriver, scriptPath string, nic jsonutils.JSONObject, isSlave bool) error {
-	script, err := driver.getUpScripts(nic, isSlave)
+func (d *SBaseBridgeDriver) generateIfupScripts(driver IBridgeDriver, scriptPath string, nic jsonutils.JSONObject, isVolatileHost bool) error {
+	script, err := driver.getUpScripts(nic, isVolatileHost)
 	if err != nil {
 		log.Errorln(err)
 		return err

--- a/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
@@ -83,15 +83,19 @@ func (l *SLinuxBridgeDriver) Interfaces() ([]string, error) {
 	return infs, nil
 }
 
-func (l *SLinuxBridgeDriver) GenerateIfdownScripts(scriptPath string, nic jsonutils.JSONObject, isSlave bool) error {
-	return l.generateIfdownScripts(l, scriptPath, nic, isSlave)
+func (l *SLinuxBridgeDriver) GenerateIfdownScripts(scriptPath string, nic jsonutils.JSONObject, isVolatileHost bool) error {
+	return l.generateIfdownScripts(l, scriptPath, nic, isVolatileHost)
 }
 
-func (l *SLinuxBridgeDriver) GenerateIfupScripts(scriptPath string, nic jsonutils.JSONObject, isSlave bool) error {
-	return l.generateIfupScripts(l, scriptPath, nic, isSlave)
+func (l *SLinuxBridgeDriver) GenerateIfupScripts(scriptPath string, nic jsonutils.JSONObject, isVolatileHost bool) error {
+	return l.generateIfupScripts(l, scriptPath, nic, isVolatileHost)
 }
 
-func (l *SLinuxBridgeDriver) getUpScripts(nic jsonutils.JSONObject, isSlave bool) (string, error) {
+func (l *SLinuxBridgeDriver) OnVolatileGuestResume(nic jsonutils.JSONObject) error {
+	return nil
+}
+
+func (l *SLinuxBridgeDriver) getUpScripts(nic jsonutils.JSONObject, isVolatileHost bool) (string, error) {
 	s := "#!/bin/bash\n\n"
 	s += fmt.Sprintf("switch='%s'\n", l.bridge)
 	if options.HostOptions.TunnelPaddingBytes > 0 {
@@ -103,7 +107,7 @@ func (l *SLinuxBridgeDriver) getUpScripts(nic jsonutils.JSONObject, isSlave bool
 	return s, nil
 }
 
-func (l *SLinuxBridgeDriver) getDownScripts(nic jsonutils.JSONObject, isSlave bool) (string, error) {
+func (l *SLinuxBridgeDriver) getDownScripts(nic jsonutils.JSONObject, isVolatileHost bool) (string, error) {
 	s := "#!/bin/sh\n\n"
 	s += fmt.Sprintf("switch='%s'\n", l.bridge)
 	s += "brctl show ${switch} | grep $1\n"


### PR DESCRIPTION
Cherry pick of #15497 on release/3.9.

#15497: fix(host): don't set ovs interface external id on migrating