### PR TITLE
Automated cherry pick of #17936: feat(climc): download container registry image directly

### DIFF
--- a/cmd/climc/shell/k8s/container_registry.go
+++ b/cmd/climc/shell/k8s/container_registry.go
@@ -67,20 +67,38 @@ func initContainerRegistry() {
 	})
 
 	type DownloadOptions struct {
-		REGISTRY string `help:"The name or id of registry" json:"-"`
 		NAME     string `help:"The name of image, e.g. 'influxdb:1.7.7'"`
+		Registry string `help:"The name or id of registry" json:"-"`
 		Output   string `help:"Saved file path"`
+		Insecure bool   `help:"Set insecure"`
+		Username string `help:"Image registry username, effective only when --registry is not specified"`
+		Password string `help:"Image registry password, effective only when --registry is not specified"`
 	}
 	R(new(DownloadOptions), "k8s-container-registry-download-image", "Download container image to a file", func(s *mcclient.ClientSession, args *DownloadOptions) error {
-		parts := strings.Split(args.NAME, ":")
-		if len(parts) != 2 {
-			return errors.Errorf("invalid NAME %q, use format <name>:<tag>", args.NAME)
-		}
-		name := parts[0]
-		tag := parts[1]
-		fileName, src, size, err := k8s.ContainerRegistries.DownloadImage(s, args.REGISTRY, name, tag)
-		if err != nil {
-			return errors.Wrap(err, "download chart")
+		var (
+			fileName string
+			src      io.Reader
+			size     int64
+			err      error
+		)
+		if args.Registry != "" {
+			parts := strings.Split(args.NAME, ":")
+			if len(parts) != 2 {
+				return errors.Errorf("invalid NAME %q, use format <name>:<tag>", args.NAME)
+			}
+			name := parts[0]
+			tag := parts[1]
+			fileName, src, size, err = k8s.ContainerRegistries.DownloadImage(s, args.Registry, name, tag)
+			if err != nil {
+				return errors.Wrap(err, "download chart")
+			}
+		} else {
+			fileName, src, size, err = k8s.ContainerRegistries.DownloadImageByManager(s, &k8s.DownloadImageByManagerInput{
+				Insecure: args.Insecure,
+				Image:    args.NAME,
+				Username: args.Username,
+				Password: args.Password,
+			})
 		}
 		output := args.Output
 		if output == "" && fileName != "" {

--- a/pkg/mcclient/modules/k8s/container_registry.go
+++ b/pkg/mcclient/modules/k8s/container_registry.go
@@ -68,13 +68,29 @@ func (m *ContainerRegistryManager) UploadImage(s *mcclient.ClientSession, id str
 	return json, nil
 }
 
+type DownloadImageByManagerInput struct {
+	Insecure bool   `json:"insecure"`
+	Image    string `json:"image"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func (m *ContainerRegistryManager) DownloadImageByManager(s *mcclient.ClientSession, input *DownloadImageByManagerInput) (string, io.Reader, int64, error) {
+	path := fmt.Sprintf("/%s/download-image", m.URLPath())
+	return m.downloadImage(s, path, input)
+}
+
 func (m *ContainerRegistryManager) DownloadImage(s *mcclient.ClientSession, id string, imageName string, imageTag string) (string, io.Reader, int64, error) {
 	params := map[string]string{
 		"image_name": imageName,
 		"tag":        imageTag,
 	}
-	query := jsonutils.Marshal(params)
 	path := fmt.Sprintf("/%s/%s/download-image", m.URLPath(), url.PathEscape(id))
+	return m.downloadImage(s, path, params)
+}
+
+func (m *ContainerRegistryManager) downloadImage(s *mcclient.ClientSession, path string, params interface{}) (string, io.Reader, int64, error) {
+	query := jsonutils.Marshal(params)
 	queryString := query.QueryString()
 	if len(queryString) > 0 {
 		path = fmt.Sprintf("%s?%s", path, queryString)


### PR DESCRIPTION
Cherry pick of #17936 on master.

#17936: feat(climc): download container registry image directly