### PR TITLE
Automated cherry pick of #17066: fix: disable policy update when enable three member system

### DIFF
--- a/pkg/keystone/models/policies.go
+++ b/pkg/keystone/models/policies.go
@@ -686,12 +686,14 @@ func (policy *SPolicy) ValidateUpdateCondition(ctx context.Context) error {
 	//if policy.IsSystem.IsTrue() {
 	//	return errors.Wrap(httperrors.ErrForbidden, "system policy")
 	//}
-	rps, err := RolePolicyManager.fetchByPolicyId(policy.Id)
-	if err != nil {
-		return errors.Wrap(err, "fetchByPolicyId")
-	}
-	if len(rps) > 0 {
-		return errors.Wrap(httperrors.ErrForbidden, "policy in use")
+	if options.Options.ThreeAdminRoleSystem {
+		rps, err := RolePolicyManager.fetchByPolicyId(policy.Id)
+		if err != nil {
+			return errors.Wrap(err, "fetchByPolicyId")
+		}
+		if len(rps) > 0 {
+			return errors.Wrap(httperrors.ErrForbidden, "policy in use")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #17066 on release/3.9.

#17066: fix: disable policy update when enable three member system