### PR TITLE
feat(host): use IsolatedDeviceModels as GPU whitelist

### DIFF
--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -149,7 +149,8 @@ type HostCommonOptions struct {
 
 	EnableRemoteExecutor bool `help:"Enable remote executor" default:"false"`
 
-	ExecutorConnectTimeoutSeconds int `help:"executor client connection timeout in seconds, default is 30" default:"30"`
+	ExecutorConnectTimeoutSeconds int  `help:"executor client connection timeout in seconds, default is 30" default:"30"`
+	EnableIsolatedDeviceWhitelist bool `help:"enable isolated device white list" default:"false"`
 }
 
 type DBOptions struct {

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -2057,6 +2057,8 @@ func (h *SHostInfo) probeSyncIsolatedDevices() (*jsonutils.JSONArray, error) {
 		}
 	}
 
+	enableDevWhitelist := options.HostOptions.EnableIsolatedDeviceWhitelist
+
 	offloadNics, err := h.getNicsOvsOffloadInterfaces(options.HostOptions.OvsOffloadNics)
 	if err != nil {
 		return nil, err
@@ -2065,7 +2067,7 @@ func (h *SHostInfo) probeSyncIsolatedDevices() (*jsonutils.JSONArray, error) {
 	h.IsolatedDeviceMan.ProbePCIDevices(
 		options.HostOptions.DisableGPU, options.HostOptions.DisableUSB, options.HostOptions.DisableCustomDevice,
 		sriovNics, offloadNics, options.HostOptions.PTNVMEConfigs, options.HostOptions.AMDVgpuPFs, options.HostOptions.NVIDIAVgpuPFs,
-	)
+		enableDevWhitelist)
 
 	objs, err := h.getRemoteIsolatedDevices()
 	if err != nil {

--- a/pkg/hostman/isolated_device/isolated_device.go
+++ b/pkg/hostman/isolated_device/isolated_device.go
@@ -110,7 +110,7 @@ type IsolatedDeviceManager interface {
 	GetDevices() []IDevice
 	GetDeviceByIdent(vendorDevId, addr, mdevId string) IDevice
 	GetDeviceByAddr(addr string) IDevice
-	ProbePCIDevices(skipGPUs, skipUSBs, skipCustomDevs bool, sriovNics, ovsOffloadNics []HostNic, nvmePciDisks, amdVgpuPFs, nvidiaVgpuPFs []string)
+	ProbePCIDevices(skipGPUs, skipUSBs, skipCustomDevs bool, sriovNics, ovsOffloadNics []HostNic, nvmePciDisks, amdVgpuPFs, nvidiaVgpuPFs []string, enableWhitelist bool)
 	StartDetachTask()
 	BatchCustomProbe()
 	AppendDetachedDevice(dev *CloudDeviceInfo)
@@ -137,7 +137,7 @@ func (man *isolatedDeviceManager) GetDevices() []IDevice {
 	return man.devices
 }
 
-func (man *isolatedDeviceManager) probeGPUS(skipGPUs bool, amdVgpuPFs, nvidiaVgpuPFs []string) {
+func (man *isolatedDeviceManager) probeGPUS(skipGPUs bool, amdVgpuPFs, nvidiaVgpuPFs []string, enableWhitelist bool, whitelistModels []IsolatedDeviceModel) {
 	if skipGPUs {
 		return
 	}
@@ -148,10 +148,10 @@ func (man *isolatedDeviceManager) probeGPUS(skipGPUs bool, amdVgpuPFs, nvidiaVgp
 		filteredAddrs = append(filteredAddrs, man.devices[i].GetAddr())
 	}
 
-	gpus, err, warns := getPassthroughGPUs(filteredAddrs)
+	gpus, err, warns := getPassthroughGPUs(filteredAddrs, enableWhitelist, whitelistModels)
 	if err != nil {
 		// ignore getPassthroughGPUS error on old machines without VGA devices
-		log.Errorf("getPassthroughGPUS: %v", err)
+		log.Errorf("getPassthroughGPUS error: %v", err)
 		man.host.AppendError(fmt.Sprintf("get passhtrough gpus %s", err.Error()), "isolated_devices", "", " ")
 	} else {
 		if len(warns) > 0 {
@@ -166,26 +166,20 @@ func (man *isolatedDeviceManager) probeGPUS(skipGPUs bool, amdVgpuPFs, nvidiaVgp
 	}
 }
 
-func (man *isolatedDeviceManager) probeCustomPCIDevs(skipCustomDevs bool) {
+func (man *isolatedDeviceManager) probeCustomPCIDevs(skipCustomDevs bool, devModels []IsolatedDeviceModel, filterClassCodes []string) {
 	if skipCustomDevs {
 		return
 	}
-	devModels, err := man.getCustomIsolatedDeviceModels()
-	if err != nil {
-		log.Errorf("get custom isolated device models %s", err.Error())
-		man.host.AppendError(fmt.Sprintf("get custom isolated device models %s", err.Error()), "isolated_devices", "", "")
-	} else {
-		for _, devModel := range devModels {
-			devs, err := getPassthroughPCIDevs(devModel)
-			if err != nil {
-				log.Errorf("getPassthroughPCIDevs %v: %s", devModel, err)
-				man.host.AppendError(fmt.Sprintf("get custom passthrough pci devices %s", err.Error()), "isolated_devices", "", "")
-				continue
-			}
-			for i, dev := range devs {
-				man.devices = append(man.devices, dev)
-				log.Infof("Add general pci device: %d => %#v", i, dev)
-			}
+	for _, devModel := range devModels {
+		devs, err := getPassthroughPCIDevs(devModel, filterClassCodes)
+		if err != nil {
+			log.Errorf("getPassthroughPCIDevs %v: %s", devModel, err)
+			man.host.AppendError(fmt.Sprintf("get custom passthrough pci devices %s", err.Error()), "isolated_devices", "", "")
+			continue
+		}
+		for i, dev := range devs {
+			man.devices = append(man.devices, dev)
+			log.Infof("Add general pci device: %d => %#v", i, dev)
 		}
 	}
 }
@@ -306,19 +300,21 @@ func (man *isolatedDeviceManager) probeNVIDIAVgpus(nvidiaVgpuPFs []string) {
 	}
 }
 
-func (man *isolatedDeviceManager) ProbePCIDevices(
-	skipGPUs, skipUSBs, skipCustomDevs bool,
-	sriovNics, ovsOffloadNics []HostNic,
-	nvmePciDisks, amdVgpuPFs, nvidiaVgpuPFs []string,
-) {
+func (man *isolatedDeviceManager) ProbePCIDevices(skipGPUs, skipUSBs, skipCustomDevs bool, sriovNics, ovsOffloadNics []HostNic, nvmePciDisks, amdVgpuPFs, nvidiaVgpuPFs []string, enableWhitelist bool) {
 	man.devices = make([]IDevice, 0)
+	devModels, err := man.getCustomIsolatedDeviceModels()
+	if err != nil {
+		log.Errorf("get isolated device devModels %s", err.Error())
+		man.host.AppendError(fmt.Sprintf("get custom isolated device devModels %s", err.Error()), "isolated_devices", "", "")
+		return
+	}
 	man.probeUSBs(skipUSBs)
-	man.probeCustomPCIDevs(skipCustomDevs)
+	man.probeCustomPCIDevs(skipCustomDevs, devModels, GpuClassCodes)
 	man.probeSRIOVNics(sriovNics)
 	man.probeOffloadNICS(ovsOffloadNics)
 	man.probeAMDVgpus(amdVgpuPFs)
 	man.probeNVIDIAVgpus(nvidiaVgpuPFs)
-	man.probeGPUS(skipGPUs, amdVgpuPFs, nvidiaVgpuPFs)
+	man.probeGPUS(skipGPUs, amdVgpuPFs, nvidiaVgpuPFs, enableWhitelist, devModels)
 }
 
 type IsolatedDeviceModel struct {
@@ -335,7 +331,7 @@ func (man *isolatedDeviceManager) getCustomIsolatedDeviceModels() ([]IsolatedDev
 	params.Set("scope", jsonutils.NewString("system"))
 	res, err := modules.IsolatedDeviceModels.List(man.getSession(), jsonutils.NewDict())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "list isolated_device_models from compute service")
 	}
 	devModels := make([]IsolatedDeviceModel, len(res.Data))
 	for i, obj := range res.Data {


### PR DESCRIPTION
**What this PR does / why we need it**:

实现透传设备白名单功能，用法如下：

```bash
kubectl edit configmaps -n onecloud default-host
```

```yaml
# add
    enable_isolated_device_whitelist: true
```

```bash
kubectl rollout restart ds -n onecloud default-host
```

```bash
# 如果没有对应的 vendor device id 的 isolated-device-model ，就会过滤掉
climc isolated-device-list
```

先用下面的命令查找需要注册的设备的 vendor device id
```bash
$ lspci  -nnvv | grep -i nvidia
```
输出里面的 10de 为  vendor_id ，对应 NVIDIA，1b06 对应的是 device_id ，对应这张显卡的型号
> 42:00.0 VGA compatible controller [0300]: NVIDIA Corporation GP102 [GeForce GTX 1080 Ti] `[10de:1b06]` (rev a1) (prog-if 00 [VGA controller])
>        Subsystem: NVIDIA Corporation Device [10de:120f]


```bash
# 比如要开启 1080Ti 的白名单，先创建 device model
climc isolated-device-model-create 'GeForce GTX 1080 Ti' GPU 10de 1b06

# 再重启 host 就可以看到对应设备了
```


<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.11
/area host
/cc @swordqiu @wanyaoqi 
