### PR TITLE
fix: make cloudaccount options visbile in list

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -139,7 +139,7 @@ type SCloudaccount struct {
 	Brand string `width:"64" charset:"utf8" nullable:"true" list:"domain" create:"optional"`
 
 	// 额外信息
-	Options *jsonutils.JSONDict `get:"domain" create:"domain_optional" update:"domain"`
+	Options *jsonutils.JSONDict `get:"domain" list:"domain" create:"domain_optional" update:"domain"`
 
 	// for backward compatiblity, keep is_public field, but not usable
 	// IsPublic bool `default:"false" nullable:"false"`


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: make cloudaccount options visbile in list
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @ioito @zexi 