### PR TITLE
Automated cherry pick of #17288: fix(baremetal): skip 'Volatile Size' line when detecting memory size

### DIFF
--- a/pkg/util/sysutils/sysutils.go
+++ b/pkg/util/sysutils/sysutils.go
@@ -162,6 +162,10 @@ func ParseDMIMemInfo(lines []string) *types.SDMIMemInfo {
 		if val == nil {
 			continue
 		}
+		// skip 'Volatile Size:' line
+		if strings.Contains(line, "Volatile") {
+			continue
+		}
 		value := strings.ToLower(*val)
 		if strings.HasSuffix(value, " mb") {
 			sizeMb, err := strconv.Atoi(strings.TrimSuffix(value, " mb"))


### PR DESCRIPTION
Cherry pick of #17288 on master.

#17288: fix(baremetal): skip 'Volatile Size' line when detecting memory size