### PR TITLE
fix(monitor): set wrong resType when query

### DIFF
--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -529,7 +529,8 @@ func (c *QueryCondition) setResType() {
 		resType = metricMeasurement.ResType
 		c.ResType = resType
 	}
-	if len(resType) != 0 && c.Query.Model.GroupBy[0].Params[0] != monitor.
+	// NOTE: shouldn't set ResType when tenant_id and domain_id within GroupBy
+	/* if len(resType) != 0 && c.Query.Model.GroupBy[0].Params[0] != monitor.
 		MEASUREMENT_TAG_ID[resType] {
 		for _, groupBy := range c.Query.Model.GroupBy {
 			tag := groupBy.Params[0]
@@ -542,7 +543,7 @@ func (c *QueryCondition) setResType() {
 				break
 			}
 		}
-	}
+	} */
 	if c.Query.Model.Database == monitor.METRIC_DATABASE_TELE {
 		c.ResType = resType
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.9
/area monitor
/cc @swordqiu 