### PR TITLE
fix: prefer id over name when fetching owner id

### DIFF
--- a/pkg/cloudcommon/db/fetch.go
+++ b/pkg/cloudcommon/db/fetch.go
@@ -227,7 +227,10 @@ func fetchItem(manager IModelManager, ctx context.Context, userCred mcclient.Tok
 }
 
 func FetchUserInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
-	userStr, key := jsonutils.GetAnyString2(data, []string{"user", "user_id"})
+	userStr, key := jsonutils.GetAnyString2(data, []string{
+		"user_id",
+		"user",
+	})
 	if len(userStr) > 0 {
 		data.(*jsonutils.JSONDict).Remove(key)
 		u, err := DefaultUserFetcher(ctx, userStr)
@@ -249,7 +252,12 @@ func FetchUserInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.IId
 }
 
 func FetchProjectInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
-	tenantId, key := jsonutils.GetAnyString2(data, []string{"project", "project_id", "tenant", "tenant_id"})
+	tenantId, key := jsonutils.GetAnyString2(data, []string{
+		"project_id",
+		"tenant_id",
+		"project",
+		"tenant",
+	})
 	if len(tenantId) > 0 {
 		data.(*jsonutils.JSONDict).Remove(key)
 		t, err := DefaultProjectFetcher(ctx, tenantId)
@@ -274,7 +282,11 @@ func FetchProjectInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.
 }
 
 func FetchDomainInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
-	domainId, key := jsonutils.GetAnyString2(data, []string{"domain_id", "project_domain", "project_domain_id"})
+	domainId, key := jsonutils.GetAnyString2(data, []string{
+		"domain_id",
+		"project_domain_id",
+		"project_domain",
+	})
 	if len(domainId) > 0 {
 		data.(*jsonutils.JSONDict).Remove(key)
 		domain, err := DefaultDomainFetcher(ctx, domainId)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: prefer id over name when fetching owner id

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- releasse/3.10
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 