### PR TITLE
Automated cherry pick of #18239: fix(host): host sysinfo metadata double quota

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1436,7 +1436,8 @@ func (h *SHostInfo) updateOrCreateHost(hostId string) (jsonutils.JSONObject, err
 	meta, _ := jsonutils.Marshal(h.getSysInfo()).GetMap()
 	input.Metadata = map[string]string{}
 	for k, v := range meta {
-		input.Metadata[k] = v.String()
+		val, _ := v.GetString()
+		input.Metadata[k] = val
 	}
 	input.Version = version.GetShortString()
 


### PR DESCRIPTION
Cherry pick of #18239 on release/3.10.

#18239: fix(host): host sysinfo metadata double quota