### PR TITLE
fix(host-deployer): windows 2008 Out-File IOException

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/windows.go
+++ b/pkg/hostman/guestfs/fsdriver/windows.go
@@ -595,7 +595,7 @@ func (w *SWindowsRootFs) DeployTelegraf(config string) (bool, error) {
 		strings.Join([]string{
 			`%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`,
 			` -executionpolicy bypass %SystemRoot%\telegraf.ps1`,
-			fmt.Sprintf(" '%s' '%s' %s", telegrafBinaryPath, telegrafConfPath, w.guestDebugLogPath),
+			fmt.Sprintf(" '%s' '%s' >> %s_telegraf", telegrafBinaryPath, telegrafConfPath, w.guestDebugLogPath),
 		}, ""),
 		`del %SystemRoot%\telegraf.ps1`,
 		w.MakeGuestDebugCmd("setup telegraf step 2"),

--- a/pkg/hostman/guestfs/fsdriver/winscripts.go
+++ b/pkg/hostman/guestfs/fsdriver/winscripts.go
@@ -522,14 +522,8 @@ mtw_main();
 const winTelegrafSetupPowerShellScript = `
 $telegraf = $args[0]
 $telegraf_conf = $args[1]
-$logpath = $args[2]
 
-if ($logpath) {
-    & $telegraf --service install --config $telegraf_conf 2>&1 | Out-File $logpath -Append -Encoding Default
-    net start telegraf | Out-File $logpath -Append -Encoding Default
-} else {
-    & $telegraf --service install --config $telegraf_conf 2>&1
-    net start telegraf
-}
+& $telegraf --service install --config $telegraf_conf
+net start telegraf
 
 `


### PR DESCRIPTION
debug log cause windows 2008 IOException, multi process open log file.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.9
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
