### PR TITLE
fix: usb tablet not function for windows 10 guest

### DIFF
--- a/pkg/util/stringutils2/i18n.go
+++ b/pkg/util/stringutils2/i18n.go
@@ -14,6 +14,14 @@
 
 package stringutils2
 
+import (
+	"bytes"
+	"io/ioutil"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/transform"
+)
+
 func IsUtf8(str string) bool {
 	for _, runeVal := range str {
 		if runeVal > 0x7f {
@@ -47,4 +55,13 @@ func IsPrintableAsciiString(str string) bool {
 		}
 	}
 	return true
+}
+
+func UTF82GB18030(s []byte) ([]byte, error) {
+	reader := transform.NewReader(bytes.NewReader(s), simplifiedchinese.GB18030.NewEncoder())
+	d, e := ioutil.ReadAll(reader)
+	if e != nil {
+		return nil, e
+	}
+	return d, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: usb tablet not function for windows 10 guest

Windows 10 will not reinitialize USB devices, so we remove USB registry to force Windows 10 to do the initialization

Reference: https://www.kraxel.org/blog/2014/03/qemu-and-usb-tablet-cpu-consumtion/
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi 