### PR TITLE
fix(baremetal): skip 'Volatile Size' line when detecting memory size

### DIFF
--- a/pkg/util/sysutils/sysutils.go
+++ b/pkg/util/sysutils/sysutils.go
@@ -162,6 +162,10 @@ func ParseDMIMemInfo(lines []string) *types.SDMIMemInfo {
 		if val == nil {
 			continue
 		}
+		// skip 'Volatile Size:' line
+		if strings.Contains(line, "Volatile") {
+			continue
+		}
 		value := strings.ToLower(*val)
 		if strings.HasSuffix(value, " mb") {
 			sizeMb, err := strconv.Atoi(strings.TrimSuffix(value, " mb"))
@@ -290,10 +294,9 @@ func GetSerialPorts(lines []string) []string {
 
 // ParseSGMap parse command 'sg_map -x' outputs:
 //
-//  /dev/sg1 0 2 0 0 0 /dev/sda
-//  /dev/sg2 0 2 1 0 0 /dev/sdb
-//  /dev/sg3 0 2 2 0 0 /dev/sdc
-//
+//	/dev/sg1 0 2 0 0 0 /dev/sda
+//	/dev/sg2 0 2 1 0 0 /dev/sdb
+//	/dev/sg3 0 2 2 0 0 /dev/sdc
 func ParseSGMap(lines []string) []compute.SGMapItem {
 	ret := make([]compute.SGMapItem, 0)
 	for _, l := range lines {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area baremetal
/cc @swordqiu 
- 3.9
