### PR TITLE
Automated cherry pick of #17727: fix: allow host access_mac nullable

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -107,7 +107,7 @@ type SHost struct {
 	Slots string `width:"16" charset:"ascii" nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 
 	// 管理口MAC
-	AccessMac string `width:"32" charset:"ascii" nullable:"false" index:"true" list:"domain" update:"domain"`
+	AccessMac string `width:"32" charset:"ascii" nullable:"true" index:"true" list:"domain" update:"domain"`
 
 	// 管理口Ip地址
 	AccessIp string `width:"16" charset:"ascii" nullable:"true" list:"domain" update:"domain"`


### PR DESCRIPTION
Cherry pick of #17727 on release/3.10.

#17727: fix: allow host access_mac nullable