### PR TITLE
Automated cherry pick of #18207: feat(region,glance): from cloudaccount to enable vmdk target format

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -49,6 +49,7 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modules/image"
 	"yunion.io/x/onecloud/pkg/multicloud/esxi/vcenter"
 	"yunion.io/x/onecloud/pkg/util/httputils"
 	"yunion.io/x/onecloud/pkg/util/logclient"
@@ -576,6 +577,13 @@ func (self *SCloudaccount) PostCreate(ctx context.Context, userCred mcclient.Tok
 			self.StartSyncVMwareNetworkTask(ctx, userCred, "", zone)
 		} else {
 			self.StartSyncCloudProviderInfoTask(ctx, userCred, nil, "")
+		}
+	}
+
+	if self.Brand == api.CLOUD_PROVIDER_VMWARE {
+		_, err := image.Images.PerformClassAction(auth.GetAdminSession(ctx, options.Options.Region), "vmware-account-added", nil)
+		if err != nil {
+			log.Errorf("failed inform glance vmware account added: %s", err)
 		}
 	}
 }

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -1649,6 +1649,14 @@ func (img *SImage) PerformChangeOwner(ctx context.Context, userCred mcclient.Tok
 	return ret, nil
 }
 
+func (m *SImageManager) PerformVmwareAccountAdded(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformChangeProjectOwnerInput) (jsonutils.JSONObject, error) {
+	log.Infof("perform vmware account added")
+	if !utils.IsInStringArray(string(qemuimg.VMDK), options.Options.TargetImageFormats) {
+		options.Options.TargetImageFormats = append(options.Options.TargetImageFormats, string(qemuimg.VMDK))
+	}
+	return nil, nil
+}
+
 /*func (image *SImage) getRealPath() string {
 	diskPath := image.GetPath("")
 	if !fileutils2.Exists(diskPath) {

--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -36,7 +36,7 @@ type SImageOptions struct {
 
 	EnableTorrentService bool `help:"Enable torrent service" default:"false"`
 
-	TargetImageFormats []string `help:"target image formats that the system will automatically convert to" default:"qcow2,vmdk"`
+	TargetImageFormats []string `help:"target image formats that the system will automatically convert to" default:"qcow2"`
 
 	TorrentClientPath string `help:"path to torrent executable" default:"/opt/yunion/bin/torrent"`
 

--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -15,6 +15,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,7 +23,9 @@ import (
 	"time"
 
 	execlient "yunion.io/x/executor/client"
+	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/utils"
 	_ "yunion.io/x/sqlchemy/backends"
 
 	api "yunion.io/x/onecloud/pkg/apis/image"
@@ -38,8 +41,11 @@ import (
 	_ "yunion.io/x/onecloud/pkg/image/policy"
 	_ "yunion.io/x/onecloud/pkg/image/tasks"
 	"yunion.io/x/onecloud/pkg/image/torrent"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modules/compute"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/procutils"
+	"yunion.io/x/onecloud/pkg/util/qemuimg"
 )
 
 func StartService() {
@@ -92,6 +98,14 @@ func StartService() {
 	app_common.InitAuth(commonOpts, func() {
 		log.Infof("Auth complete!!")
 	})
+
+	if ok, err := hasVmwareAccount(); err != nil {
+		log.Errorf("failed	get vmware cloudaccounts")
+	} else if ok {
+		if !utils.IsInStringArray(string(qemuimg.VMDK), options.Options.TargetImageFormats) {
+			options.Options.TargetImageFormats = append(options.Options.TargetImageFormats, string(qemuimg.VMDK))
+		}
+	}
 
 	trackers := torrent.GetTrackers()
 	if len(trackers) == 0 {
@@ -147,6 +161,17 @@ func StartService() {
 			procutils.NewCommand("umount", options.Options.S3MountPoint).Run()
 		}
 	})
+}
+
+func hasVmwareAccount() (bool, error) {
+	q := jsonutils.NewDict()
+	q.Add(jsonutils.NewString("system"), "scope")
+	q.Add(jsonutils.NewString("brand"), "VMware")
+	res, err := compute.Cloudaccounts.List(auth.GetAdminSession(context.Background(), options.Options.Region), q)
+	if err != nil {
+		return false, err
+	}
+	return res.Total > 0, nil
 }
 
 func initS3() {


### PR DESCRIPTION
Cherry pick of #18207 on release/3.9.

#18207: feat(region,glance): from cloudaccount to enable vmdk target format