### PR TITLE
Automated cherry pick of #16957: fix(host): don't return error on disk snap chain params miss

### DIFF
--- a/pkg/hostman/guestman/guesthandlers/guesthandler.go
+++ b/pkg/hostman/guestman/guesthandlers/guesthandler.go
@@ -385,7 +385,7 @@ func guestDestPrepareMigrateInternal(ctx context.Context, userCred mcclient.Toke
 		}
 		diskSnapsChain, err := body.Get("disk_snaps_chain")
 		if err != nil {
-			return httperrors.NewMissingParameterError("disk_snaps_chain")
+			params.DiskSnapsChain = jsonutils.NewDict()
 		} else {
 			params.DiskSnapsChain = diskSnapsChain
 		}


### PR DESCRIPTION
Cherry pick of #16957 on release/3.10.

#16957: fix(host): don't return error on disk snap chain params miss