### PR TITLE
fix: climc logs-splitable support monitor notify

### DIFF
--- a/pkg/mcclient/options/logs.go
+++ b/pkg/mcclient/options/logs.go
@@ -18,7 +18,7 @@ import "yunion.io/x/jsonutils"
 
 type EventSplitableOptions struct {
 	ID      string `choices:"splitable|splitable-export"`
-	Service string `help:"service" choices:"compute|identity|image|log|cloudevent" default:"compute"`
+	Service string `help:"service" choices:"compute|identity|image|log|cloudevent|monitor|notify" default:"compute"`
 	Table   string `help:"when id is splitable-export table must be input"`
 }
 
@@ -31,7 +31,7 @@ func (self *EventSplitableOptions) Params() (jsonutils.JSONObject, error) {
 }
 
 type EventPurgeSplitableOptions struct {
-	Service string `help:"service" choices:"compute|identity|image|log|cloudevent" default:"compute"`
+	Service string `help:"service" choices:"compute|identity|image|log|cloudevent|monitor|notify" default:"compute"`
 	Tables  []string
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: climc logs-splitable support monitor notify

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi @ioito 