### PR TITLE
fix(region): not sync update netinterface wire_id when merge wires at

### DIFF
--- a/pkg/compute/models/wire_id_change_handler.go
+++ b/pkg/compute/models/wire_id_change_handler.go
@@ -88,3 +88,22 @@ func (manager *SNetworkManager) handleWireIdChange(ctx context.Context, args *wi
 	}
 	return nil
 }
+
+func (manager *SNetInterfaceManager) handleWireIdChange(ctx context.Context, args *wireIdChangeArgs) error {
+	ns := make([]SNetInterface, 0, 8)
+	err := db.FetchModelObjects(manager, manager.Query().Equals("wire_id", args.oldWire.Id), &ns)
+	if err != nil {
+		return err
+	}
+	for i := range ns {
+		n := &ns[i]
+		_, err := db.Update(n, func() error {
+			n.WireId = args.newWire.Id
+			return nil
+		})
+		if err != nil {
+			return errors.Wrapf(err, "unable to update network %q", n.GetId())
+		}
+	}
+	return nil
+}

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -1265,6 +1265,7 @@ func (wm *SWireManager) handleWireIdChange(ctx context.Context, args *wireIdChan
 		HostwireManager,
 		NetworkManager,
 		LoadbalancerClusterManager,
+		NetInterfaceManager,
 	}
 
 	errs := []error{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Hotfix/qj merge wire not sync update netinterface 3.9

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 