### PR TITLE
fix: set vcpu vendor_id based on host cpu vendor_id for release/3.9

### DIFF
--- a/pkg/hostman/guestman/qemu/qemu.go
+++ b/pkg/hostman/guestman/qemu/qemu.go
@@ -381,18 +381,29 @@ func newBaseOptions_x86_64() *baseOptions_x86_64 {
 }
 
 func (o *baseOptions_x86_64) CPU(input CPUOption, osName string) (string, string, error) {
-	var accel, cpuType string
+	var accel, cpuType, vendor string
 	if input.EnableKVM {
+		if input.IsCPUIntel {
+			vendor = "GenuineIntel"
+		} else if input.IsCPUAMD {
+			vendor = "AuthenticAMD"
+		}
 		accel = "kvm"
 		cpuType = ""
 		if osName == OS_NAME_MACOS {
 			cpuType = "Penryn,vendor=GenuineIntel"
 		} else if input.HostCPUPassthrough {
 			cpuType = "host"
+			if len(vendor) > 0 {
+				cpuType += fmt.Sprintf(",vendor=%s", vendor)
+			}
 			// https://unix.stackexchange.com/questions/216925/nmi-received-for-unknown-reason-20-do-you-have-a-strange-power-saving-mode-ena
 			cpuType += ",+kvm_pv_eoi"
 		} else {
 			cpuType = "qemu64"
+			if len(vendor) > 0 {
+				cpuType += fmt.Sprintf(",vendor=%s", vendor)
+			}
 			cpuType += ",+kvm_pv_eoi"
 			if input.IsCPUIntel {
 				cpuType += ",+vmx"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: set vcpu vendor_id based on host cpu vendor_id for release/3.9

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi 