### PR TITLE
fix(vpcagent): fetch data from region server defaultly

### DIFF
--- a/pkg/vpcagent/options/options.go
+++ b/pkg/vpcagent/options/options.go
@@ -34,10 +34,11 @@ const (
 type VpcAgentOptions struct {
 	VpcProvider string `default:"ovn"`
 
-	APISyncIntervalSeconds      int  `default:"10"`
-	APIRunDelayMilliseconds     int  `default:"100"`
-	APIListBatchSize            int  `default:"1024"`
-	FetchDataFromComputeService bool `default:"false"`
+	APISyncIntervalSeconds  int `default:"10"`
+	APIRunDelayMilliseconds int `default:"100"`
+	APIListBatchSize        int `default:"1024"`
+	// TODO: set this to true, becuase https://github.com/yunionio/cloudpods/issues/17273 is not fixed
+	FetchDataFromComputeService bool `default:"true"`
 
 	OvnWorkerCheckInterval int    `default:"180"`
 	OvnNorthDatabase       string `help:"address for accessing ovn north database.  Default to local unix socket"`


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.10
/area vpcagent
/cc @swordqiu @wanyaoqi 
