### PR TITLE
Automated cherry pick of #17116: fix: lbagent fail to start due to empty prioty and interface

### DIFF
--- a/pkg/util/ovnutils/ovnutils.go
+++ b/pkg/util/ovnutils/ovnutils.go
@@ -17,6 +17,7 @@ package ovnutils
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -121,9 +122,11 @@ func mustPrepService() {
 func InitOvn(opts SOvnOptions) (err error) {
 	defer func() {
 		if panicVal := recover(); panicVal != nil {
+			debug.PrintStack()
 			err = panicVal.(error)
 		}
 	}()
+	system_service.Init()
 	mustPrepOvsdbConfig(opts)
 	configBridgeMtu(opts)
 	if _, ok := ovnContainerImageTag(); !ok {


### PR DESCRIPTION
Cherry pick of #17116 on release/3.10.

#17116: fix: lbagent fail to start due to empty prioty and interface