### PR TITLE
fix: clickhouse mapping table use the same name as origin

### DIFF
--- a/pkg/cloudcommon/db/modelbase.go
+++ b/pkg/cloudcommon/db/modelbase.go
@@ -86,7 +86,7 @@ func NewModelBaseManagerWithSplitableDBName(model interface{}, tableName string,
 	return modelMan
 }
 
-func NewModelBaseManagerWithClickhouseMapping(manager IModelManager, tblname, keyword, keywordPlural string) SModelBaseManager {
+func NewModelBaseManagerWithClickhouseMapping(manager IModelManager, keyword, keywordPlural string) SModelBaseManager {
 	ots := manager.TableSpec()
 	var extraOpts sqlchemy.TableExtraOptions
 	switch consts.DefaultDBDialect() {
@@ -100,7 +100,7 @@ func NewModelBaseManagerWithClickhouseMapping(manager IModelManager, tblname, ke
 	default:
 		panic(fmt.Sprintf("unsupport dialect %s to be backend of clickhouse", consts.DefaultDBDialect()))
 	}
-	nts := newClickhouseTableSpecFromMySQL(ots, tblname, ClickhouseDB, extraOpts)
+	nts := newClickhouseTableSpecFromMySQL(ots, ots.Name(), ClickhouseDB, extraOpts)
 	modelMan := SModelBaseManager{
 		tableSpec:     nts,
 		keyword:       keyword,


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: clickhouse mapping table use the same name as origin

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 