### PR TITLE
fix(region): add CloudKubeClusterId option in KubeNodePoolListInput

### DIFF
--- a/pkg/apis/compute/kube_node_pools.go
+++ b/pkg/apis/compute/kube_node_pools.go
@@ -22,6 +22,8 @@ type KubeNodePoolListInput struct {
 
 	RegionalFilterListInput
 	ManagedResourceListInput
+
+	CloudKubeClusterId string `json:"cloud_kube_cluster_id"`
 }
 
 type KubeNodePoolCreateInput struct {

--- a/pkg/compute/models/kube_node_pools.go
+++ b/pkg/compute/models/kube_node_pools.go
@@ -240,6 +240,9 @@ func (manager *SKubeNodePoolManager) ListItemFilter(
 	if err != nil {
 		return nil, errors.Wrap(err, "SStatusStandaloneResourceBaseManager.ListItemFilter")
 	}
+	if query.CloudKubeClusterId != "" {
+		q = q.Equals("cloud_kube_cluster_id", query.CloudKubeClusterId)
+	}
 	return q, nil
 }
 

--- a/pkg/mcclient/options/compute/kube_node_pool.go
+++ b/pkg/mcclient/options/compute/kube_node_pool.go
@@ -22,6 +22,7 @@ import (
 
 type KubeNodePoolListOptions struct {
 	options.BaseListOptions
+	CloudKubeClusterId string `json:"cloud_kube_cluster_id"`
 }
 
 func (opts *KubeNodePoolListOptions) Params() (jsonutils.JSONObject, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- master
/area region
/cc @ioito 