### PR TITLE
Automated cherry pick of #18352: fix: missing project mapping body

### DIFF
--- a/pkg/apis/compute/project_mappings.go
+++ b/pkg/apis/compute/project_mappings.go
@@ -143,6 +143,8 @@ type SProjectMappingAccount struct {
 }
 
 type ProjectMappingDetails struct {
+	SProjectMapping
+
 	apis.EnabledStatusInfrasResourceBaseDetails
 
 	Rules []ProjectMappingRuleInfoDetails


### PR DESCRIPTION
Cherry pick of #18352 on release/3.11.

#18352: fix: missing project mapping body