### PR TITLE
Automated cherry pick of #15651: fix(webconsole): not get pod info when fetchK8sEnv

### DIFF
--- a/pkg/webconsole/handlers.go
+++ b/pkg/webconsole/handlers.go
@@ -71,17 +71,6 @@ func fetchK8sEnv(ctx context.Context, w http.ResponseWriter, r *http.Request) (*
 	podName := params["<podName>"]
 	adminSession := auth.GetAdminSession(ctx, o.Options.Region, "")
 
-	query := jsonutils.NewDict()
-	query.Add(jsonutils.NewString(k8sReq.Namespace), "namespace")
-	query.Add(jsonutils.NewString(k8sReq.Cluster), "cluster")
-	obj, err := k8s.Pods.Get(adminSession, podName, query)
-	if err != nil {
-		return nil, err
-	}
-	if obj == nil {
-		return nil, httperrors.NewNotFoundError("Not found pod %q", podName)
-	}
-
 	data := jsonutils.NewDict()
 	ret, err := k8s.KubeClusters.GetSpecific(adminSession, k8sReq.Cluster, "kubeconfig", data)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #15651 on release/3.8.

#15651: fix(webconsole): not get pod info when fetchK8sEnv