### PR TITLE
fix(host): try reloading telegraf by restarting docker

### DIFF
--- a/pkg/hostman/system_service/telegraf.go
+++ b/pkg/hostman/system_service/telegraf.go
@@ -21,7 +21,10 @@ import (
 	"strings"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/httputils"
+
+	"yunion.io/x/onecloud/pkg/util/procutils"
 )
 
 type STelegraf struct {
@@ -205,11 +208,43 @@ func (s *STelegraf) BgReloadConf(kwargs map[string]interface{}) {
 }
 
 func (s *STelegraf) ReloadTelegraf() error {
-	log.Infof("Start reolad telegraf...")
+	log.Infof("Start reloading telegraf...")
+	errs := []error{}
+	if err := s.reloadTelegrafByDocker(); err != nil {
+		errs = append(errs, errors.Wrap(err, "reloadTelegrafByDocker"))
+		if err := s.reloadTelegrafByHTTP(); err != nil {
+			errs = append(errs, errors.Wrap(err, "reloadTelegrafByHTTP"))
+			return errors.NewAggregate(errs)
+		}
+	}
+	log.Infof("Finish reloading telegraf")
+	return nil
+}
+
+func (s *STelegraf) reloadTelegrafByDocker() error {
+	log.Infof("Reloading telegraf by docker...")
+	output, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", "/usr/bin/docker ps --filter 'label=io.kubernetes.container.name=telegraf' --format '{{.ID}}'").Output()
+	if err != nil {
+		return errors.Wrap(err, "using docker ps find telegraf container")
+	}
+	id := strings.TrimSpace(string(output))
+	if len(id) == 0 {
+		return errors.Errorf("not found telegraf running container")
+	}
+	if err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", "/usr/bin/docker restart "+id).Run(); err != nil {
+		return errors.Wrapf(err, "restart telegraf container %q", id)
+	}
+	return nil
+}
+
+func (s *STelegraf) reloadTelegrafByHTTP() error {
 	telegrafReoladUrl := "http://127.0.0.1:8087/reload"
-	_, _, err := httputils.JSONRequest(
+	log.Infof("Reloading telegraf by %q ...", telegrafReoladUrl)
+	if _, _, err := httputils.JSONRequest(
 		httputils.GetDefaultClient(), context.Background(),
 		"POST", telegrafReoladUrl, nil, nil, false,
-	)
-	return err
+	); err != nil {
+		return errors.Wrap(err, "reload telegraf by http reload api")
+	}
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

通过 docker restart telegraf 容器重启，之前通过 http api restart 可能会造成进程泄漏

![img_v2_4dfc14ba-fdad-47c1-8005-e34acc3c3eag](https://github.com/yunionio/cloudpods/assets/10767027/ae9a1935-d78e-4d89-80f0-587476c8d102)


<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.9
/area host
/cc @swordqiu @wanyaoqi 