### PR TITLE
Automated cherry pick of #17792: fix(climc): 'zone-list --region' is ignored

### DIFF
--- a/pkg/mcclient/options/compute/zone.go
+++ b/pkg/mcclient/options/compute/zone.go
@@ -22,7 +22,7 @@ import (
 
 type ZoneListOptions struct {
 	options.BaseListOptions
-	Region    string `help:"cloud region ID or Name" json:"-"`
+	Region    string `help:"cloud region ID or Name"`
 	City      string `help:"Filter zone by city of cloudregions"`
 	Usable    *bool  `help:"List all zones where networks are usable"`
 	UsableVpc *bool  `help:"List all zones where vpc are usable"`


### PR DESCRIPTION
Cherry pick of #17792 on master.

#17792: fix(climc): 'zone-list --region' is ignored