### PR TITLE
fix: allow remvoe server extra options of specific value

### DIFF
--- a/cmd/climc/shell/compute/servers.go
+++ b/cmd/climc/shell/compute/servers.go
@@ -398,10 +398,15 @@ func init() {
 	type ServerRemoveExtraOption struct {
 		ID  string `help:"ID or name of server"`
 		KEY string `help:"Option key"`
+
+		Value string `help:"Option value"`
 	}
 	R(&ServerRemoveExtraOption{}, "server-remove-extra-options", "Remove server extra options", func(s *mcclient.ClientSession, args *ServerRemoveExtraOption) error {
 		params := jsonutils.NewDict()
 		params.Add(jsonutils.NewString(args.KEY), "key")
+		if len(args.Value) > 0 {
+			params.Add(jsonutils.NewString(args.Value), "value")
+		}
 		result, err := modules.Servers.PerformAction(s, args.ID, "del-extra-option", params)
 		if err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allow remvoe server extra options of specific value

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi @wanyaoqi 