### PR TITLE
fix: init shceduler schedinfo project and domain

### DIFF
--- a/pkg/scheduler/api/sched.go
+++ b/pkg/scheduler/api/sched.go
@@ -95,6 +95,13 @@ func FetchSchedInfo(req *http.Request) (*SchedInfo, error) {
 	data := NewSchedInfo(input)
 	data.UserCred = userCred
 
+	if len(data.Domain) == 0 {
+		data.Domain = userCred.GetProjectDomainId()
+	}
+	if len(data.Project) == 0 {
+		data.Project = userCred.GetProjectId()
+	}
+
 	domainId := data.Domain
 	for _, net := range data.Networks {
 		if net.Domain == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: init shceduler schedinfo project and domain

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 