### PR TITLE
fix(apigateway): add GetSpecificMethods to resource manager

### DIFF
--- a/cmd/climc/shell/k8s/container_registry.go
+++ b/cmd/climc/shell/k8s/container_registry.go
@@ -33,6 +33,7 @@ func initContainerRegistry() {
 	cmd := NewK8sResourceCmd(k8s.ContainerRegistries)
 	cmd.List(new(o.RegistryListOptions))
 	cmd.Show(new(o.RegistryGetOptions))
+	cmd.Delete(new(o.RegistryGetOptions))
 	cmd.Create(new(o.RegistryCreateOptions))
 	cmd.Get("images", new(o.RegistryGetImagesOptions))
 	cmd.Get("image-tags", new(o.RegistryGetImageTagsOptions))

--- a/pkg/apigateway/handler/resource.go
+++ b/pkg/apigateway/handler/resource.go
@@ -311,7 +311,7 @@ func (f *ResourceHandlers) getSpecHandler(ctx context.Context, w http.ResponseWr
 	query := req.Query()
 
 	module2, e := modulebase.GetModule(session, req.Spec())
-	if e != nil {
+	if e != nil || module.GetSpecificMethods().Has(req.Spec()) {
 		obj, e := module.GetSpecific(session, req.ResID(), req.Spec(), query)
 		if e != nil {
 			httperrors.GeneralServerError(ctx, w, e)

--- a/pkg/mcclient/modulebase/base.go
+++ b/pkg/mcclient/modulebase/base.go
@@ -28,6 +28,7 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/httputils"
 	"yunion.io/x/pkg/util/printutils"
+	"yunion.io/x/pkg/util/sets"
 
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -41,6 +42,8 @@ type BaseManager struct {
 
 	columns      []string
 	adminColumns []string
+
+	specificMethods sets.String
 }
 
 func NewBaseManager(serviceType, endpointType, version string, columns, adminColumns []string) *BaseManager {
@@ -49,9 +52,18 @@ func NewBaseManager(serviceType, endpointType, version string, columns, adminCol
 		endpointType: endpointType,
 		version:      version,
 		// apiVersion:   apiVersion,
-		columns:      columns,
-		adminColumns: adminColumns,
+		columns:         columns,
+		adminColumns:    adminColumns,
+		specificMethods: sets.NewString(),
 	}
+}
+
+func (m *BaseManager) GetSpecificMethods() sets.String {
+	return m.specificMethods
+}
+
+func (m *BaseManager) SetSpecificMethods(ms ...string) {
+	m.specificMethods = sets.NewString(ms...)
 }
 
 func (this *BaseManager) GetColumns(session *mcclient.ClientSession) []string {

--- a/pkg/mcclient/modulebase/modules.go
+++ b/pkg/mcclient/modulebase/modules.go
@@ -23,6 +23,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/printutils"
+	"yunion.io/x/pkg/util/sets"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
@@ -142,6 +143,8 @@ type Manager interface {
 	BatchDeleteInContextWithParam(session *mcclient.ClientSession, idlist []string, query jsonutils.JSONObject, body jsonutils.JSONObject, ctx Manager, ctxid string) []printutils.SubmitResult
 	BatchDeleteInContexts(session *mcclient.ClientSession, idlist []string, body jsonutils.JSONObject, ctxs []ManagerContext) []printutils.SubmitResult
 	BatchDeleteInContextsWithParam(session *mcclient.ClientSession, idlist []string, query jsonutils.JSONObject, body jsonutils.JSONObject, ctxs []ManagerContext) []printutils.SubmitResult
+
+	GetSpecificMethods() sets.String
 }
 
 type IResourceManager interface {

--- a/pkg/mcclient/modules/k8s/container_registry.go
+++ b/pkg/mcclient/modules/k8s/container_registry.go
@@ -44,11 +44,13 @@ type ContainerRegistryManager struct {
 }
 
 func NewContainerRegistryManager() *ContainerRegistryManager {
-	return &ContainerRegistryManager{
+	man := &ContainerRegistryManager{
 		ResourceManager: NewResourceManager("container_registry", "container_registries",
 			NewResourceCols("Url", "Type"),
 			NewColumns()),
 	}
+	man.SetSpecificMethods("images")
+	return man
 }
 
 func (m *ContainerRegistryManager) UploadImage(s *mcclient.ClientSession, id string, params jsonutils.JSONObject, body io.Reader, size int64) (jsonutils.JSONObject, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

主要解决下面这种场景：
假设一个后端服务定义了 GetDetailsImages 的 get_spec api ，url为: /model_manager/id/images 
但是通过 apigateway 请求不会转发到这个后端服务的 model_manager ，因为 apigateway 会优先那 images 这个去匹配到 glance image 的 manager ，然后就走 joint manager 的逻辑了

对应到 k8s 服务的 ContainerRegistryManager ，我有一个查询镜像仓库下面镜像的 api ，url 为：GET /container_registries/$reg_id/images，然后这里的 spec 为 images 关键字，apigateway 会匹配到 glance 的 ImageManager ，然后就请求到错误的地址了

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.10
/area apigateway climc
/cc @swordqiu 