### PR TITLE
Automated cherry pick of #17947: fix: allow remvoe server extra options of specific value

### DIFF
--- a/cmd/climc/shell/compute/servers.go
+++ b/cmd/climc/shell/compute/servers.go
@@ -392,10 +392,15 @@ func init() {
 	type ServerRemoveExtraOption struct {
 		ID  string `help:"ID or name of server"`
 		KEY string `help:"Option key"`
+
+		Value string `help:"Option value"`
 	}
 	R(&ServerRemoveExtraOption{}, "server-remove-extra-options", "Remove server extra options", func(s *mcclient.ClientSession, args *ServerRemoveExtraOption) error {
 		params := jsonutils.NewDict()
 		params.Add(jsonutils.NewString(args.KEY), "key")
+		if len(args.Value) > 0 {
+			params.Add(jsonutils.NewString(args.Value), "value")
+		}
 		result, err := modules.Servers.PerformAction(s, args.ID, "del-extra-option", params)
 		if err != nil {
 			return err


### PR DESCRIPTION
Cherry pick of #17947 on release/3.9.

#17947: fix: allow remvoe server extra options of specific value