### PR TITLE
fix(region,host): virtio dirver local disk live migrate

### DIFF
--- a/pkg/compute/tasks/guest_live_migrate_task.go
+++ b/pkg/compute/tasks/guest_live_migrate_task.go
@@ -473,6 +473,11 @@ func (self *GuestLiveMigrateTask) OnStartDestComplete(ctx context.Context, guest
 		self.TaskFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("Get migrate port error: %s", err)))
 		return
 	}
+	nbdServerPort, err := data.Get("nbd_server_port")
+	if err != nil {
+		self.TaskFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("Get nbd server port error: %s", err)))
+		return
+	}
 
 	targetHostId, _ := self.Params.GetString("target_host_id")
 	targetHost := models.HostManager.FetchHostById(targetHostId)
@@ -481,6 +486,7 @@ func (self *GuestLiveMigrateTask) OnStartDestComplete(ctx context.Context, guest
 	isLocalStorage, _ := self.Params.Get("is_local_storage")
 	body.Set("is_local_storage", isLocalStorage)
 	body.Set("live_migrate_dest_port", liveMigrateDestPort)
+	body.Set("nbd_server_port", nbdServerPort)
 	body.Set("dest_ip", jsonutils.NewString(targetHost.AccessIp))
 	body.Set("enable_tls", jsonutils.NewBool(jsonutils.QueryBoolean(self.GetParams(), "enable_tls", false)))
 	body.Set("quickly_finish", jsonutils.NewBool(jsonutils.QueryBoolean(self.GetParams(), "quickly_finish", false)))

--- a/pkg/hostman/guestman/guesthandlers/guesthandler.go
+++ b/pkg/hostman/guestman/guesthandlers/guesthandler.go
@@ -443,6 +443,10 @@ func guestLiveMigrate(ctx context.Context, userCred mcclient.TokenCredential, si
 	if err != nil {
 		return nil, httperrors.NewMissingParameterError("live_migrate_dest_port")
 	}
+	nbdServerPort, err := body.Int("nbd_server_port")
+	if err != nil {
+		return nil, httperrors.NewMissingParameterError("live_migrate_dest_port")
+	}
 	destIp, err := body.GetString("dest_ip")
 	if err != nil {
 		return nil, httperrors.NewMissingParameterError("dest_ip")
@@ -456,6 +460,7 @@ func guestLiveMigrate(ctx context.Context, userCred mcclient.TokenCredential, si
 	params := &guestman.SLiveMigrate{
 		Sid:           sid,
 		DestPort:      int(destPort),
+		NbdServerPort: int(nbdServerPort),
 		DestIp:        destIp,
 		IsLocal:       isLocal,
 		EnableTLS:     enableTLS,

--- a/pkg/hostman/guestman/guesthelper.go
+++ b/pkg/hostman/guestman/guesthelper.go
@@ -77,6 +77,7 @@ type SDestPrepareMigrate struct {
 type SLiveMigrate struct {
 	Sid            string
 	DestPort       int
+	NbdServerPort  int
 	DestIp         string
 	IsLocal        bool
 	EnableTLS      bool

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -807,19 +807,39 @@ func (s *SKVMGuestInstance) onReceiveQMPEvent(event *monitor.Event) {
 		s.eventGuestStop()
 	case `"QUORUM_REPORT_BAD"`:
 		s.eventQuorumReportBad(event)
+	case `"MIGRATION"`:
+		s.eventMigration(event)
+	}
+}
+
+func (s *SKVMGuestInstance) eventMigration(event *monitor.Event) {
+	if s.MigrateTask == nil {
+		return
+	}
+
+	status, ok := event.Data["status"]
+	if !ok {
+		return
+	}
+	if status == "pre-switchover" {
+		// migrating complete
+		s.MigrateTask.onMigrateReceivedPreSwitchoverEvent()
+		hostutils.UpdateServerProgress(context.Background(), s.Id, 0.0, 0)
+	} else if status == "completed" {
+		s.MigrateTask.migrateComplete(nil)
 	}
 }
 
 func (s *SKVMGuestInstance) eventBlockJobError(event *monitor.Event) {
-	s.SyncMirrorJobFailed(event.String())
+	if s.MigrateTask != nil {
+		s.MigrateTask.onMigrateReceivedBlockJobError(event.String())
+	} else {
+		s.SyncMirrorJobFailed(event.String())
+	}
 }
 
 func (s *SKVMGuestInstance) eventGuestStop() {
-	if s.MigrateTask != nil {
-		// migrating complete
-		s.MigrateTask.onMigrateReceivedStopEvent()
-	}
-	hostutils.UpdateServerProgress(context.Background(), s.Id, 0.0, 0)
+	// do nothing
 }
 
 func (s *SKVMGuestInstance) eventQuorumReportBad(event *monitor.Event) {
@@ -870,6 +890,10 @@ func (s *SKVMGuestInstance) eventGuestPaniced(event *monitor.Event) {
 }
 
 func (s *SKVMGuestInstance) eventBlockJobReady(event *monitor.Event) {
+	if !s.IsSlave() {
+		return
+	}
+
 	itype, ok := event.Data["type"]
 	if !ok {
 		log.Errorf("block job missing event type")
@@ -906,25 +930,23 @@ func (s *SKVMGuestInstance) eventBlockJobReady(event *monitor.Event) {
 		return
 	}
 
-	if s.IsSlave() { // is backup server
-		disk, err := storageman.GetManager().GetDiskByPath(diskPath)
-		if err != nil {
-			log.Errorf("eventBlockJobReady failed get disk %s", diskPath)
-			return
-		}
-		disk.PostCreateFromImageFuse()
-		blockJobCount := s.BlockJobsCount()
-		if blockJobCount == 0 {
-			for {
-				_, err := modules.Servers.PerformAction(
-					hostutils.GetComputeSession(context.Background()), s.GetId(), "slave-block-stream-ready", nil,
-				)
-				if err != nil {
-					log.Errorf("onReceiveQMPEvent sync slave block stream ready error: %s", err)
-					time.Sleep(3 * time.Second)
-				} else {
-					break
-				}
+	disk, err := storageman.GetManager().GetDiskByPath(diskPath)
+	if err != nil {
+		log.Errorf("eventBlockJobReady failed get disk %s", diskPath)
+		return
+	}
+	disk.PostCreateFromImageFuse()
+	blockJobCount := s.BlockJobsCount()
+	if blockJobCount == 0 {
+		for {
+			_, err := modules.Servers.PerformAction(
+				hostutils.GetComputeSession(context.Background()), s.GetId(), "slave-block-stream-ready", nil,
+			)
+			if err != nil {
+				log.Errorf("onReceiveQMPEvent sync slave block stream ready error: %s", err)
+				time.Sleep(3 * time.Second)
+			} else {
+				break
 			}
 		}
 	}
@@ -1007,6 +1029,20 @@ func (s *SKVMGuestInstance) migrateEnableMultifd() error {
 	}
 	log.Infof("migrate dest guest enable multifd")
 	s.Monitor.MigrateSetCapability("multifd", "on", cb)
+	return <-err
+}
+
+func (s *SKVMGuestInstance) migrateStartNbdServer(nbdServerPort int) error {
+	var err = make(chan error)
+	onNbdServerStarted := func(res string) {
+		if len(res) > 0 {
+			err <- errors.Errorf("failed enable multifd %s", res)
+		} else {
+			err <- nil
+		}
+	}
+	log.Infof("migrate dest guest start nbd server on %d", nbdServerPort)
+	s.Monitor.StartNbdServer(nbdServerPort, true, true, onNbdServerStarted)
 	return <-err
 }
 
@@ -1151,6 +1187,15 @@ func (s *SKVMGuestInstance) guestRun(ctx context.Context) {
 			hostutils.TaskFailed(ctx, err.Error())
 			return
 		}
+		nbdServerPort := s.manager.GetNBDServerFreePort()
+		defer s.manager.unsetPort(nbdServerPort)
+		err = s.migrateStartNbdServer(nbdServerPort)
+		if err != nil {
+			hostutils.TaskFailed(ctx, err.Error())
+			return
+		}
+		body.Set("nbd_server_port", jsonutils.NewInt(int64(nbdServerPort)))
+
 		if s.LiveMigrateUseTls {
 			s.setDestMigrateTLS(ctx, body)
 		} else {

--- a/pkg/hostman/monitor/hmp.go
+++ b/pkg/hostman/monitor/hmp.go
@@ -320,6 +320,11 @@ func (m *HmpMonitor) MigrateIncoming(address string, callback StringCallback) {
 	m.Query(cmd, callback)
 }
 
+func (m *HmpMonitor) MigrateContinue(state string, callback StringCallback) {
+	cmd := fmt.Sprintf("migrate_continue %s", state)
+	m.Query(cmd, callback)
+}
+
 func (m *HmpMonitor) Migrate(
 	destStr string, copyIncremental, copyFull bool, callback StringCallback,
 ) {
@@ -402,7 +407,7 @@ func (m *HmpMonitor) ReloadDiskBlkdev(device, path string, callback StringCallba
 	m.Query(fmt.Sprintf("reload_disk_snapshot_blkdev -n %s %s", device, path), callback)
 }
 
-func (m *HmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMode, format string, unmap, blockReplication bool) {
+func (m *HmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMode, format string, unmap, blockReplication bool, speed int64) {
 	cmd := "drive_mirror -n"
 	if blockReplication {
 		cmd += " -c"
@@ -465,6 +470,10 @@ func (m *HmpMonitor) StartNbdServer(port int, exportAllDevice, writable bool, ca
 	}
 	cmd += fmt.Sprintf(" 0.0.0.0:%d", port)
 	m.Query(cmd, callback)
+}
+
+func (m *HmpMonitor) StopNbdServer(callback StringCallback) {
+	m.Query("nbd_server_stop", callback)
 }
 
 func (m *HmpMonitor) ResizeDisk(driveName string, sizeMB int64, callback StringCallback) {

--- a/pkg/hostman/monitor/monitor.go
+++ b/pkg/hostman/monitor/monitor.go
@@ -223,7 +223,7 @@ type Monitor interface {
 
 	XBlockdevChange(parent, node, child string, callback StringCallback)
 	BlockStream(drive string, callback StringCallback)
-	DriveMirror(callback StringCallback, drive, target, syncMode, format string, unmap, blockReplication bool)
+	DriveMirror(callback StringCallback, drive, target, syncMode, format string, unmap, blockReplication bool, speed int64)
 	DriveBackup(callback StringCallback, drive, target, syncMode, format string)
 	BlockJobComplete(drive string, cb StringCallback)
 	BlockReopenImage(drive, newImagePath, format string, cb StringCallback)
@@ -234,6 +234,7 @@ type Monitor interface {
 	MigrateSetParameter(key string, val interface{}, callback StringCallback)
 	MigrateIncoming(address string, callback StringCallback)
 	Migrate(destStr string, copyIncremental, copyFull bool, callback StringCallback)
+	MigrateContinue(state string, callback StringCallback)
 	GetMigrateStatus(callback StringCallback)
 	MigrateStartPostcopy(callback StringCallback)
 	GetMigrateStats(callback MigrateStatsCallback)
@@ -241,6 +242,7 @@ type Monitor interface {
 	ReloadDiskBlkdev(device, path string, callback StringCallback)
 	SetVncPassword(proto, password string, callback StringCallback)
 	StartNbdServer(port int, exportAllDevice, writable bool, callback StringCallback)
+	StopNbdServer(callback StringCallback)
 
 	ResizeDisk(driveName string, sizeMB int64, callback StringCallback)
 	BlockIoThrottle(driveName string, bps, iops int64, callback StringCallback)

--- a/pkg/hostman/monitor/qmp.go
+++ b/pkg/hostman/monitor/qmp.go
@@ -698,6 +698,11 @@ func (m *QmpMonitor) MigrateIncoming(address string, callback StringCallback) {
 	m.HumanMonitorCommand(cmd, callback)
 }
 
+func (m *QmpMonitor) MigrateContinue(state string, callback StringCallback) {
+	cmd := fmt.Sprintf("migrate_continue %s", state)
+	m.HumanMonitorCommand(cmd, callback)
+}
+
 func (m *QmpMonitor) Migrate(
 	destStr string, copyIncremental, copyFull bool, callback StringCallback,
 ) {
@@ -858,7 +863,7 @@ func (m *QmpMonitor) ReloadDiskBlkdev(device, path string, callback StringCallba
 	m.Query(cmd, cb)
 }
 
-func (m *QmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMode, format string, unmap, blockReplication bool) {
+func (m *QmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMode, format string, unmap, blockReplication bool, speed int64) {
 	var (
 		cb = func(res *Response) {
 			callback(m.actionResult(res))
@@ -871,6 +876,9 @@ func (m *QmpMonitor) DriveMirror(callback StringCallback, drive, target, syncMod
 			"unmap":  unmap,
 		}
 	)
+	if speed > 0 {
+		args["speed"] = speed
+	}
 	if blockReplication {
 		args["block-replication"] = true
 	}
@@ -949,6 +957,10 @@ func (m *QmpMonitor) StartNbdServer(port int, exportAllDevice, writable bool, ca
 	}
 	cmd += fmt.Sprintf(" 0.0.0.0:%d", port)
 	m.HumanMonitorCommand(cmd, callback)
+}
+
+func (m *QmpMonitor) StopNbdServer(callback StringCallback) {
+	m.HumanMonitorCommand("nbd_server_stop", callback)
 }
 
 func (m *QmpMonitor) ResizeDisk(driveName string, sizeMB int64, callback StringCallback) {


### PR DESCRIPTION
Guest using the virtio-blk driver for local disks, iothread is used to handle IO operations, Qemu will segfault when copying disks during live migration. To address this issue, use nbd server and drive_mirror approach to copy the disks.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
