### PR TITLE
Automated cherry pick of #15976: fix(region): esxi to kvm clean sched desc disk.storage

### DIFF
--- a/pkg/compute/tasks/guest_convert_esxi_to_kvm_task.go
+++ b/pkg/compute/tasks/guest_convert_esxi_to_kvm_task.go
@@ -54,6 +54,7 @@ func (self *GuestConvertEsxiToKvmTask) GetSchedParams() (*schedapi.ScheduleInput
 	for i := range schedDesc.Disks {
 		schedDesc.Disks[i].Backend = ""
 		schedDesc.Disks[i].Medium = ""
+		schedDesc.Disks[i].Storage = ""
 	}
 	schedDesc.Hypervisor = api.HYPERVISOR_KVM
 	return schedDesc, nil


### PR DESCRIPTION
Cherry pick of #15976 on release/3.9.

#15976: fix(region): esxi to kvm clean sched desc disk.storage