### PR TITLE
Automated cherry pick of #18058: fix: skip get metadata check if usercred is nil

### DIFF
--- a/pkg/cloudcommon/db/metadata.go
+++ b/pkg/cloudcommon/db/metadata.go
@@ -656,8 +656,9 @@ func isAllowGetMetadata(ctx context.Context, obj IModel, userCred mcclient.Token
 				return true
 			}
 		}
+		return false
 	}
-	return false
+	return true
 }
 
 func (manager *SMetadataManager) GetAll(ctx context.Context, obj IModel, keys []string, keyPrefix string, userCred mcclient.TokenCredential) (map[string]string, error) {


### PR DESCRIPTION
Cherry pick of #18058 on release/3.10.

#18058: fix: skip get metadata check if usercred is nil