### PR TITLE
fix(region): rds skip notImplementedErr

### DIFF
--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -2411,7 +2411,7 @@ func (self *SManagedVirtualizationRegionDriver) RequestRemoteUpdateDBInstance(ct
 
 		err = iRds.Update(ctx, cloudprovider.SDBInstanceUpdateOptions{NAME: instance.Name, Description: instance.Description})
 		if err != nil {
-			if errors.Cause(err) != cloudprovider.ErrNotSupported {
+			if errors.Cause(err) != cloudprovider.ErrNotSupported || errors.Cause(err) != cloudprovider.ErrNotImplemented {
 				return nil, errors.Wrap(err, "iRds.Update")
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

ignore notImplementedErr for rds.Update

**Does this PR need to be backport to the previous release branch?**:

If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

/cc @ioito 