### PR TITLE
fix: windows GPU vm should set hypervisor=off 3.9

### DIFF
--- a/pkg/hostman/guestman/qemu/qemu.go
+++ b/pkg/hostman/guestman/qemu/qemu.go
@@ -388,6 +388,9 @@ func (o *baseOptions_x86_64) CPU(input CPUOption, osName string) (string, string
 		} else if input.IsCPUAMD {
 			vendor = "AuthenticAMD"
 		}
+		if len(input.IsolatedDeviceCPU) > 0 {
+			input.HostCPUPassthrough = true
+		}
 		accel = "kvm"
 		cpuType = ""
 		if osName == OS_NAME_MACOS {
@@ -415,15 +418,14 @@ func (o *baseOptions_x86_64) CPU(input CPUOption, osName string) (string, string
 			}
 		}
 
-		if !input.EnableNested {
-			cpuType += ",kvm=off"
-		}
-
 		if len(input.IsolatedDeviceCPU) > 0 {
-			cpuType = input.IsolatedDeviceCPU
-			if len(vendor) > 0 {
-				cpuType += fmt.Sprintf(",vendor=%s", vendor)
+			if osName == OS_NAME_WINDOWS {
+				cpuType += ",hypervisor=off"
+			} else {
+				cpuType += ",kvm=off"
 			}
+		} else if !input.EnableNested {
+			cpuType += ",kvm=off"
 		}
 	} else {
 		accel = "tcg"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: windows GPU vm should set hypervisor=off

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 