### PR TITLE
fix: auth getStats should ignore no permission error

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -238,11 +238,13 @@ func getStatsInfo(ctx context.Context, req *http.Request) (jsonutils.JSONObject,
 	}{}
 
 	accounts, err := compute_modules.Cloudaccounts.List(s, params)
-	if err != nil {
+	if err != nil && httputils.ErrorCode(err) != 403 {
 		return nil, err
 	}
 
-	ret.Cloudaccounts = accounts.Total
+	if accounts != nil {
+		ret.Cloudaccounts = accounts.Total
+	}
 
 	return jsonutils.Marshal(ret), nil
 }
@@ -250,7 +252,7 @@ func getStatsInfo(ctx context.Context, req *http.Request) (jsonutils.JSONObject,
 func (h *AuthHandlers) getStats(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 	data, err := getStatsInfo(ctx, req)
 	if err != nil {
-		httperrors.NotFoundError(ctx, w, err.Error())
+		httperrors.GeneralServerError(ctx, w, err)
 		return
 	}
 	body := jsonutils.NewDict()


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: auth getStats should ignore no permission error

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 