### PR TITLE
Automated cherry pick of #17101: fix(host): pciroot not assigned in switch case

### DIFF
--- a/pkg/hostman/guestman/guesttasks.go
+++ b/pkg/hostman/guestman/guesttasks.go
@@ -490,7 +490,7 @@ func (d *SGuestDiskSyncTask) startAddDisk(disk *desc.SGuestDisk) {
 	case DISK_DRIVER_SCSI:
 		bus = "scsi.0"
 	case DISK_DRIVER_VIRTIO:
-		pciRoot := d.guest.getHotPlugPciController()
+		pciRoot = d.guest.getHotPlugPciController()
 		if pciRoot == nil {
 			log.Errorf("no hotplugable pci controller found")
 			d.errors = append(d.errors, errors.Errorf("no hotplugable pci controller found"))


### PR DESCRIPTION
Cherry pick of #17101 on release/3.10.

#17101: fix(host): pciroot not assigned in switch case