### PR TITLE
fix: limit roles that a user join a project

### DIFF
--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -84,6 +84,9 @@ const (
 	IdentitySyncStatusIdle    = "idle"
 
 	MinimalSyncIntervalSeconds = 5 * 60 // 5 minutes
+
+	MaxUserRolesInProject  = 10
+	MaxGroupRolesInProject = 5
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: limit roles that a user join a project

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 