### PR TITLE
feat(region,host): support ovs offload.

### DIFF
--- a/pkg/apis/compute/isolated_device.go
+++ b/pkg/apis/compute/isolated_device.go
@@ -101,11 +101,12 @@ type IsolatedDeviceUpdateInput struct {
 }
 
 type IsolatedDeviceJsonDesc struct {
-	Id             string `json:"id"`
-	DevType        string `json:"dev_type"`
-	Model          string `json:"model"`
-	Addr           string `json:"addr"`
-	VendorDeviceId string `json:"vendor_device_id"`
-	Vendor         string `json:"vendor"`
-	NetworkIndex   int8   `json:"network_index"`
+	Id                  string `json:"id"`
+	DevType             string `json:"dev_type"`
+	Model               string `json:"model"`
+	Addr                string `json:"addr"`
+	VendorDeviceId      string `json:"vendor_device_id"`
+	Vendor              string `json:"vendor"`
+	NetworkIndex        int8   `json:"network_index"`
+	OvsOffloadInterface string `json:"ovs_offload_interface"`
 }

--- a/pkg/compute/models/isolated_devices.go
+++ b/pkg/compute/models/isolated_devices.go
@@ -94,6 +94,8 @@ type SIsolatedDevice struct {
 	NetworkIndex int8 `nullable:"true" default:"-1" list:"user" update:"user"`
 	// Nic wire id
 	WireId string `width:"36" charset:"ascii" nullable:"true" index:"true" list:"domain" update:"domain" create:"domain_optional"`
+	// Offload interface name
+	OvsOffloadInterface string `width:"16" charset:"ascii" nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 
 	// # pci address of `Bus:Device.Function` format, or usb bus address of `bus.addr`
 	Addr string `width:"16" charset:"ascii" nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
@@ -664,13 +666,14 @@ func (manager *SIsolatedDeviceManager) TotalCount(
 
 func (self *SIsolatedDevice) getDesc() *api.IsolatedDeviceJsonDesc {
 	return &api.IsolatedDeviceJsonDesc{
-		Id:             self.Id,
-		DevType:        self.DevType,
-		Model:          self.Model,
-		Addr:           self.Addr,
-		VendorDeviceId: self.VendorDeviceId,
-		Vendor:         self.getVendor(),
-		NetworkIndex:   self.NetworkIndex,
+		Id:                  self.Id,
+		DevType:             self.DevType,
+		Model:               self.Model,
+		Addr:                self.Addr,
+		VendorDeviceId:      self.VendorDeviceId,
+		Vendor:              self.getVendor(),
+		NetworkIndex:        self.NetworkIndex,
+		OvsOffloadInterface: self.OvsOffloadInterface,
 	}
 }
 

--- a/pkg/hostman/guestman/pci.go
+++ b/pkg/hostman/guestman/pci.go
@@ -281,6 +281,12 @@ func (s *SKVMGuestInstance) initGuestNetworks(pciRoot, pciBridge *desc.PCIContro
 	}
 
 	for i := 0; i < len(s.Desc.Nics); i++ {
+		if err := s.generateNicScripts(s.Desc.Nics[i]); err != nil {
+			return errors.Wrapf(err, "generateNicScripts for nic: %v", s.Desc.Nics[i])
+		}
+		s.Desc.Nics[i].UpscriptPath = s.getNicUpScriptPath(s.Desc.Nics[i])
+		s.Desc.Nics[i].DownscriptPath = s.getNicDownScriptPath(s.Desc.Nics[i])
+
 		if s.Desc.Nics[i].Driver != "vfio-pci" {
 			switch s.GetOsName() {
 			case OS_NAME_MACOS:
@@ -294,12 +300,6 @@ func (s *SKVMGuestInstance) initGuestNetworks(pciRoot, pciBridge *desc.PCIContro
 				vectors := s.Desc.Nics[i].NumQueues * 2
 				s.Desc.Nics[i].Vectors = &vectors
 			}
-
-			if err := s.generateNicScripts(s.Desc.Nics[i]); err != nil {
-				return errors.Wrapf(err, "generateNicScripts for nic: %v", s.Desc.Nics[i])
-			}
-			s.Desc.Nics[i].UpscriptPath = s.getNicUpScriptPath(s.Desc.Nics[i])
-			s.Desc.Nics[i].DownscriptPath = s.getNicDownScriptPath(s.Desc.Nics[i])
 
 			id := fmt.Sprintf("netdev-%s", s.Desc.Nics[i].Ifname)
 			switch s.Desc.Nics[i].Driver {

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -662,7 +662,10 @@ func (s *SKVMGuestInstance) generateStopScript(data *jsonutils.JSONDict) string 
 
 	for _, nic := range nics {
 		if nic.Driver == api.NETWORK_DRIVER_VFIO {
-			continue
+			dev, _ := s.GetSriovDeviceByNetworkIndex(nic.Index)
+			if dev != nil && dev.GetOvsOffloadInterfaceName() == "" {
+				continue
+			}
 		}
 		downscript := s.getNicDownScriptPath(nic)
 		cmd += fmt.Sprintf("%s %s\n", downscript, nic.Ifname)

--- a/pkg/hostman/hostinfo/hostbridge/ovs.go
+++ b/pkg/hostman/hostinfo/hostbridge/ovs.go
@@ -191,10 +191,13 @@ func (o *SOVSBridgeDriver) getUpScripts(nic *desc.SGuestNetwork, isVolatileHost 
 	s += "PORT=$(ovs-ofctl show $SWITCH | grep -w $IF)\n"
 	s += "PORT=$(echo $PORT | awk 'BEGIN{FS=\"(\"}{print $1}')\n"
 	s += "OFCTL=$(ovs-vsctl get-controller $SWITCH)\n"
-	s += "if [ -z \"$OFCTL\" ]; then\n"
-	s += "    ovs-vsctl set Interface $IF ingress_policing_rate=$LIMIT\n"
-	s += "    ovs-vsctl set Interface $IF ingress_policing_burst=$BURST\n"
-	s += "fi\n"
+	if nic.Driver != compute.NETWORK_DRIVER_VFIO {
+		s += "if [ -z \"$OFCTL\" ]; then\n"
+		s += "    ovs-vsctl set Interface $IF ingress_policing_rate=$LIMIT\n"
+		s += "    ovs-vsctl set Interface $IF ingress_policing_burst=$BURST\n"
+		s += "fi\n"
+	}
+
 	s += "if [ $LIMIT_DOWNLOAD != \"0mbit\" ]; then\n"
 	s += "    tc qdisc del dev $IF root 2>/dev/null\n"
 	s += "    tc qdisc add dev $IF root handle 1: htb default 10\n"

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1843,18 +1843,52 @@ func (h *SHostInfo) probeSyncIsolatedDevicesStep() {
 	h.deployAdminAuthorizedKeys()
 }
 
-func (h *SHostInfo) getNicsInterfaces() [][2]string {
-	res := [][2]string{}
+func (h *SHostInfo) getNicsInterfaces(nics []string) []isolated_device.HostNic {
+	if len(nics) == 0 {
+		return nil
+	}
+	res := []isolated_device.HostNic{}
 	for i := 0; i < len(h.Nics); i++ {
-		res = append(res, [2]string{h.Nics[i].Inter, h.Nics[i].WireId})
+		if utils.IsInStringArray(h.Nics[i].Inter, nics) {
+			res = append(res, isolated_device.HostNic{h.Nics[i].Bridge, h.Nics[i].Inter, h.Nics[i].WireId})
+		}
 	}
 	return res
 }
 
+func (h *SHostInfo) getNicsOvsOffloadInterfaces(nics []string) ([]isolated_device.HostNic, error) {
+	if len(nics) == 0 {
+		return nil, nil
+	}
+
+	res := []isolated_device.HostNic{}
+	for i := 0; i < len(h.Nics); i++ {
+		if utils.IsInStringArray(h.Nics[i].Inter, nics) {
+			if fileutils2.Exists(fmt.Sprintf("/sys/class/net/%s/bonding/slaves", h.Nics[i].Inter)) {
+				interStr, err := fileutils2.FileGetContents(fmt.Sprintf("/sys/class/net/%s/bonding/slaves", h.Nics[i].Inter))
+				if err != nil {
+					return nil, err
+				}
+				inters := strings.Split(strings.TrimSpace(interStr), " ")
+				for _, inter := range inters {
+					res = append(res, isolated_device.HostNic{h.Nics[i].Bridge, inter, h.Nics[i].WireId})
+				}
+			} else {
+				res = append(res, isolated_device.HostNic{h.Nics[i].Bridge, h.Nics[i].Inter, h.Nics[i].WireId})
+			}
+		}
+	}
+	return res, nil
+}
+
 func (h *SHostInfo) probeSyncIsolatedDevices() (*jsonutils.JSONArray, error) {
+	offloadNics, err := h.getNicsOvsOffloadInterfaces(options.HostOptions.OvsOffloadNics)
+	if err != nil {
+		return nil, err
+	}
+	sriovNics := h.getNicsInterfaces(options.HostOptions.SRIOVNics)
 	if err := h.IsolatedDeviceMan.ProbePCIDevices(
-		options.HostOptions.DisableGPU, options.HostOptions.DisableUSB,
-		options.HostOptions.DisableSRIOVNic, h.getNicsInterfaces(),
+		options.HostOptions.DisableGPU, options.HostOptions.DisableUSB, sriovNics, offloadNics,
 	); err != nil {
 		return nil, errors.Wrap(err, "ProbePCIDevices")
 	}

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -170,9 +170,10 @@ type SHostOptions struct {
 
 	DisableKVM bool `help:"force disable KVM" default:"false" json:"disable_kvm"`
 
-	DisableGPU      bool `help:"force disable GPU detect" default:"false" json:"disable_gpu"`
-	DisableUSB      bool `help:"force disable USB detect" default:"true" json:"disable_usb"`
-	DisableSRIOVNic bool `help:"force disable USB detect" default:"true" json:"disable_sriov_nic"`
+	DisableGPU     bool     `help:"force disable GPU detect" default:"false" json:"disable_gpu"`
+	DisableUSB     bool     `help:"force disable USB detect" default:"true" json:"disable_usb"`
+	SRIOVNics      []string `help:"nics enable sriov" json:"sriov_nics"`
+	OvsOffloadNics []string `help:"nics enable ovs offload" json:"ovs_offload_nics"`
 
 	EthtoolEnableGso bool `help:"use ethtool to turn on or off GSO(generic segment offloading)" default:"false" json:"ethtool_enable_gso"`
 


### PR DESCRIPTION
Cloudpods Ovs offload implemention base on SR-IOV support. IsolatedDevices add field `OvsOffloadInterface`.

Host config add `ovs_offload_nics` to specify which nic enable ovs offload, and removed flag `disable_sriov_nics` add flag `sriov_nics` to configure sriov nics.

Tested Hardware: Mellanox ConnectX-5 NICs

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
