### PR TITLE
fix: usage filter by policy tags revisit2

### DIFF
--- a/pkg/compute/usages/handler.go
+++ b/pkg/compute/usages/handler.go
@@ -950,12 +950,13 @@ func guestHypervisorsUsage(
 	count := make(map[string]interface{})
 
 	results := db.UsagePolicyCheck(userToken, models.GuestManager, scope)
+	log.Debugf("guestHypervisorsUsage origin %s", results.String())
 	results = results.Merge(policyResult)
 	if results.Result.IsDeny() {
 		// deny
 		return count
 	}
-	log.Debugf("guestHypervisorsUsage results %s", results.String())
+	log.Debugf("guestHypervisorsUsage policyResults %s results %s", policyResult.String(), results.String())
 	// temporarily hide system resources
 	// XXX needs more work later
 	guest := models.GuestManager.TotalCount(scope, ownerId, rangeObjs, status, hypervisors,

--- a/pkg/util/rbacutils/results.go
+++ b/pkg/util/rbacutils/results.go
@@ -75,13 +75,7 @@ func (result SPolicyResult) Json() jsonutils.JSONObject {
 }
 
 func mergeTagList(t1, t2 tagutils.TTagSetList) tagutils.TTagSetList {
-	ret := tagutils.TTagSetList{}
-	for i := range t1 {
-		for j := range t2 {
-			ret = append(ret, t1[i].Append(t2[j]...))
-		}
-	}
-	return ret
+	return t1.IntersectList(t2)
 }
 
 func (r1 SPolicyResult) Merge(r2 SPolicyResult) SPolicyResult {

--- a/pkg/util/tagutils/tag_test.go
+++ b/pkg/util/tagutils/tag_test.go
@@ -59,6 +59,28 @@ func TestSTagCompare(t *testing.T) {
 			},
 			cmp: -1,
 		},
+		{
+			t1: STag{
+				Key:   "a",
+				Value: AnyValue,
+			},
+			t2: STag{
+				Key:   "a",
+				Value: NoValue,
+			},
+			cmp: -1,
+		},
+		{
+			t1: STag{
+				Key:   "a",
+				Value: NoValue,
+			},
+			t2: STag{
+				Key:   "a",
+				Value: AnyValue,
+			},
+			cmp: 1,
+		},
 	}
 	for _, c := range cases {
 		got := Compare(c.t1, c.t2)

--- a/pkg/util/tagutils/tagset_test.go
+++ b/pkg/util/tagutils/tagset_test.go
@@ -434,3 +434,144 @@ func TestTagset2MapString(t *testing.T) {
 		}
 	}
 }
