### PR TITLE
fix: disable application profiling by default

### DIFF
--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -151,6 +151,7 @@ var (
 
 			"is_slave_node",
 			"config_sync_period_seconds",
+			"enable_app_profiling",
 
 			// ############################
 			// db blacklist options

--- a/pkg/appsrv/appsrv.go
+++ b/pkg/appsrv/appsrv.go
@@ -73,6 +73,8 @@ type Application struct {
 	exception func(method, path string, body jsonutils.JSONObject, err error)
 
 	isTLS bool
+
+	enableProfiling bool
 }
 
 const (
@@ -553,7 +555,9 @@ func (app *Application) ListenAndServeTLSWithCleanup2(addr string, certFile, key
 	httpSrv := app.initServer(addr)
 	if isMaster {
 		app.addDefaultHandlers()
-		AddPProfHandler("", app)
+		if app.enableProfiling {
+			addPProfHandler("", app)
+		}
 		app.httpServer = httpSrv
 		app.registerCleanShutdown(app.httpServer, onStop)
 	} else {
@@ -664,4 +668,8 @@ func FetchEnv(ctx context.Context, w http.ResponseWriter, r *http.Request) (para
 
 func (app *Application) GetContext() context.Context {
 	return app.context
+}
+
+func (app *Application) EnableProfiling() {
+	app.enableProfiling = true
 }

--- a/pkg/appsrv/handlers.go
+++ b/pkg/appsrv/handlers.go
@@ -51,7 +51,7 @@ func CORSHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
     }
 }*/
 
-func AddPProfHandler(prefix string, app *Application) {
+func addPProfHandler(prefix string, app *Application) {
 	pp := "/debug/pprof"
 	if prefix != "" {
 		prefix = fmt.Sprintf("%s/%s", prefix, pp)

--- a/pkg/appsrv/send.go
+++ b/pkg/appsrv/send.go
@@ -22,10 +22,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/gotypes"
 )
 

--- a/pkg/cloudcommon/app/app.go
+++ b/pkg/cloudcommon/app/app.go
@@ -37,6 +37,9 @@ func InitApp(options *common_options.BaseOptions, dbAccess bool) *appsrv.Applica
 	// if dbConn != nil {
 	//	app.SetContext(appsrv.APP_CONTEXT_KEY_DB, dbConn)
 	//}
+	if options.EnableAppProfiling {
+		app.EnableProfiling()
+	}
 	return app
 }
 

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -116,6 +116,8 @@ type BaseOptions struct {
 
 	PlatformName  string            `help:"identity name of this platform" default:"Cloudpods"`
 	PlatformNames map[string]string `help:"identity name of this platform by language"`
+
+	EnableAppProfiling bool `help:"enable profiling API" default:"false"`
 }
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: disable application profiling by default

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito @wanyaoqi 