### PR TITLE
Automated cherry pick of #15609: fix(region): sriov typo

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -70,7 +70,7 @@ type NetworkConfig struct {
 	NumQueues int    `json:"num_queues"`
 
 	// sriov nic
-	SriovDevice *IsolatedDeviceConfig `json:"srive_device"`
+	SriovDevice *IsolatedDeviceConfig `json:"sriov_device"`
 
 	RequireDesignatedIP bool `json:"require_designated_ip"`
 


### PR DESCRIPTION
Cherry pick of #15609 on release/3.10.

#15609: fix(region): sriov typo