### PR TITLE
fix(github-action): set issue close inactive-day to 7

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -12,8 +12,8 @@ jobs:
         uses: actions-cool/issues-helper@v2
         with:
           actions: 'close-issues'
-          labels: 'state/awaiting user feedback'
-          inactive-day: 37
+          labels: 'stale,state/awaiting user feedback'
+          inactive-day: 7
           body: |
             If you do not provide feedback for more than 37 days, we will close the issue and you can either reopen it or submit a new issue.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
NONE