### PR TITLE
Automated cherry pick of #17547: fix(host): telegraf ignore hugetlbfs

### DIFF
--- a/pkg/hostman/system_service/telegraf.go
+++ b/pkg/hostman/system_service/telegraf.go
@@ -98,7 +98,7 @@ func (s *STelegraf) GetConfig(kwargs map[string]interface{}) string {
 	conf += "\n"
 	conf += "[[inputs.disk]]\n"
 	conf += "  ignore_mount_points = [\"/etc/telegraf\", \"/etc/hosts\", \"/etc/hostname\", \"/etc/resolv.conf\", \"/dev/termination-log\"]"
-	conf += "  ignore_fs = [\"tmpfs\", \"devtmpfs\", \"overlay\", \"squashfs\", \"iso9660\", \"rootfs\"]\n"
+	conf += "  ignore_fs = [\"tmpfs\", \"devtmpfs\", \"overlay\", \"squashfs\", \"iso9660\", \"rootfs\", \"hugetlbfs\"]\n"
 	conf += "\n"
 	conf += "[[inputs.diskio]]\n"
 	conf += "  skip_serial_number = false\n"


### PR DESCRIPTION
Cherry pick of #17547 on release/3.10.

#17547: fix(host): telegraf ignore hugetlbfs