+
+func TestTagSetAppend(t *testing.T) {
+	cases := []struct {
+		set1 TTagSet
+		set2 TTagSet
+		want TTagSet
+	}{
+		{
+			set1: TTagSet{
+				{
+					Key:   "a",
+					Value: "1",
+				},
+			},
+			set2: TTagSet{
+				{
+					Key:   "b",
+					Value: "2",
+				},
+			},
+			want: TTagSet{
+				{
+					Key:   "a",
+					Value: "1",
+				},
+				{
+					Key:   "b",
+					Value: "2",
+				},
+			},
+		},
+		{
+			set1: TTagSet{
+				{
+					Key:   "a",
+					Value: AnyValue,
+				},
+			},
+			set2: TTagSet{
+				{
+					Key:   "a",
+					Value: "1",
+				},
+				{
+					Key:   "b",
+					Value: "2",
+				},
+			},
+			want: TTagSet{
+				{
+					Key:   "a",
+					Value: AnyValue,
+				},
+				{
+					Key:   "b",
+					Value: "2",
+				},
+			},
+		},
+		{
+			set1: TTagSet{
+				{
+					Key:   "a",
+					Value: AnyValue,
+				},
+			},
+			set2: TTagSet{
+				{
+					Key:   "a",
+					Value: NoValue,
+				},
+				{
+					Key:   "b",
+					Value: "2",
+				},
+			},
+			want: TTagSet{
+				{
+					Key:   "b",
+					Value: "2",
+				},
+			},
+		},
+		{
+			set1: TTagSet{
+				{
+					Key:   "a",
+					Value: AnyValue,
+				},
+			},
+			set2: TTagSet{
+				{
+					Key:   "a",
+					Value: NoValue,
+				},
+			},
+			want: TTagSet{},
+		},
+		{
+			set1: TTagSet{
+				{
+					Key:   "a",
+					Value: AnyValue,
+				},
+			},
+			set2: TTagSet{},
+			want: TTagSet{
+				{
+					Key:   "a",
+					Value: AnyValue,
+				},
+			},
+		},
+		{
+			set1: TTagSet{
+				{
+					Key:   "a",
+					Value: AnyValue,
+				},
+			},
+			set2: TTagSet{
+				{
+					Key:   "a",
+					Value: AnyValue,
+				},
+			},
+			want: TTagSet{
+				{
+					Key:   "a",
+					Value: AnyValue,
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		got := c.set1.Append(c.set2...)
+		if jsonutils.Marshal(got).String() != jsonutils.Marshal(c.want).String() {
+			t.Errorf("got: %s want: %s", jsonutils.Marshal(got).String(), jsonutils.Marshal(c.want).String())
+		}
+	}
+}

--- a/pkg/util/tagutils/tagsetlist.go
+++ b/pkg/util/tagutils/tagsetlist.go
@@ -89,6 +89,34 @@ func (tsl TTagSetList) Append(t TTagSet) TTagSetList {
 	return ret
 }
 
+func (tsl TTagSetList) Intersect(t TTagSet) TTagSetList {
+	ret := TTagSetList{}
+	for i := 0; i < len(tsl); i++ {
+		ret = ret.Append(tsl[i].Append(t...))
+	}
+	return ret
+}
+
+func (tsl TTagSetList) IntersectList(t TTagSetList) TTagSetList {
+	if len(tsl) == 0 && len(t) == 0 {
+		return TTagSetList{}
+	}
+	if len(tsl) == 0 && len(t) > 0 {
+		return t
+	}
+	if len(tsl) > 0 && len(t) == 0 {
+		return tsl
+	}
+	ret := TTagSetList{}
+	for i := 0; i < len(t); i++ {
+		tmp := tsl.Intersect(t[i])
+		for j := 0; j < len(tmp); j++ {
+			ret = ret.Append(tmp[j])
+		}
+	}
+	return ret
+}
+
 func (tsl TTagSetList) String() string {
 	tss := make([]string, len(tsl))
 	for i := 0; i < len(tss); i++ {

--- a/pkg/util/tagutils/tagsetlist_test.go
+++ b/pkg/util/tagutils/tagsetlist_test.go
@@ -292,3 +292,138 @@ func TestTTagSetList_Flattern(t *testing.T) {
 		}
 	}
 }
+
+func TestIntersect(t *testing.T) {
+	cases := []struct {
+		tsl  TTagSetList
+		ts   TTagSet
+		want TTagSetList
+	}{
+		{
+			tsl: TTagSetList{
+				TTagSet{
+					{
+						Key:   "a",
+						Value: "1",
+					},
+				},
+			},
+			ts: TTagSet{
+				{
+					Key:   "b",
+					Value: "2",
+				},
+			},
+			want: TTagSetList{
+				TTagSet{
+					{
+						Key:   "a",
+						Value: "1",
+					},
+					{
+						Key:   "b",
+						Value: "2",
+					},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		got := c.tsl.Intersect(c.ts)
+		if jsonutils.Marshal(got).String() != jsonutils.Marshal(c.want).String() {
+			t.Errorf("got %s want %s", jsonutils.Marshal(got).String(), jsonutils.Marshal(c.want).String())
+		}
+	}
+}
+
+func TestIntersects(t *testing.T) {
+	cases := []struct {
+		tsl  TTagSetList
+		ts2  TTagSetList
+		want TTagSetList
+	}{
+		{
+			tsl: TTagSetList{
+				TTagSet{
+					{
+						Key:   "a",
+						Value: "1",
+					},
+				},
+				TTagSet{
+					{
+						Key:   "b",
+						Value: "1",
+					},
+				},
+			},
+			ts2: TTagSetList{
+				TTagSet{
+					{
+						Key:   "c",
+						Value: "2",
+					},
+				},
+			},
+			want: TTagSetList{
+				TTagSet{
+					{
+						Key:   "a",
+						Value: "1",
+					},
+					{
+						Key:   "c",
+						Value: "2",
+					},
+				},
+				TTagSet{
+					{
+						Key:   "b",
+						Value: "1",
+					},
+					{
+						Key:   "c",
+						Value: "2",
+					},
+				},
+			},
+		},
+		{
+			tsl: TTagSetList{
+				TTagSet{
+					{
+						Key:   "a",
+						Value: "1",
+					},
+				},
+				TTagSet{
+					{
+						Key:   "b",
+						Value: "1",
+					},
+				},
+			},
+			ts2: TTagSetList{},
+			want: TTagSetList{
+				TTagSet{
+					{
+						Key:   "a",
+						Value: "1",
+					},
+				},
+				TTagSet{
+					{
+						Key:   "b",
+						Value: "1",
+					},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		got := c.tsl.IntersectList(c.ts2)
+		if jsonutils.Marshal(got).String() != jsonutils.Marshal(c.want).String() {
+			t.Errorf("got %s want %s", jsonutils.Marshal(got).String(), jsonutils.Marshal(c.want).String())
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: usage filter by policy tags revisit2
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 