### PR TITLE
Automated cherry pick of #16358: fix(baremetal): panic occured when using SSD as raid PD

### DIFF
--- a/pkg/baremetal/utils/disktool/disktool.go
+++ b/pkg/baremetal/utils/disktool/disktool.go
@@ -651,6 +651,11 @@ func (tool *PartitionTool) parseLsDisk(lines []string, driver string) {
 						break
 					}
 				}
+				if remoteDisk == nil {
+					// not found ssd disk
+					remoteDisk = disks[i-raidSsdDiskCnt]
+					log.Warningf("not found ssd driver disk for %#v, using remote disk %#v", driverDisk, remoteDisk)
+				}
 				driverDisk.SetInfo(remoteDisk)
 			} else {
 				driverDisk.SetInfo(disks[i-raidSsdDiskCnt])


### PR DESCRIPTION
Cherry pick of #16358 on master.

#16358: fix(baremetal): panic occured when using SSD as raid PD