### PR TITLE
Automated cherry pick of #15710: fix: init shceduler schedinfo project and domain

### DIFF
--- a/pkg/scheduler/api/sched.go
+++ b/pkg/scheduler/api/sched.go
@@ -95,6 +95,13 @@ func FetchSchedInfo(req *http.Request) (*SchedInfo, error) {
 	data := NewSchedInfo(input)
 	data.UserCred = userCred
 
+	if len(data.Domain) == 0 {
+		data.Domain = userCred.GetProjectDomainId()
+	}
+	if len(data.Project) == 0 {
+		data.Project = userCred.GetProjectId()
+	}
+
 	domainId := data.Domain
 	for _, net := range data.Networks {
 		if net.Domain == "" {


### PR DESCRIPTION
Cherry pick of #15710 on release/3.10.

#15710: fix: init shceduler schedinfo project and domain