### PR TITLE
fix(host): start daemon guest on guest not running

### DIFF
--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -607,7 +607,7 @@ func (s *SKVMGuestInstance) ImportServer(pendingDelete bool) {
 	s.manager.SaveServer(s.Id, s)
 	s.manager.RemoveCandidateServer(s)
 
-	if (s.IsDirtyShotdown() || s.IsDaemon()) && !pendingDelete {
+	if s.IsDirtyShotdown() && !pendingDelete {
 		log.Infof("Server dirty shutdown or a daemon %s", s.GetName())
 
 		if s.Desc.IsMaster || s.Desc.IsSlave ||
@@ -623,6 +623,8 @@ func (s *SKVMGuestInstance) ImportServer(pendingDelete bool) {
 		if !pendingDelete {
 			s.StartMonitor(context.Background(), nil)
 		}
+	} else if s.IsDaemon() {
+		s.StartGuest(context.Background(), nil, jsonutils.NewDict())
 	} else {
 		var action = "stopped"
 		if s.IsSuspend() {


### PR DESCRIPTION
Check guest status on Start daemon server.
StartGuest on guest status running will restart guest.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
