### PR TITLE
Automated cherry pick of #16177: fix(scheduler): storage failed reason isn't showed in forecast result

### DIFF
--- a/pkg/scheduler/algorithm/predicates/guest/storage_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/guest/storage_predicate.go
@@ -272,12 +272,12 @@ func (p *StoragePredicate) Execute(ctx context.Context, u *core.Unit, c core.Can
 			req, err := sizeRequest.Get(be, medium)
 			if err != nil {
 				h.Exclude(fmt.Sprintf("get request size by backend %q, medium %q: %v", be, medium, err))
-				break
+				return h.GetResult()
 			}
 			capacity, actualCapacity, err := getStorageCapacity(be, medium, req.GetMax(), req.GetTotal(), useRsvd)
 			if err != nil {
 				h.Exclude(err.Error())
-				continue
+				return h.GetResult()
 			}
 			tmpCap := utils.Min(capacity.capacity, actualCapacity.capacity)
 			if capacity.capacity <= 0 {


### PR DESCRIPTION
Cherry pick of #16177 on release/3.9.

#16177: fix(scheduler): storage failed reason isn't showed in forecast result