### PR TITLE
fix(host): kvm detect and iommu probe

### DIFF
--- a/pkg/hostman/isolated_device/gpu.go
+++ b/pkg/hostman/isolated_device/gpu.go
@@ -32,6 +32,7 @@ import (
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 	"yunion.io/x/onecloud/pkg/util/regutils2"
+	"yunion.io/x/onecloud/pkg/util/sysutils"
 )
 
 const (
@@ -170,9 +171,11 @@ func (dev *sGPUBaseDevice) CustomProbe() error {
 	}
 	grubCmdline = strings.TrimSpace(grubCmdline)
 	params := sets.NewString(strings.Split(grubCmdline, " ")...)
-	if !params.IsSuperset(sets.NewString("intel_iommu=on",
-		"vfio_iommu_type1.allow_unsafe_interrupts=1")) {
-		return fmt.Errorf("Some GRUB_CMDLINE iommu parameters are missing")
+	if !params.IsSuperset(sets.NewString("vfio_iommu_type1.allow_unsafe_interrupts=1")) {
+		return fmt.Errorf("GRUB_CMDLINE iommu parameters vfio_iommu_type1.allow_unsafe_interrupts=1 missing")
+	}
+	if sysutils.IsProcessorIntel() && !params.IsSuperset(sets.NewString("intel_iommu=on")) {
+		return fmt.Errorf("GRUB_CMDLINE iommu parameters intel_iommu=on missing")
 	}
 	isNouveauBlacklisted := false
 	if params.IsSuperset(sets.NewString("rdblacklist=nouveau", "nouveau.modeset=0")) ||

--- a/pkg/util/sysutils/kvm.go
+++ b/pkg/util/sysutils/kvm.go
@@ -82,18 +82,30 @@ func isDevKVMExists() bool {
 
 func detectKVMModuleSupport() string {
 	var km = KVM_MODULE_UNSUPPORT
-	if ModprobeKvmModule(KVM_MODULE_INTEL, false, false) {
-		km = KVM_MODULE_INTEL
-	} else if ModprobeKvmModule(KVM_MODULE_AMD, false, false) {
-		km = KVM_MODULE_AMD
-	} else if ModprobeKvmModule(KVM_MODULE, false, false) {
-		if isDevKVMExists() {
+	if isDevKVMExists() {
+		if IsKernelModuleLoaded(KVM_MODULE_INTEL) {
+			km = KVM_MODULE_INTEL
+		} else if IsKernelModuleLoaded(KVM_MODULE_AMD) {
+			km = KVM_MODULE_AMD
+		} else if IsKernelModuleLoaded(KVM_MODULE) {
 			km = KVM_MODULE
-		}
-	}
-	if km == KVM_MODULE_UNSUPPORT {
-		if isDevKVMExists() {
+		} else {
 			km = KVM_MODULE_BUILDIN
+		}
+	} else {
+		if ModprobeKvmModule(KVM_MODULE_INTEL, false, false) {
+			km = KVM_MODULE_INTEL
+		} else if ModprobeKvmModule(KVM_MODULE_AMD, false, false) {
+			km = KVM_MODULE_AMD
+		} else if ModprobeKvmModule(KVM_MODULE, false, false) {
+			if isDevKVMExists() {
+				km = KVM_MODULE
+			}
+		}
+		if km == KVM_MODULE_UNSUPPORT {
+			if isDevKVMExists() {
+				km = KVM_MODULE_BUILDIN
+			}
 		}
 	}
 	return km


### PR DESCRIPTION
- use lsmod check kvm modules on /dev/kvm exist
- don't check grub params "intel_iommu=on" on kvm_intel not loaded

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.9
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
