### PR TITLE
Automated cherry pick of #16028: fix: ovn options missing eip and brmapped

### DIFF
--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -154,13 +154,6 @@ type SHostOptions struct {
 	SdnAllowConntrackInvalid bool `help:"allow packets marked by conntrack as INVALID to pass" default:"$SDN_ALLOW_CONNTRACK_INVALID|false"`
 
 	ovnutils.SOvnOptions
-	/* OvnSouthDatabase          string `help:"address for accessing ovn south database" default:"$HOST_OVN_SOUTH_DATABASE|unix:/var/run/openvswitch/ovnsb_db.sock"`
-	OvnEncapIpDetectionMethod string `help:"detection method for ovn_encap_ip" default:"$HOST_OVN_ENCAP_IP_DETECTION_METHOD"`
-	OvnEncapIp                string `help:"encap ip for ovn datapath.  Default to src address of default route" default:"$HOST_OVN_ENCAP_IP"`
-	OvnIntegrationBridge      string `help:"name of integration bridge for logical ports" default:"$HOST_OVN_INTEGRATION_BRIDGE|brvpc"`
-	OvnMappedBridge           string `help:"name of bridge for mapped traffic management" default:"$HOST_OVN_MAPPED_BRIDGE|brmapped"`
-	OvnEipBridge              string `help:"name of bridge for eip traffic management" default:"$HOST_OVN_EIP_BRIDGE|breip"`
-	OvnUnderlayMtu            int    `help:"mtu of ovn underlay network" default:"1500"` */
 
 	// EnableRemoteExecutor bool `help:"Enable remote executor" default:"false"`
 	HostHealthTimeout int `help:"host health timeout" default:"30"`

--- a/pkg/util/ovnutils/options.go
+++ b/pkg/util/ovnutils/options.go
@@ -20,4 +20,6 @@ type SOvnOptions struct {
 	OvnEncapIpDetectionMethod string `help:"detection method for ovn_encap_ip" default:"$HOST_OVN_ENCAP_IP_DETECTION_METHOD"`
 	OvnEncapIp                string `help:"encap ip for ovn datapath.  Default to src address of default route" default:"$HOST_OVN_ENCAP_IP"`
 	OvnUnderlayMtu            int    `help:"mtu of ovn underlay network" default:"1500"`
+	OvnMappedBridge           string `help:"name of bridge for mapped traffic management" default:"$HOST_OVN_MAPPED_BRIDGE|brmapped"`
+	OvnEipBridge              string `help:"name of bridge for eip traffic management" default:"$HOST_OVN_EIP_BRIDGE|breip"`
 }


### PR DESCRIPTION
Cherry pick of #16028 on release/3.10.

#16028: fix: ovn options missing eip and brmapped