### PR TITLE
Automated cherry pick of #16258: fix(vpcagent): import ovn package in vpcagent service.go

### DIFF
--- a/cmd/vpcagent/main.go
+++ b/cmd/vpcagent/main.go
@@ -19,7 +19,6 @@ import (
 
 	"yunion.io/x/onecloud/pkg/util/atexit"
 	"yunion.io/x/onecloud/pkg/util/procutils"
-	_ "yunion.io/x/onecloud/pkg/vpcagent/ovn"
 	"yunion.io/x/onecloud/pkg/vpcagent/service"
 )
 

--- a/pkg/vpcagent/service/service.go
+++ b/pkg/vpcagent/service/service.go
@@ -31,6 +31,7 @@ import (
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/vpcagent/options"
+	_ "yunion.io/x/onecloud/pkg/vpcagent/ovn"
 	"yunion.io/x/onecloud/pkg/vpcagent/worker"
 )
 


### PR DESCRIPTION
Cherry pick of #16258 on release/3.10.

#16258: fix(vpcagent): import ovn package in vpcagent service.go