### PR TITLE
fix: allow add esxi as onecloud lb backend

### DIFF
--- a/pkg/compute/models/loadbalancerbackends.go
+++ b/pkg/compute/models/loadbalancerbackends.go
@@ -306,7 +306,12 @@ func (man *SLoadbalancerBackendManager) ValidateCreateData(ctx context.Context, 
 			return nil, httperrors.NewInputParameterError("region of host %q (%s) != region of loadbalancer %q (%s))",
 				host.Name, host.ZoneId, lb.Name, lb.ZoneId)
 		}
-		if host.ManagerId != lb.ManagerId {
+		if len(lb.ManagerId) == 0 {
+			if !utils.IsInStringArray(host.HostType, []string{api.HOST_TYPE_HYPERVISOR, api.HOST_TYPE_ESXI}) {
+				return nil, httperrors.NewInputParameterError("host type of host %q (%s) should be either hypervisor or esxi",
+					host.Name, host.HostType)
+			}
+		} else if host.ManagerId != lb.ManagerId {
 			return nil, httperrors.NewInputParameterError("manager of host %q (%s) != manager of loadbalancer %q (%s))",
 				host.Name, host.ManagerId, lb.Name, lb.ManagerId)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allow add esxi as onecloud lb backend

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 