### PR TITLE
Automated cherry pick of #18408: fix(region): kube cluster brand

### DIFF
--- a/pkg/apis/compute/kube_cluster.go
+++ b/pkg/apis/compute/kube_cluster.go
@@ -69,8 +69,6 @@ type KubeClusterDetails struct {
 	apis.EnabledStatusInfrasResourceBaseDetails
 
 	SKubeCluster
-	ManagedResourceInfo
-	CloudregionResourceInfo
 	VpcResourceInfo
 }
 

--- a/pkg/compute/models/kube_clusters.go
+++ b/pkg/compute/models/kube_clusters.go
@@ -133,10 +133,10 @@ func (manager *SKubeClusterManager) FetchCustomizeColumns(
 	for i := range rows {
 		rows[i] = api.KubeClusterDetails{
 			EnabledStatusInfrasResourceBaseDetails: stdRows[i],
-			ManagedResourceInfo:                    managerRows[i],
-			CloudregionResourceInfo:                regionRows[i],
 			VpcResourceInfo:                        vpcRows[i],
 		}
+		rows[i].ManagedResourceInfo = managerRows[i]
+		rows[i].CloudregionResourceInfo = regionRows[i]
 	}
 	return rows
 }


### PR DESCRIPTION
Cherry pick of #18408 on release/3.11.

#18408: fix(region): kube cluster brand