### PR TITLE
Automated cherry pick of #15557: fix(cloudmon): collectStatsMetrics ret is nil

### DIFF
--- a/pkg/cloudmon/misc/system.go
+++ b/pkg/cloudmon/misc/system.go
@@ -123,6 +123,10 @@ func collectStatsMetrics(ctx context.Context, ep api.EndpointDetails, version, t
 		return nil, errors.Wrapf(err, "request")
 	}
 
+	if ret == nil {
+		return nil, errors.Wrap(errors.Errorf("ret is nil"), "ret is nil")
+	}
+
 	stats := struct {
 		HttpCode2xx    float64 `json:"duration.2XX"`
 		HttpCode4xx    float64 `json:"duration.4XX"`


### PR DESCRIPTION
Cherry pick of #15557 on release/3.10.

#15557: fix(cloudmon): collectStatsMetrics ret is nil