### PR TITLE
fix(baremetal): skip running sysinit.sh when arch is aarch64

### DIFF
--- a/pkg/baremetal/tasks/baseprepare.go
+++ b/pkg/baremetal/tasks/baseprepare.go
@@ -75,14 +75,17 @@ func (task *sBaremetalPrepareTask) GetStartTime() time.Time {
 }
 
 func (task *sBaremetalPrepareTask) prepareBaremetalInfo(cli *ssh.Client) (*baremetalPrepareInfo, error) {
-	_, err := cli.Run("/lib/mos/sysinit.sh")
-	if err != nil {
-		return nil, err
-	}
-
 	arch, err := getArchitecture(cli)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "getArchitecture")
+	}
+
+	if arch == apis.OS_ARCH_X86_64 {
+		if _, err := cli.Run("/lib/mos/sysinit.sh"); err != nil {
+			return nil, errors.Wrap(err, "run /lib/mos/sysinit.sh")
+		}
+	} else {
+		log.Infof("Skip running /lib/mos/sysinit.sh when arch is %q", arch)
 	}
 
 	sysInfo, err := getDMISysinfo(cli)


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- 3.9
/area baremetal
/cc @swordqiu 
