### PR TITLE
fix: clean pending usage when dry run validate_create_data

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -1320,20 +1320,22 @@ func (dispatcher *DBModelDispatcher) Create(ctx context.Context, query jsonutils
 		return nil, errors.Wrap(err, "isClassRbacAllowed")
 	}
 
-	dryRun := jsonutils.QueryBoolean(data, "dry_run", false)
-
-	if !dryRun && InitPendingUsagesInContext != nil {
+	// initialize pending usage in context any way
+	if InitPendingUsagesInContext != nil {
 		ctx = InitPendingUsagesInContext(ctx)
 	}
+	dryRun := jsonutils.QueryBoolean(data, "dry_run", false)
 
+	// inject tag filters imposed by policy
 	data.(*jsonutils.JSONDict).Update(policyResult.Json())
 
 	model, err := DoCreate(manager, ctx, userCred, query, data, ownerId)
 	if err != nil {
-		if !dryRun && CancelPendingUsagesInContext != nil {
+		// validate failed, clean pending usage
+		if CancelPendingUsagesInContext != nil {
 			e := CancelPendingUsagesInContext(ctx, userCred)
 			if e != nil {
-				err = errors.Wrapf(err, e.Error())
+				err = errors.Wrapf(err, "CancelPendingUsagesInContext fail %s", e.Error())
 			}
 		}
 		failErr := manager.OnCreateFailed(ctx, userCred, ownerId, query, data)
@@ -1344,6 +1346,13 @@ func (dispatcher *DBModelDispatcher) Create(ctx context.Context, query jsonutils
 	}
 
 	if dryRun {
+		// dry run, clean pending usage
+		if CancelPendingUsagesInContext != nil {
+			err := CancelPendingUsagesInContext(ctx, userCred)
+			if err != nil {
+				return nil, errors.Wrap(err, "CancelPendingUsagesInContext")
+			}
+		}
 		return getItemDetails(manager, model, ctx, userCred, query)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: clean pending usage when dry run validate_create_data

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito @wanyaoqi 