### PR TITLE
Automated cherry pick of #17253: feat(climc): use raw name when query list length is 1

### DIFF
--- a/pkg/mcclient/options/base.go
+++ b/pkg/mcclient/options/base.go
@@ -141,10 +141,15 @@ func optionsStructRvToParams(rv reflect.Value) (*jsonutils.JSONDict, error) {
 			panic(msg)
 		case reflect.Slice, reflect.Array:
 			l := f.Len()
-			for i := 0; i < l; i++ {
-				namei := fmt.Sprintf("%s.%d", name, i)
-				vali := jsonutils.Marshal(f.Index(i).Interface())
-				p.Set(namei, vali)
+			if l == 1 {
+				vali := jsonutils.Marshal(f.Index(0).Interface())
+				p.Set(name, vali)
+			} else {
+				for i := 0; i < l; i++ {
+					namei := fmt.Sprintf("%s.%d", name, i)
+					vali := jsonutils.Marshal(f.Index(i).Interface())
+					p.Set(namei, vali)
+				}
 			}
 		default:
 			msg := fmt.Sprintf("unsupported field type %s: %s", ft.Name, ft.Type)

--- a/pkg/mcclient/options/base_test.go
+++ b/pkg/mcclient/options/base_test.go
@@ -177,7 +177,7 @@ func TestOptionsStructToParams(t *testing.T) {
 			},
 			{
 				In:   &s{[]string{"holy"}},
-				Want: `{"string_slice.0": "holy"}`,
+				Want: `{"string_slice": "holy"}`,
 			},
 			{
 				In:   &s{[]string{"holy", "goblet"}},
@@ -201,7 +201,7 @@ func TestOptionsStructToParams(t *testing.T) {
 			},
 			{
 				In:   &s{[]string{"holy"}},
-				Want: `{"string.0": "holy"}`,
+				Want: `{"string": "holy"}`,
 			},
 			{
 				In:   &s{[]string{"holy", "goblet"}},


### PR DESCRIPTION
Cherry pick of #17253 on release/3.9.

#17253: feat(climc): use raw name when query list length is 1