### PR TITLE
Automated cherry pick of #18207: feat(region,glance): from cloudaccount to enable vmdk target format

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -52,6 +52,7 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modules/image"
 	"yunion.io/x/onecloud/pkg/util/logclient"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
@@ -634,6 +635,13 @@ func (self *SCloudaccount) PostCreate(ctx context.Context, userCred mcclient.Tok
 		self.StartSyncCloudAccountInfoTask(ctx, userCred, nil, "", data)
 	} else {
 		self.SubmitSyncAccountTask(ctx, userCred, nil)
+	}
+
+	if self.Brand == api.CLOUD_PROVIDER_VMWARE {
+		_, err := image.Images.PerformClassAction(auth.GetAdminSession(ctx, options.Options.Region), "vmware-account-added", nil)
+		if err != nil {
+			log.Errorf("failed inform glance vmware account added: %s", err)
+		}
 	}
 }
 

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -1651,6 +1651,14 @@ func (img *SImage) PerformChangeOwner(ctx context.Context, userCred mcclient.Tok
 	return ret, nil
 }
 
+func (m *SImageManager) PerformVmwareAccountAdded(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformChangeProjectOwnerInput) (jsonutils.JSONObject, error) {
+	log.Infof("perform vmware account added")
+	if !utils.IsInStringArray(string(qemuimgfmt.VMDK), options.Options.TargetImageFormats) {
+		options.Options.TargetImageFormats = append(options.Options.TargetImageFormats, string(qemuimgfmt.VMDK))
+	}
+	return nil, nil
+}
+
 /*func (image *SImage) getRealPath() string {
 	diskPath := image.GetPath("")
 	if !fileutils2.Exists(diskPath) {

--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -36,7 +36,7 @@ type SImageOptions struct {
 
 	EnableTorrentService bool `help:"Enable torrent service" default:"false"`
 
-	TargetImageFormats []string `help:"target image formats that the system will automatically convert to" default:"qcow2,vmdk"`
+	TargetImageFormats []string `help:"target image formats that the system will automatically convert to" default:"qcow2"`
 
 	TorrentClientPath string `help:"path to torrent executable" default:"/opt/yunion/bin/torrent"`
 


### PR DESCRIPTION
Cherry pick of #18207 on release/3.10.

#18207: feat(region,glance): from cloudaccount to enable vmdk target format