### PR TITLE
Automated cherry pick of #18124: fix: charset mismatch in tenant cache convert_ids

### DIFF
--- a/pkg/cloudcommon/db/tenantcache.go
+++ b/pkg/cloudcommon/db/tenantcache.go
@@ -581,7 +581,7 @@ func (manager *STenantCacheManager) ConvertIds(ids []string, isDomain bool) ([]s
 		q = manager.GetTenantQuery("id")
 	}
 	q = q.Filter(sqlchemy.OR(
-		sqlchemy.In(q.Field("id"), ids),
+		sqlchemy.In(q.Field("id"), stringutils2.RemoveUtf8Strings(ids)),
 		sqlchemy.In(q.Field("name"), ids),
 	))
 	q = q.Distinct()


### PR DESCRIPTION
Cherry pick of #18124 on release/3.11.

#18124: fix: charset mismatch in tenant cache convert_ids