### PR TITLE
Automated cherry pick of #17016: fix(host): guest name has space

### DIFF
--- a/pkg/hostman/guestman/qemu/qemu.go
+++ b/pkg/hostman/guestman/qemu/qemu.go
@@ -224,7 +224,7 @@ func (o baseOptions) KeyboardLayoutLanguage(lang string) string {
 }
 
 func (o baseOptions) Name(name string) string {
-	return fmt.Sprintf(`-name '%s',debug-threads=on`, name)
+	return fmt.Sprintf(`-name '%s',debug-threads=on`, strings.ReplaceAll(name, " ", "_"))
 }
 
 func (o baseOptions) UUID(enable bool, uuid string) string {


### PR DESCRIPTION
Cherry pick of #17016 on release/3.10.

#17016: fix(host): guest name has space