### PR TITLE
Automated cherry pick of #17775: fix: windows 2012 no dns

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/windows.go
+++ b/pkg/hostman/guestfs/fsdriver/windows.go
@@ -326,7 +326,7 @@ func (w *SWindowsRootFs) DeployNetworkingScripts(rootfs IDiskPartition, nics []*
 			dnslist := netutils2.GetNicDns(snic)
 			if len(dnslist) > 0 {
 				lines = append(lines, fmt.Sprintf(
-					`      netsh interface ip set dns name="%%%%b" source=static addr=%s ddns=disabled suffix=interface`, dnslist[0]))
+					`      netsh interface ip set dns name="%%%%b" source=static addr=%s`, dnslist[0]))
 				if len(dnslist) > 1 {
 					for i := 1; i < len(dnslist); i++ {
 						lines = append(lines, fmt.Sprintf(`      netsh interface ip add dns "%%%%b" %s index=%d`, dnslist[i], i+1))


### PR DESCRIPTION
Cherry pick of #17775 on release/3.9.

#17775: fix: windows 2012 no dns