### PR TITLE
Automated cherry pick of #15862: fix(region): 避免创建相同配置时使用当前实例的hostname

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -5835,6 +5835,7 @@ func (self *SGuest) ToCreateInput(ctx context.Context, userCred mcclient.TokenCr
 	// clean some of user input
 	userInput.GenerateName = ""
 	userInput.Description = ""
+	userInput.Hostname = ""
 	return userInput
 }
 


### PR DESCRIPTION
Cherry pick of #15862 on release/3.10.

#15862: fix(region): 避免创建相同配置时使用当前实例的hostname