### PR TITLE
Automated cherry pick of #18342: fix: unable to recognize anolis os

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/anolis.go
+++ b/pkg/hostman/guestfs/fsdriver/anolis.go
@@ -40,8 +40,8 @@ func (d *SAnolisRootFs) String() string {
 }
 
 func (d *SAnolisRootFs) RootSignatures() []string {
-	sig := d.sRedhatLikeRootFs.RootSignatures()
-	return append([]string{"/etc/anolis-release"}, sig...)
+	sig := d.sLinuxRootFs.RootSignatures()
+	return append([]string{"/etc/sysconfig/network", "/etc/anolis-release"}, sig...)
 }
 
 func (d *SAnolisRootFs) GetReleaseInfo(rootFs IDiskPartition) *deployapi.ReleaseInfo {


### PR DESCRIPTION
Cherry pick of #18342 on release/3.11.

#18342: fix: unable to recognize anolis os