### PR TITLE
Automated cherry pick of #17550: fix(region): esxi disk with vmdk format

### DIFF
--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -221,6 +221,10 @@ func (self *SESXiGuestDriver) GetDeployStatus() ([]string, error) {
 }
 
 func (self *SESXiGuestDriver) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, data *api.ServerCreateInput) (*api.ServerCreateInput, error) {
+	for i := 0; i < len(data.Disks); i++ {
+		data.Disks[i].Format = "vmdk"
+	}
+
 	// check disk config
 	if len(data.Disks) == 0 {
 		return data, nil
@@ -243,6 +247,7 @@ func (self *SESXiGuestDriver) ValidateCreateData(ctx context.Context, userCred m
 	for i, subImage := range image.SubImages {
 		nDataDisk := *rootDisk
 		nDataDisk.SizeMb = subImage.MinDiskMB
+		nDataDisk.Format = "vmdk"
 		nDataDisk.Index = i
 		if i > 0 {
 			nDataDisk.ImageId = ""


### PR DESCRIPTION
Cherry pick of #17550 on release/3.10.

#17550: fix(region): esxi disk with vmdk format