### PR TITLE
fix(scheduler): storage failed reason isn't showed in forecast result

### DIFF
--- a/pkg/scheduler/algorithm/predicates/guest/storage_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/guest/storage_predicate.go
@@ -272,12 +272,12 @@ func (p *StoragePredicate) Execute(ctx context.Context, u *core.Unit, c core.Can
 			req, err := sizeRequest.Get(be, medium)
 			if err != nil {
 				h.Exclude(fmt.Sprintf("get request size by backend %q, medium %q: %v", be, medium, err))
-				break
+				return h.GetResult()
 			}
 			capacity, actualCapacity, err := getStorageCapacity(be, medium, req.GetMax(), req.GetTotal(), useRsvd)
 			if err != nil {
 				h.Exclude(err.Error())
-				continue
+				return h.GetResult()
 			}
 			tmpCap := utils.Min(capacity.capacity, actualCapacity.capacity)
 			if capacity.capacity <= 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.9
/area scheduler
/close #16174