### PR TITLE
fix: cherry_pick_pull.sh fail to parse URL of github URL with credential

### DIFF
--- a/scripts/cherry_pick_pull.sh
+++ b/scripts/cherry_pick_pull.sh
@@ -46,8 +46,8 @@ declare -r REBASEMAGIC="${REPO_ROOT}/.git/rebase-apply"
 DRY_RUN=${DRY_RUN:-""}
 UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
 FORK_REMOTE=${FORK_REMOTE:-origin}
-MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $3}')}
-MAIN_REPO_NAME=${MAIN_REPO_NAME:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $4}')}
+MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk -F'github.com' '{print $2}' | awk -F'/' 'NR==1{print $2}')}
+MAIN_REPO_NAME=${MAIN_REPO_NAME:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk -F'github.com' '{print $2}' | awk -F'/' 'NR==1{print $3}')}
 
 if [[ -z ${GITHUB_USER:-} ]]; then
   echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"
@@ -172,6 +172,7 @@ gitamcleanup=true
 for pull in "${PULLS[@]}"; do
   echo "+++ Downloading patch to /tmp/${pull}.patch (in case you need to do this again)"
 
+  echo "Downloading https://github.com/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pull/${pull}.patch ..."
   curl -o "/tmp/${pull}.patch" -sSL "https://github.com/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pull/${pull}.patch"
   echo
   echo "+++ About to attempt cherry pick of PR. To reattempt:"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: cherry_pick_pull.sh fail to parse URL of github URL with token credential， i.e.  https://xxxxx:x-oauth-basic@github.com/yunionio/onecloud

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 