### PR TITLE
fix: disable multifd when enable tls migration

### DIFF
--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -989,6 +989,8 @@ func (s *SKVMGuestInstance) setDestMigrateTLS(ctx context.Context, data *jsonuti
 }
 
 func (s *SKVMGuestInstance) migrateEnableMultifd() error {
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1899442
+	// Migration fails if both multifd and tls are enabled
 	if version.LT(s.QemuVersion, "4.0.0") || s.LiveMigrateUseTls {
 		return nil
 	}

--- a/pkg/hostman/storageman/core.go
+++ b/pkg/hostman/storageman/core.go
@@ -357,7 +357,12 @@ func cleanDailyFiles(storagePath, subDir string, keepDay int) {
 			subDirPath := path.Join(recycleDir, file.Name())
 			if options.HostOptions.ZeroCleanDiskData {
 				// try to zero clean files in subdir
-				zeroclean.ZeroDir(subDirPath)
+				err := zeroclean.ZeroDir(subDirPath)
+				if err != nil {
+					log.Errorf("zeroclean disk %s fail %s", subDirPath, err)
+				} else {
+					log.Debugf("zeroclean disk %s success!", subDirPath)
+				}
 			}
 			if output, err := procutils.NewCommand("rm", "-rf", subDirPath).Output(); err != nil {
 				log.Errorf("clean recycle dir %s error: %s, %s", subDirPath, err, output)

--- a/pkg/hostman/storageman/storage_local.go
+++ b/pkg/hostman/storageman/storage_local.go
@@ -339,7 +339,12 @@ func (s *SLocalStorage) deleteBackendFile(diskpath string, skipRecycle bool) err
 		log.Infof("Delete disk file %s immediately", backendPath)
 		if options.HostOptions.ZeroCleanDiskData {
 			// try to zero clean files in subdir
-			zeroclean.ZeroDir(backendPath)
+			err := zeroclean.ZeroDir(backendPath)
+			if err != nil {
+				log.Errorf("zeroclean disk %s fail %s", backendPath, err)
+			} else {
+				log.Debugf("zeroclean disk %s success!", backendPath)
+			}
 		}
 		return procutils.NewCommand("rm", "-rf", backendPath).Run()
 	}
@@ -368,7 +373,12 @@ func (s *SLocalStorage) DeleteDiskfile(diskpath string, skipRecycle bool) error 
 		log.Infof("Delete disk file %s immediately", diskpath)
 		if options.HostOptions.ZeroCleanDiskData {
 			// try to zero clean files in subdir
-			zeroclean.ZeroDir(diskpath)
+			err := zeroclean.ZeroDir(diskpath)
+			if err != nil {
+				log.Errorf("zeroclean disk %s fail %s", diskpath, err)
+			} else {
+				log.Debugf("zeroclean disk %s success!", diskpath)
+			}
 		}
 		return procutils.NewCommand("rm", "-rf", diskpath).Run()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: disable multifd when enable tls migration

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi 