### PR TITLE
fix(host): guest sync update cdrom bootindex

### DIFF
--- a/pkg/hostman/guestman/guesttasks.go
+++ b/pkg/hostman/guestman/guesttasks.go
@@ -303,6 +303,7 @@ func (d *SGuestDiskSyncTask) OnEjectCdromContentSucc(cdName string) {
 	for i, cdrom := range d.guest.Desc.Cdroms {
 		if cdrom.Id == cdName {
 			d.guest.Desc.Cdroms[i].Path = ""
+			d.guest.Desc.Cdroms[i].BootIndex = nil
 		}
 	}
 	d.syncDisksConf()

--- a/pkg/hostman/guestman/qemu/generate.go
+++ b/pkg/hostman/guestman/qemu/generate.go
@@ -344,8 +344,10 @@ func generateCdromOptions(optDrv QemuOptions, cdroms []*desc.SGuestCdrom) []stri
 			opts = append(opts, optDrv.Drive(driveOpt))
 			devOpt := fmt.Sprintf("%s,drive=%s,bus=ide.1",
 				cdrom.Ide.DevType, cdrom.Id)
-			if cdrom.BootIndex != nil && *cdrom.BootIndex >= 0 {
-				devOpt += fmt.Sprintf(",bootindex=%d", *cdrom.BootIndex)
+			if len(cdromPath) > 0 {
+				if cdrom.BootIndex != nil && *cdrom.BootIndex >= 0 {
+					devOpt += fmt.Sprintf(",bootindex=%d", *cdrom.BootIndex)
+				}
 			}
 			// TODO: ,bus=ide.%d,unit=%d
 			//, cdrom.Ide.Bus, cdrom.Ide.Unit)
@@ -356,8 +358,10 @@ func generateCdromOptions(optDrv QemuOptions, cdroms []*desc.SGuestCdrom) []stri
 
 				devOpt := fmt.Sprintf("%s,drive=%s", cdrom.Scsi.DevType, cdrom.Id)
 				devOpt += desc.OptionsToString(cdrom.Scsi.Options)
-				if cdrom.BootIndex != nil && *cdrom.BootIndex >= 0 {
-					devOpt += fmt.Sprintf(",bootindex=%d", *cdrom.BootIndex)
+				if len(cdromPath) > 0 {
+					if cdrom.BootIndex != nil && *cdrom.BootIndex >= 0 {
+						devOpt += fmt.Sprintf(",bootindex=%d", *cdrom.BootIndex)
+					}
 				}
 				opts = append(opts, optDrv.Device(devOpt))
 			}


### PR DESCRIPTION
generate qemu cmdline check cdrom path before generate bootindex params

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
