### PR TITLE
fix: set vcpu vendor_id based on host cpu vendor_id

### DIFF
--- a/pkg/hostman/guestman/arch/x86.go
+++ b/pkg/hostman/guestman/arch/x86.go
@@ -136,6 +136,11 @@ func (x86 *X86) GenerateCpuDesc(cpus uint, cpuMax uint, s KVMGuestInstance) (*de
 	var accel, cpuType, vendor, level string
 	var features = make(map[string]bool, 0)
 	if s.IsKvmSupport() {
+		if isCPUIntel {
+			vendor = "GenuineIntel"
+		} else if isCPUAMD {
+			vendor = "AuthenticAMD"
+		}
 		accel = "kvm"
 		if s.GetOsName() == qemu.OS_NAME_MACOS {
 			cpuType = "Penryn"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: set vcpu vendor_id based on host cpu vendor_id
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi @ioito 