### PR TITLE
Automated cherry pick of #15800: fix(mcclient): 避免休眠后再次启动后admin token失效, 导致用户登录失败

### DIFF
--- a/pkg/mcclient/auth/auth.go
+++ b/pkg/mcclient/auth/auth.go
@@ -331,6 +331,9 @@ func Client() *mcclient.Client {
 }
 
 func AdminCredential() mcclient.TokenCredential {
+	if manager.adminCredential.GetExpires().Before(time.Now()) {
+		manager.reAuth()
+	}
 	return manager.adminCredential
 }
 


### PR DESCRIPTION
Cherry pick of #15800 on release/3.10.

#15800: fix(mcclient): 避免休眠后再次启动后admin token失效, 导致用户登录失败