### PR TITLE
feat(climc): make cloud-provider-clirc supports output format

### DIFF
--- a/cmd/climc/shell/compute/cloudproviders.go
+++ b/cmd/climc/shell/compute/cloudproviders.go
@@ -26,6 +26,11 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient/options/compute"
 )
 
+type ClircShowOpt struct {
+	options.BaseIdOptions
+	FollowOutputFormat bool `help:"follow output format"`
+}
+
 func init() {
 	cmd := shell.NewResourceCmd(&modules.Cloudproviders).WithKeyword("cloud-provider")
 	cmd.List(&compute.CloudproviderListOptions{})
@@ -39,17 +44,21 @@ func init() {
 	cmd.Perform("project-mapping", &compute.ClouproviderProjectMappingOptions{})
 	cmd.Perform("set-syncing", &compute.ClouproviderSetSyncingOptions{})
 
-	cmd.GetWithCustomShow("clirc", func(result jsonutils.JSONObject) {
+	cmd.GetWithCustomOptionShow("clirc", func(result jsonutils.JSONObject, opt shell.IGetOpt) {
 		rc := make(map[string]string)
 		err := result.Unmarshal(&rc)
 		if err != nil {
-			log.Errorf("error: %v", err)
+			log.Errorf("Unmarshal error: %v", err)
 			return
 		}
-		for k, v := range rc {
-			fmt.Printf(`export %s='%s'`+"\n", k, v)
+		if opt.(*ClircShowOpt).FollowOutputFormat {
+			shell.PrintObject(result)
+		} else {
+			for k, v := range rc {
+				fmt.Printf(`export %s='%s'`+"\n", k, v)
+			}
 		}
-	}, &options.BaseIdOptions{})
+	}, &ClircShowOpt{})
 	cmd.Get("storage-classes", &compute.CloudproviderStorageClassesOptions{})
 	cmd.Get("change-owner-candidate-domains", &options.BaseIdOptions{})
 	cmd.Get("balance", &options.BaseIdOptions{})

--- a/cmd/climc/shell/helper.go
+++ b/cmd/climc/shell/helper.go
@@ -477,6 +477,12 @@ type IGetOpt interface {
 }
 
 func (cmd ResourceCmd) GetWithCustomShow(specific string, show func(data jsonutils.JSONObject), args IGetOpt) {
+	cmd.GetWithCustomOptionShow(specific, func(data jsonutils.JSONObject, _ IGetOpt) {
+		show(data)
+	}, args)
+}
+
+func (cmd ResourceCmd) GetWithCustomOptionShow(specific string, show func(data jsonutils.JSONObject, args IGetOpt), args IGetOpt) {
 	man := cmd.manager
 	callback := func(s *mcclient.ClientSession, args IGetOpt) error {
 		params, err := args.Params()
@@ -487,7 +493,7 @@ func (cmd ResourceCmd) GetWithCustomShow(specific string, show func(data jsonuti
 		if err != nil {
 			return err
 		}
-		show(ret)
+		show(ret, args)
 		return nil
 	}
 	cmd.RunWithDesc(specific, fmt.Sprintf("Get %s of a %s", specific, man.GetKeyword()), args, callback)


### PR DESCRIPTION
**What this PR does / why we need it**:

```bash
climc --output-format json cloud-provider-clirc xxx --follow-output-format
{
  "AWS_ACCESS_KEY": "xxxxxxxxxx",
  "AWS_ACCESS_URL": "InternationalCloud",
  "AWS_ACCOUNT_ID": "",
  "AWS_REGION": "us-west-1",
  "AWS_SECRET": "xxxxxxxxxxxxxx"
}

```

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- 3.10
/cc @swordqiu @ioito 
