### PR TITLE
Automated cherry pick of #18682: fix: make host dhcp lease options global

### DIFF
--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -27,6 +27,9 @@ type SHostBaseOptions struct {
 	ManageNtpConfiguration bool `default:"true"`
 
 	DisableSecurityGroup bool `help:"disable security group" default:"false"`
+
+	DhcpLeaseTime   int `default:"100663296" help:"DHCP lease time in seconds"`
+	DhcpRenewalTime int `default:"67108864" help:"DHCP renewal time in seconds"`
 }
 
 type SHostOptions struct {
@@ -86,9 +89,7 @@ type SHostOptions struct {
 
 	DefaultQemuVersion string `help:"Default qemu version" default:"2.12.1"`
 
-	DhcpRelay       []string `help:"DHCP relay upstream"`
-	DhcpLeaseTime   int      `default:"100663296" help:"DHCP lease time in seconds"`
-	DhcpRenewalTime int      `default:"67108864" help:"DHCP renewal time in seconds"`
+	DhcpRelay []string `help:"DHCP relay upstream"`
 
 	TunnelPaddingBytes int64 `help:"Specify tunnel padding bytes" default:"0"`
 


### PR DESCRIPTION
Cherry pick of #18682 on release/3.8.

#18682: fix: make host dhcp lease options global