### PR TITLE
Automated cherry pick of #18565: fix: qemu disk set serial as disk_id

### DIFF
--- a/pkg/hostman/guestman/qemu/generate.go
+++ b/pkg/hostman/guestman/qemu/generate.go
@@ -378,6 +378,7 @@ func getDiskDeviceOption(optDrv QemuOptions, disk api.GuestdiskJsonDesc, isArm b
 
 	var opt = ""
 	opt += GetDiskDeviceModel(diskDriver)
+	opt += fmt.Sprintf(",serial=%s", strings.ReplaceAll(disk.DiskId, "-", ""))
 	opt += fmt.Sprintf(",drive=drive_%d", diskIndex)
 	if diskDriver == DISK_DRIVER_VIRTIO {
 		// virtio-blk


### PR DESCRIPTION
Cherry pick of #18565 on release/3.9.

#18565: fix: qemu disk set serial as disk_id