### PR TITLE
fix(host): guest name has space

### DIFF
--- a/pkg/hostman/guestman/qemu/qemu.go
+++ b/pkg/hostman/guestman/qemu/qemu.go
@@ -224,7 +224,7 @@ func (o baseOptions) KeyboardLayoutLanguage(lang string) string {
 }
 
 func (o baseOptions) Name(name string) string {
-	return fmt.Sprintf(`-name '%s',debug-threads=on`, name)
+	return fmt.Sprintf(`-name '%s',debug-threads=on`, strings.ReplaceAll(name, " ", "_"))
 }
 
 func (o baseOptions) UUID(enable bool, uuid string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
release/3.10   use startvm.py cause space can't pass to qemu cmdline
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
