### PR TITLE
fix cherrypick script

### DIFF
--- a/scripts/cherry_pick_pull.sh
+++ b/scripts/cherry_pick_pull.sh
@@ -46,8 +46,8 @@ declare -r REBASEMAGIC="${REPO_ROOT}/.git/rebase-apply"
 DRY_RUN=${DRY_RUN:-""}
 UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
 FORK_REMOTE=${FORK_REMOTE:-origin}
-MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk -F'github.com' '{print $2}' | awk -F'[./]' 'NR==1{print $2}')}
-MAIN_REPO_NAME=${MAIN_REPO_NAME:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk -F'github.com' '{print $2}' | awk -F'[./]' 'NR==1{print $3}')}
+MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk -F'github.com' '{print $2}' | awk -F'[:./]' 'NR==1{print $2}')}
+MAIN_REPO_NAME=${MAIN_REPO_NAME:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk -F'github.com' '{print $2}' | awk -F'[:./]' 'NR==1{print $3}')}
 
 if [[ -z ${GITHUB_USER:-} ]]; then
   echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"


### PR DESCRIPTION
**What this PR does / why we need it**:
```
echo 'git@github.com:yunionio/cloudpods.git' | awk -F'github.com' '{print $2}' | awk -F'[:./]' 'NR==1{print $2}'
yunionio
```
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
