### PR TITLE
Automated cherry pick of #16907: fix: auth getStats should ignore no permission error

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -237,11 +237,13 @@ func getStatsInfo(ctx context.Context, req *http.Request) (jsonutils.JSONObject,
 	}{}
 
 	accounts, err := compute_modules.Cloudaccounts.List(s, params)
-	if err != nil {
+	if err != nil && httputils.ErrorCode(err) != 403 {
 		return nil, err
 	}
 
-	ret.Cloudaccounts = accounts.Total
+	if accounts != nil {
+		ret.Cloudaccounts = accounts.Total
+	}
 
 	return jsonutils.Marshal(ret), nil
 }
@@ -249,7 +251,7 @@ func getStatsInfo(ctx context.Context, req *http.Request) (jsonutils.JSONObject,
 func (h *AuthHandlers) getStats(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 	data, err := getStatsInfo(ctx, req)
 	if err != nil {
-		httperrors.NotFoundError(ctx, w, err.Error())
+		httperrors.GeneralServerError(ctx, w, err)
 		return
 	}
 	body := jsonutils.NewDict()


### PR DESCRIPTION
Cherry pick of #16907 on release/3.9.

#16907: fix: auth getStats should ignore no permission error