### PR TITLE
Automated cherry pick of #15503: fix(host): json ignore etcd and common options

### DIFF
--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -37,9 +37,8 @@ type SHostBaseOptions struct {
 }
 
 type SHostOptions struct {
-	common_options.EtcdOptions
-
-	SHostBaseOptions
+	common_options.EtcdOptions `json:"-"`
+	SHostBaseOptions           `json:"-"`
 
 	CommonConfigFile string `help:"common config file for container"`
 


### PR DESCRIPTION
Cherry pick of #15503 on release/3.10.

#15503: fix(host): json ignore etcd and common options