### PR TITLE
fix: qemu disk set serial as disk_id

### DIFF
--- a/pkg/hostman/guestman/qemu/generate.go
+++ b/pkg/hostman/guestman/qemu/generate.go
@@ -326,6 +326,7 @@ func getDiskDeviceOption(optDrv QemuOptions, disk *desc.SGuestDisk) string {
 
 	var opt = ""
 	opt += GetDiskDeviceModel(diskDriver)
+	opt += fmt.Sprintf(",serial=%s", strings.ReplaceAll(disk.DiskId, "-", ""))
 	opt += fmt.Sprintf(",drive=drive_%d", diskIndex)
 	if diskDriver == DISK_DRIVER_VIRTIO {
 		// virtio-blk


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: qemu disk set serial as disk_id
Some software many require globally UNIQUE disk serial for license

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi 