### PR TITLE
Automated cherry pick of #15694: fix(scheduler): do migrate checking when hypervisor is not esxi

### DIFF
--- a/pkg/scheduler/algorithm/predicates/guest/migrate_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/guest/migrate_predicate.go
@@ -52,30 +52,33 @@ func (p *MigratePredicate) Execute(ctx context.Context, u *core.Unit, c core.Can
 	if schedData.LiveMigrate {
 		host := c.Getter().Host()
 
-		// target host mem page size check
-		if schedData.HostMemPageSizeKB != host.PageSizeKB {
-			h.Exclude(predicates.ErrHostMemPageSizeNotMatchForLiveMigrate)
-			return h.GetResult()
-		}
-
-		// target host cpu check
-		if schedData.CpuMode != compute.CPU_MODE_QEMU && (schedData.SkipCpuCheck == nil || *schedData.SkipCpuCheck == false) {
-			if schedData.CpuDesc != host.CpuDesc {
-				h.Exclude(predicates.ErrHostCpuModelIsNotMatchForLiveMigrate)
+		guestHypervisor := u.SchedData().Hypervisor
+		if guestHypervisor != compute.HYPERVISOR_ESXI {
+			// target host mem page size check
+			if schedData.HostMemPageSizeKB != host.PageSizeKB {
+				h.Exclude(predicates.ErrHostMemPageSizeNotMatchForLiveMigrate)
 				return h.GetResult()
 			}
-			if len(schedData.CpuMicrocode) > 0 && schedData.CpuMicrocode != host.CpuMicrocode {
-				h.Exclude(predicates.ErrHostCpuMicrocodeNotMatchForLiveMigrate)
-				return h.GetResult()
-			}
-		}
 
-		// target host kernel check
-		if schedData.SkipKernelCheck != nil && !*schedData.SkipKernelCheck {
-			kv, _ := host.SysInfo.GetString("kernel_version")
-			if schedData.TargetHostKernel != "" && schedData.TargetHostKernel != kv {
-				h.Exclude2(predicates.ErrHostKernelNotMatchForLiveMigrate, kv, schedData.TargetHostKernel)
-				return h.GetResult()
+			// target host cpu check
+			if schedData.CpuMode != compute.CPU_MODE_QEMU && (schedData.SkipCpuCheck == nil || *schedData.SkipCpuCheck == false) {
+				if schedData.CpuDesc != host.CpuDesc {
+					h.Exclude(predicates.ErrHostCpuModelIsNotMatchForLiveMigrate)
+					return h.GetResult()
+				}
+				if len(schedData.CpuMicrocode) > 0 && schedData.CpuMicrocode != host.CpuMicrocode {
+					h.Exclude(predicates.ErrHostCpuMicrocodeNotMatchForLiveMigrate)
+					return h.GetResult()
+				}
+			}
+
+			// target host kernel check
+			if schedData.SkipKernelCheck != nil && !*schedData.SkipKernelCheck {
+				kv, _ := host.SysInfo.GetString("kernel_version")
+				if schedData.TargetHostKernel != "" && schedData.TargetHostKernel != kv {
+					h.Exclude2(predicates.ErrHostKernelNotMatchForLiveMigrate, kv, schedData.TargetHostKernel)
+					return h.GetResult()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick of #15694 on release/3.10.

#15694: fix(scheduler): do migrate checking when hypervisor is not esxi