### PR TITLE
Automated cherry pick of #16155: fix(host): tls live migrate disable mulitfd

### DIFF
--- a/pkg/hostman/guestman/guesttasks.go
+++ b/pkg/hostman/guestman/guesttasks.go
@@ -739,6 +739,11 @@ func (s *SGuestLiveMigrateTask) onSetAutoConverge(res string) {
 		}
 		s.startMigrate()
 	}
+	if s.params.EnableTLS {
+		s.Monitor.MigrateSetCapability("multifd", "off", cb)
+		return
+	}
+
 	log.Infof("migrate src guest enable multifd")
 	s.Monitor.MigrateSetCapability("multifd", "on", cb)
 }

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -885,7 +885,7 @@ func (s *SKVMGuestInstance) setDestMigrateTLS(ctx context.Context, data *jsonuti
 }
 
 func (s *SKVMGuestInstance) migrateEnableMultifd() error {
-	if version.LT(s.QemuVersion, "4.0.0") {
+	if version.LT(s.QemuVersion, "4.0.0") || jsonutils.QueryBoolean(s.Desc, "live_migrate_use_tls", false) {
 		return nil
 	}
 	var err = make(chan error)


### PR DESCRIPTION
Cherry pick of #16155 on release/3.9.

#16155: fix(host): tls live migrate disable mulitfd