### PR TITLE
Automated cherry pick of #17711: fix: set vcpu vendor_id based on host cpu vendor_id

### DIFF
--- a/pkg/hostman/guestman/arch/x86.go
+++ b/pkg/hostman/guestman/arch/x86.go
@@ -136,6 +136,11 @@ func (x86 *X86) GenerateCpuDesc(cpus uint, cpuMax uint, s KVMGuestInstance) (*de
 	var accel, cpuType, vendor, level string
 	var features = make(map[string]bool, 0)
 	if s.IsKvmSupport() {
+		if isCPUIntel {
+			vendor = "GenuineIntel"
+		} else if isCPUAMD {
+			vendor = "AuthenticAMD"
+		}
 		accel = "kvm"
 		if s.GetOsName() == qemu.OS_NAME_MACOS {
 			cpuType = "Penryn"


### PR DESCRIPTION
Cherry pick of #17711 on release/3.10.

#17711: fix: set vcpu vendor_id based on host cpu vendor_id