### PR TITLE
Automated cherry pick of #15547: fix(region): use qcow2 format on raw disk cache image

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1399,6 +1399,13 @@ func (self *SDisk) GetFsFormat() string {
 	return self.FsFormat
 }
 
+func (self *SDisk) GetCacheImageFormat() string {
+	if self.DiskFormat == "raw" {
+		return "qcow2"
+	}
+	return self.DiskFormat
+}
+
 func (manager *SDiskManager) getDisksByStorage(storage *SStorage) ([]SDisk, error) {
 	disks := make([]SDisk, 0)
 	q := manager.Query().Equals("storage_id", storage.Id)

--- a/pkg/compute/tasks/disk_create_task.go
+++ b/pkg/compute/tasks/disk_create_task.go
@@ -46,7 +46,7 @@ func (self *DiskCreateTask) OnInit(ctx context.Context, obj db.IStandaloneModel,
 		self.SetStage("OnStorageCacheImageComplete", nil)
 		input := api.CacheImageInput{
 			ImageId:      imageId,
-			Format:       disk.DiskFormat,
+			Format:       disk.GetCacheImageFormat(),
 			ParentTaskId: self.GetTaskId(),
 		}
 		guest := disk.GetGuest()


### PR DESCRIPTION
Cherry pick of #15547 on release/3.9.

#15547: fix(region): use qcow2 format on raw disk cache image