### PR TITLE
Automated cherry pick of #17144: feat(climc): support output yaml format

### DIFF
--- a/cmd/climc/entry/climc.go
+++ b/cmd/climc/entry/climc.go
@@ -72,7 +72,7 @@ type BaseOptions struct {
 	OsZoneName     string `default:"$OS_ZONE_NAME" help:"Defaults to env[OS_ZONE_NAME]"`
 	OsEndpointType string `default:"$OS_ENDPOINT_TYPE|internalURL" help:"Defaults to env[OS_ENDPOINT_TYPE] or internalURL" choices:"publicURL|internalURL|adminURL"`
 	// ApiVersion     string `default:"$API_VERSION" help:"override default modules service api version"`
-	OutputFormat string `default:"$CLIMC_OUTPUT_FORMAT|table" choices:"table|kv|json|flatten-table|flatten-kv" help:"output format"`
+	OutputFormat string `default:"$CLIMC_OUTPUT_FORMAT|table" choices:"table|kv|json|yaml|flatten-table|flatten-kv" help:"output format"`
 
 	ParallelRun int `help:"run in parallel to stess test the performance of server"`
 

--- a/cmd/climc/shell/utils.go
+++ b/cmd/climc/shell/utils.go
@@ -30,6 +30,7 @@ const (
 	OUTPUT_FORMAT_TABLE         = "table"         // pretty table
 	OUTPUT_FORMAT_FLATTEN_TABLE = "flatten-table" // pretty table with flattened keys
 	OUTPUT_FORMAT_JSON          = "json"          // json string
+	OUTPUT_FORMAT_YAML          = "yaml"          // yaml string
 	OUTPUT_FORMAT_KV            = "kv"            // "key: value" as separate line
 	OUTPUT_FORMAT_FLATTEN_KV    = "flatten-kv"    // kv with flattened keys
 )
@@ -47,6 +48,8 @@ func PrintList(list *printutils.ListResult, columns []string) {
 	case OUTPUT_FORMAT_JSON:
 		fmt.Print(jsonutils.Marshal(list).PrettyString())
 		fmt.Print("\n")
+	case OUTPUT_FORMAT_YAML:
+		fmt.Print(jsonutils.Marshal(list).YAMLString())
 	default:
 		fmt.Fprintf(os.Stderr, "unknown output format: %q\n", outputFormat)
 	}
@@ -61,6 +64,8 @@ func PrintObject(obj jsonutils.JSONObject) {
 	case OUTPUT_FORMAT_JSON:
 		fmt.Print(obj.PrettyString())
 		fmt.Print("\n")
+	case OUTPUT_FORMAT_YAML:
+		fmt.Print(obj.YAMLString())
 	case OUTPUT_FORMAT_FLATTEN_TABLE:
 		printObjectRecursive(obj)
 	case OUTPUT_FORMAT_FLATTEN_KV:


### PR DESCRIPTION
Cherry pick of #17144 on release/3.10.

#17144: feat(climc): support output yaml format