### PR TITLE
Automated cherry pick of #18156: fix(region): remove ansible restart network on guest sync

### DIFF
--- a/pkg/compute/tasks/guest_qga_restart_network_task.go
+++ b/pkg/compute/tasks/guest_qga_restart_network_task.go
@@ -85,9 +85,5 @@ func (self *GuestQgaRestartNetworkTask) taskFailed(ctx context.Context, guest *m
 	guest.SetStatus(self.GetUserCred(), api.VM_QGA_SET_NETWORK_FAILED, err.Error())
 	guest.UpdateQgaStatus(api.QGA_STATUS_EXECUTE_FAILED)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_RESTART_NETWORK, jsonutils.NewString(err.Error()), self.UserCred, false)
-	if prevIp != "" {
-		//use ansible to restart network
-		guest.StartRestartNetworkTask(ctx, self.UserCred, "", prevIp, inBlockStream)
-	}
 	self.SetStageFailed(ctx, nil)
 }

--- a/pkg/compute/tasks/guest_sync_task.go
+++ b/pkg/compute/tasks/guest_sync_task.go
@@ -75,10 +75,6 @@ func (self *GuestSyncConfTask) StartRestartNetworkTask(ctx context.Context, gues
 		return
 	}
 	inBlockStream := jsonutils.QueryBoolean(self.Params, "in_block_stream", false)
-	if guest.Hypervisor != api.HYPERVISOR_KVM {
-		guest.StartRestartNetworkTask(ctx, self.UserCred, "", prevIp, inBlockStream)
-		return
-	}
 	preMac, err := self.Params.GetString("prev_mac")
 	if err != nil {
 		log.Errorf("unable to get prev_mac when restart_network is true when sync guest")
@@ -124,7 +120,8 @@ func (self *GuestSyncConfTask) StartRestartNetworkTask(ctx context.Context, gues
 	}()
 	if err != nil {
 		log.Errorf("guest %s failed start qga restart network task: %s", guest.GetName(), err)
-		guest.StartRestartNetworkTask(ctx, self.UserCred, "", prevIp, inBlockStream)
+		guest.SetStatus(self.GetUserCred(), api.VM_QGA_SET_NETWORK_FAILED, err.Error())
+		logclient.AddActionLogWithStartable(self, guest, logclient.ACT_RESTART_NETWORK, jsonutils.NewString(err.Error()), self.UserCred, false)
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #18156 on release/3.11.

#18156: fix(region): remove ansible restart network on guest sync