### PR TITLE
fix(host): detect qemu caps

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -917,7 +917,7 @@ func (h *SHostInfo) detectQemuCapabilities(version string) error {
 		log.Errorf("failed start qemu caps cmdline: %s", qmpCmds)
 	}
 	segs := bytes.Split(out, []byte{'\n'})
-	if len(segs) != 6 {
+	if len(segs) < 6 {
 		return errors.Errorf("unexpect qmp res %s", out)
 	}
 	res, err := jsonutils.Parse(bytes.TrimSpace(segs[2]))


### PR DESCRIPTION
ingnore pmemclean output on qemu version 2.12.1

Signed-off-by: wanyaoqi <d3lx.yq@gmail.com>

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
