### PR TITLE
fix(webconsole): not get pod info when fetchK8sEnv

### DIFF
--- a/pkg/webconsole/handlers.go
+++ b/pkg/webconsole/handlers.go
@@ -82,17 +82,6 @@ func fetchK8sEnv(ctx context.Context, w http.ResponseWriter, r *http.Request) (*
 	podName := params["<podName>"]
 	adminSession := auth.GetAdminSession(ctx, o.Options.Region)
 
-	query := jsonutils.NewDict()
-	query.Add(jsonutils.NewString(k8sReq.Namespace), "namespace")
-	query.Add(jsonutils.NewString(k8sReq.Cluster), "cluster")
-	obj, err := k8s.Pods.Get(adminSession, podName, query)
-	if err != nil {
-		return nil, err
-	}
-	if obj == nil {
-		return nil, httperrors.NewNotFoundError("Not found pod %q", podName)
-	}
-
 	data := jsonutils.NewDict()
 	ret, err := k8s.KubeClusters.GetSpecific(adminSession, k8sReq.Cluster, "kubeconfig", data)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.8
/area webconsole
/cc @swordqiu 