### PR TITLE
fix: customized show content of get-property

### DIFF
--- a/cmd/climc/shell/helper.go
+++ b/cmd/climc/shell/helper.go
@@ -229,7 +229,7 @@ type IPropertyOpt interface {
 	Property() string
 }
 
-func (cmd ResourceCmd) GetProperty(args IPropertyOpt) {
+func (cmd ResourceCmd) GetPropertyWithShowFunc(args IPropertyOpt, showFunc func(jsonutils.JSONObject) error) {
 	man := cmd.manager
 	callback := func(s *mcclient.ClientSession, args IPropertyOpt) error {
 		params, err := args.Params()
@@ -240,6 +240,17 @@ func (cmd ResourceCmd) GetProperty(args IPropertyOpt) {
 		if err != nil {
 			return err
 		}
+		err = showFunc(ret)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	cmd.RunWithDesc(args.Property(), fmt.Sprintf("Get property of a %s", man.GetKeyword()), args, callback)
+}
+
+func (cmd ResourceCmd) GetProperty(args IPropertyOpt) {
+	cmd.GetPropertyWithShowFunc(args, func(ret jsonutils.JSONObject) error {
 		if _, ok := ret.(*jsonutils.JSONArray); ok {
 			data, _ := ret.GetArray()
 			PrintList(&printutils.ListResult{
@@ -249,8 +260,7 @@ func (cmd ResourceCmd) GetProperty(args IPropertyOpt) {
 			PrintObject(ret)
 		}
 		return nil
-	}
-	cmd.RunWithDesc(args.Property(), fmt.Sprintf("Get property of a %s", man.GetKeyword()), args, callback)
+	})
 }
 
 func (cmd ResourceCmd) Show(args IShowOpt) {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: customized show content of get-property
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 