### PR TITLE
Automated cherry pick of #18874: fix(host-deployer): qemu deployer without kvm support

### DIFF
--- a/pkg/hostman/diskutils/qemu_kvm/driver.go
+++ b/pkg/hostman/diskutils/qemu_kvm/driver.go
@@ -467,9 +467,10 @@ func (d *QemuX86Driver) StartGuest(sshPort, ncpu, memSizeMB int, hugePage bool, 
 	cmd := QEMU_KVM_PATH
 	if sysutils.IsKvmSupport() {
 		cmd += __("-enable-kvm")
+		cmd += __("-cpu host")
+	} else {
+		cmd += __("-cpu max")
 	}
-
-	cmd += __("-cpu host")
 	cmd += __("-M pc")
 
 	d.pidPath = fmt.Sprintf("/tmp/%s.pid", uuid)
@@ -560,9 +561,10 @@ func (d *QemuARMDriver) StartGuest(sshPort, ncpu, memSizeMB int, hugePage bool, 
 	cmd := QEMU_KVM_PATH
 	if sysutils.IsKvmSupport() {
 		cmd += __("-enable-kvm")
+		cmd += __("-cpu host")
+	} else {
+		cmd += __("-cpu max")
 	}
-
-	cmd += __("-cpu host")
 	cmd += __("-M virt")
 
 	d.pidPath = fmt.Sprintf("/tmp/%s.pid", uuid)

--- a/pkg/hostman/hostdeployer/deployserver/deployserver.go
+++ b/pkg/hostman/hostdeployer/deployserver/deployserver.go
@@ -94,11 +94,11 @@ func (*DeployerServer) DeployGuestFs(ctx context.Context, req *deployapi.DeployP
 	}
 	defer disk.Cleanup()
 
+	defer disk.Disconnect()
 	if err := disk.Connect(req.GuestDesc); err != nil {
 		log.Errorf("Failed to connect %s disk: %s", req.GuestDesc.Hypervisor, err)
 		return new(deployapi.DeployGuestFsResponse), errors.Wrap(err, "Connect")
 	}
-	defer disk.Disconnect()
 
 	ret, err := disk.DeployGuestfs(req)
 	if ret == nil {
@@ -132,10 +132,11 @@ func (*DeployerServer) ResizeFs(ctx context.Context, req *deployapi.ResizeFsPara
 		return new(deployapi.Empty), errors.Wrap(err, "GetIDisk fail")
 	}
 	defer disk.Cleanup()
+
+	defer disk.Disconnect()
 	if err := disk.Connect(nil); err != nil {
 		return new(deployapi.Empty), errors.Wrap(err, "disk connect failed")
 	}
-	defer disk.Disconnect()
 
 	return disk.ResizeFs()
 }


### PR DESCRIPTION
Cherry pick of #18874 on release/3.10.

#18874: fix(host-deployer): qemu deployer without kvm support