### PR TITLE
fix(region): exec batch task no need to lock class so far

### DIFF
--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -514,8 +514,9 @@ func execITask(taskValue reflect.Value, task *STask, odata jsonutils.JSONObject,
 		}
 		task.taskObjects = objs
 
-		lockman.LockClass(ctx, objResManager, task.UserCred.GetProjectId())
-		defer lockman.ReleaseClass(ctx, objResManager, task.UserCred.GetProjectId())
+		// TODO: Currently, there is no need to lock the objResManager class.
+		// lockman.LockClass(ctx, objResManager, task.UserCred.GetProjectId())
+		// defer lockman.ReleaseClass(ctx, objResManager, task.UserCred.GetProjectId())
 
 		params[1] = reflect.ValueOf(objs)
 	} else {


### PR DESCRIPTION
Currently, there is no need to lock the objResManager class. If want lock class, should add check task is necessary.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
