### PR TITLE
feat(region,climc): add set-os-info api

### DIFF
--- a/cmd/climc/shell/compute/servers.go
+++ b/cmd/climc/shell/compute/servers.go
@@ -122,6 +122,7 @@ func init() {
 	cmd.Perform("reset-nic-traffic-limit", &options.ServerNicTrafficLimitOptions{})
 	cmd.Perform("set-nic-traffic-limit", &options.ServerNicTrafficLimitOptions{})
 	cmd.Perform("add-sub-ips", &options.ServerAddSubIpsOptions{})
+	cmd.BatchPerform("set-os-info", &options.ServerSetOSInfoOptions{})
 
 	cmd.Get("vnc", new(options.ServerVncOptions))
 	cmd.Get("desc", new(options.ServerIdOptions))

--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -1118,3 +1118,12 @@ type GuestPerformStartInput struct {
 	// 仅适用于KVM虚拟机
 	QemuVersion string `json:"qemu_version"`
 }
+
+type ServerSetOSInfoInput struct {
+	// OS type, e.g.: Linux, Windows
+	Type string `json:"type" help:"OS type, e.g.: Linux, Windows"`
+	// OS distribution, e.g.: CentOS, Ubuntu, Windows Server 2016 Datacenter
+	Distribution string `json:"distribution" help:"OS distribution, e.g.: CentOS, Ubuntu, Windows Server 2016 Datacenter"`
+	// OS version, e.g: 7.9, 22.04, 6.3
+	Version string `json:"version" help:"OS version, e.g.: 7.9, 22.04, 6.3"`
+}

--- a/pkg/compute/guestdrivers/base.go
+++ b/pkg/compute/guestdrivers/base.go
@@ -537,3 +537,7 @@ func (self *SBaseGuestDriver) RequestResetNicTrafficLimit(ctx context.Context, t
 func (self *SBaseGuestDriver) RequestSetNicTrafficLimit(ctx context.Context, task taskman.ITask, host *models.SHost, guest *models.SGuest, input []api.ServerNicTrafficLimit) error {
 	return httperrors.ErrNotImplemented
 }
+
+func (self *SBaseGuestDriver) ValidateSetOSInfo(ctx context.Context, userCred mcclient.TokenCredential, _ *models.SGuest, _ *api.ServerSetOSInfoInput) error {
+	return nil
+}

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -1371,3 +1371,7 @@ func (self *SManagedVirtualizedGuestDriver) RequestRemoteUpdate(ctx context.Cont
 
 	return nil
 }
+
+func (self *SManagedVirtualizedGuestDriver) ValidateSetOSInfo(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, input *api.ServerSetOSInfoInput) error {
+	return httperrors.NewNotAcceptableError("%s server doesn't allow to set OS info", guest.Hypervisor)
+}

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -241,6 +241,8 @@ type IGuestDriver interface {
 	FetchMonitorUrl(ctx context.Context, guest *SGuest) string
 	RequestResetNicTrafficLimit(ctx context.Context, task taskman.ITask, host *SHost, guest *SGuest, input []api.ServerNicTrafficLimit) error
 	RequestSetNicTrafficLimit(ctx context.Context, task taskman.ITask, host *SHost, guest *SGuest, input []api.ServerNicTrafficLimit) error
+
+	ValidateSetOSInfo(ctx context.Context, userCred mcclient.TokenCredential, guest *SGuest, input *api.ServerSetOSInfoInput) error
 }
 
 var guestDrivers map[string]IGuestDriver

--- a/pkg/mcclient/options/compute/servers.go
+++ b/pkg/mcclient/options/compute/servers.go
@@ -1474,3 +1474,13 @@ type ServerAddSubIpsOptions struct {
 func (o *ServerAddSubIpsOptions) Params() (jsonutils.JSONObject, error) {
 	return jsonutils.Marshal(o), nil
 }
+
+type ServerSetOSInfoOptions struct {
+	ServerIdsOptions
+
+	computeapi.ServerSetOSInfoInput
+}
+
+func (o *ServerSetOSInfoOptions) Params() (jsonutils.JSONObject, error) {
+	return jsonutils.Marshal(o), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

```bash
# 使用方法
climc --debug server-set-os-info --type Linux --version 18.04.3 --distribution Ubuntu  <server_id1> <server_id2>
```

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.10
/area region climc
/cc @swordqiu @ioito 