### PR TITLE
Automated cherry pick of #18485: fix(region): avoid hostname has '-' suffix

### DIFF
--- a/pkg/compute/models/hostnameresource.go
+++ b/pkg/compute/models/hostnameresource.go
@@ -73,6 +73,9 @@ func (manager *SHostnameResourceBaseManager) ValidateHostname(name string, osTyp
 			input.Hostname = input.Hostname[:15]
 		}
 	}
+	for strings.HasSuffix(input.Hostname, "-") {
+		input.Hostname = strings.TrimSuffix(input.Hostname, "-")
+	}
 	if len(input.Hostname) < 2 {
 		return input, httperrors.NewInputParameterError("the hostname length must be greater than or equal to 2")
 	}


### PR DESCRIPTION
Cherry pick of #18485 on release/3.10.

#18485: fix(region): avoid hostname has '-' suffix