### PR TITLE
Automated cherry pick of #16315: fix(keystone): add kubeserver running_mode option to blacklist

### DIFF
--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -227,6 +227,11 @@ var (
 			"deploy_server_socket_path",
 			"enable_remote_executor",
 			"executor_socket_path",
+
+			// ############################
+			// kubeserver blacklist options
+			// ############################
+			"running_mode",
 		},
 	}
 )


### PR DESCRIPTION
Cherry pick of #16315 on master.

#16315: fix(keystone): add kubeserver running_mode option to blacklist