### PR TITLE
Automated cherry pick of #15837: fix: disable metadata server monitor for SR-IOV

### DIFF
--- a/pkg/compute/guestdrivers/kvm.go
+++ b/pkg/compute/guestdrivers/kvm.go
@@ -1067,7 +1067,7 @@ func (self *SKVMGuestDriver) RequestQgaCommand(ctx context.Context, userCred mcc
 }
 
 func (self *SKVMGuestDriver) FetchMonitorUrl(ctx context.Context, guest *models.SGuest) string {
-	if options.Options.KvmMonitorAgentUseMetadataService {
+	if options.Options.KvmMonitorAgentUseMetadataService && !guest.IsSriov() {
 		return apis.MetaServiceMonitorAgentUrl
 	}
 	return self.SVirtualizedGuestDriver.FetchMonitorUrl(ctx, guest)

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -6387,7 +6387,21 @@ func (manager *SGuestManager) CustomizedTotalCount(ctx context.Context, userCred
 		return -1, nil, errors.Wrap(err, "SGuestManager query total_disk")
 	}
 
-	log.Debugf("CustomizedTotalCount %s", jsonutils.Marshal(results))
+	// log.Debugf("CustomizedTotalCount %s", jsonutils.Marshal(results))
 
 	return results.Count, jsonutils.Marshal(results), nil
+}
+
+func (guest *SGuest) IsSriov() bool {
+	nics, err := guest.GetNetworks("")
+	if err != nil {
+		log.Errorf("guest.GetNetworks fail %s", err)
+		return false
+	}
+	for i := range nics {
+		if nics[i].Driver == api.NETWORK_DRIVER_VFIO {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Cherry pick of #15837 on release/3.10.

#15837: fix: disable metadata server monitor for SR-IOV