### PR TITLE
fix(region): qga set password status on failed

### DIFF
--- a/pkg/apis/compute/guest_const.go
+++ b/pkg/apis/compute/guest_const.go
@@ -160,8 +160,9 @@ const (
 
 	VM_SYNC_ISOLATED_DEVICE_FAILED = "sync_isolated_device_failed"
 
-	VM_QGA_SET_PASSWORD      = "qga_set_password"
-	VM_QGA_COMMAND_EXECUTING = "qga_command_executing"
+	VM_QGA_SET_PASSWORD        = "qga_set_password"
+	VM_QGA_COMMAND_EXECUTING   = "qga_command_executing"
+	VM_QGA_EXEC_COMMAND_FAILED = "qga_exec_command_failed"
 
 	SHUTDOWN_STOP      = "stop"
 	SHUTDOWN_TERMINATE = "terminate"

--- a/pkg/compute/tasks/guest_qga_reset_password_task.go
+++ b/pkg/compute/tasks/guest_qga_reset_password_task.go
@@ -41,7 +41,7 @@ func (self *SGuestQgaBaseTask) guestPing(ctx context.Context, guest *models.SGue
 }
 
 func (self *SGuestQgaBaseTask) taskFailed(ctx context.Context, guest *models.SGuest, reason string) {
-	guest.SetStatus(self.UserCred, api.VM_RUNNING, "on qga set user password failed")
+	guest.SetStatus(self.UserCred, api.VM_QGA_EXEC_COMMAND_FAILED, reason)
 	guest.UpdateQgaStatus(api.QGA_STATUS_EXECUTE_FAILED)
 	db.OpsLog.LogEvent(guest, db.ACT_SET_USER_PASSWORD_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithContext(ctx, guest, logclient.ACT_SET_USER_PASSWORD, reason, self.UserCred, false)


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
