### PR TITLE
fix: storecli missing lv device name

### DIFF
--- a/pkg/baremetal/utils/raid/megactl/storcli.go
+++ b/pkg/baremetal/utils/raid/megactl/storcli.go
@@ -275,6 +275,8 @@ type StorcliLogicalVolume struct {
 	PDs []*StorcliLogicalVolumePD
 	// Properties
 	Properties *StorcliLogicalVolumeProperties
+	// index
+	Index int
 }
 
 func (lvs *StorcliLogicalVolumes) GetLogicalVolumes(controller int) ([]*StorcliLogicalVolume, error) {
@@ -308,6 +310,7 @@ func (lvs *StorcliLogicalVolumes) GetLogicalVolumes(controller int) ([]*StorcliL
 			return nil, errors.Wrapf(err, "Unmarshal %s to StorcliLogicalVolume", lvObj)
 		}
 		lv := lvArr[0]
+		lv.Index = vIdx
 		lv.Name = keyIdx
 		pdObj, err := data.Get(pdKey)
 		if err != nil {
@@ -348,7 +351,12 @@ func (lv *StorcliLogicalVolume) IsSSD() bool {
 }
 
 func (lv *StorcliLogicalVolume) GetOSDevice() string {
-	return lv.Properties.DeviceName
+	dev := lv.Properties.DeviceName
+	if len(dev) == 0 {
+		// try to guest device name
+		dev = fmt.Sprintf("sd%c", 'a'+lv.Index)
+	}
+	return dev
 }
 
 func (lv *StorcliLogicalVolume) GetSysBlockRotationalPath() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: storecli missing lv device name

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi 