### PR TITLE
Automated cherry pick of #18718: fix(climc): bash completion is not working

### DIFF
--- a/build/climc/root/opt/yunion/scripts/motd/climc.sh
+++ b/build/climc/root/opt/yunion/scripts/motd/climc.sh
@@ -1,8 +1,13 @@
 export PATH=/opt/yunion/bin:$PATH
 
+if [ -f /etc/profile.d/bash_completion.sh ]; then
+    source /etc/profile.d/bash_completion.sh
+fi
+
 test -f /etc/yunion/rcadmin && source /etc/yunion/rcadmin
 
 source <(climc --completion bash)
+source <(kubectl completion bash)
 
 echo "Welcome to Cloud Shell :-) You may execute climc and other command tools in this shell."
 echo "Please exec 'climc' to get started"


### PR DESCRIPTION
Cherry pick of #18718 on release/3.11.

#18718: fix(climc): bash completion is not working