### PR TITLE
fix(util): fixed yunion.io/x/sqlchemy version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,8 @@ GOPROXY ?= direct
 
 mod:
 	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go get -d yunion.io/x/cloudmux@$(RELEASE_BRANCH)
-	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go get -d $(patsubst %,%@master,$(shell GO111MODULE=on go mod edit -print  | sed -n -e 's|.*\(yunion.io/x/[a-z].*\) v.*|\1|p' | grep -v '/cloudmux$$'))
+	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go get -d yunion.io/x/sqlchemy@v1.1.2
+	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go get -d $(patsubst %,%@master,$(shell GO111MODULE=on go mod edit -print  | sed -n -e 's|.*\(yunion.io/x/[a-z].*\) v.*|\1|p' | egrep -v '/cloudmux$$|sqlchemy'))
 	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go mod tidy
 	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go mod vendor -v
 

--- a/go.mod
+++ b/go.mod
@@ -89,14 +89,14 @@ require (
 	k8s.io/client-go v0.19.3
 	k8s.io/cluster-bootstrap v0.19.3
 	moul.io/http2curl/v2 v2.3.0
-	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231204065542-fd7a110fdf83
+	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231204130454-2f77e6e2ee90
 	yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32
 	yunion.io/x/jsonutils v1.0.1-0.20230613121553-0f3b41e2ef19
 	yunion.io/x/log v1.0.1-0.20230411060016-feb3f46ab361
 	yunion.io/x/ovsdb v0.0.0-20230306173834-f164f413a900
 	yunion.io/x/pkg v1.0.1-0.20231101105448-abef64cdc142
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
-	yunion.io/x/sqlchemy v1.1.2-0.20231201052514-97026b18ccf0
+	yunion.io/x/sqlchemy v1.1.2
 	yunion.io/x/structarg v0.0.0-20231017124457-df4d5009457c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1195,8 +1195,8 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231204065542-fd7a110fdf83 h1:GtC/WeDI2/9aTq1tw5ZlZKFdnKOuUuDGXo6ux7fT+fU=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231204065542-fd7a110fdf83/go.mod h1:2sgCN7nRPQL3woLfdgqLDd92vwAHqtlz3KKiHxC5BAw=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231204130454-2f77e6e2ee90 h1:PvDll2WcCBwkZ6TeoM6muG9xdycoXklYhgBZi0UPDWI=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231204130454-2f77e6e2ee90/go.mod h1:2sgCN7nRPQL3woLfdgqLDd92vwAHqtlz3KKiHxC5BAw=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32 h1:v7POYkQwo1XzOxBoIoRVr/k0V9Y5JyjpshlIFa9raug=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32/go.mod h1:Uxuou9WQIeJXNpy7t2fPLL0BYLvLiMvGQwY7Qc6aSws=
 yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH3WE/H1BjUQdFiWu50JGCFQuuy+Z634=
@@ -1214,7 +1214,7 @@ yunion.io/x/pkg v1.0.1-0.20231101105448-abef64cdc142 h1:L6LqxfP08eWUx+A6yQdrL6VB
 yunion.io/x/pkg v1.0.1-0.20231101105448-abef64cdc142/go.mod h1:ksCJVQ+DwKrJ5QBEoU8pzrDFfDaZVAFH/iJ6yQCYxJk=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
-yunion.io/x/sqlchemy v1.1.2-0.20231201052514-97026b18ccf0 h1:+MaykFV6YCakTLnHR3v31tovXhkvWgkBPFa83MuCekA=
-yunion.io/x/sqlchemy v1.1.2-0.20231201052514-97026b18ccf0/go.mod h1:uuPVZEyEq3sWd5vf9VjGSy6lZzof22X87OEHw9sddJQ=
+yunion.io/x/sqlchemy v1.1.2 h1:h44E1ZO3bwiObXZsnCNSTRgXc9xSV86CWINUMs0qDVE=
+yunion.io/x/sqlchemy v1.1.2/go.mod h1:uuPVZEyEq3sWd5vf9VjGSy6lZzof22X87OEHw9sddJQ=
 yunion.io/x/structarg v0.0.0-20231017124457-df4d5009457c h1:QuLab2kSRECZRxo4Lo2KcYn6XjQFDGaZ1+x0pYDVVwQ=
 yunion.io/x/structarg v0.0.0-20231017124457-df4d5009457c/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1473,7 +1473,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231204065542-fd7a110fdf83
+# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231204130454-2f77e6e2ee90
 ## explicit; go 1.18
 yunion.io/x/cloudmux/pkg/apis
 yunion.io/x/cloudmux/pkg/apis/billing
@@ -1619,7 +1619,7 @@ yunion.io/x/pkg/utils
 # yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 ## explicit; go 1.12
 yunion.io/x/s3cli
-# yunion.io/x/sqlchemy v1.1.2-0.20231201052514-97026b18ccf0
+# yunion.io/x/sqlchemy v1.1.2
 ## explicit; go 1.17
 yunion.io/x/sqlchemy
 yunion.io/x/sqlchemy/backends

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/apsara/apsara.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/apsara/apsara.go
@@ -262,6 +262,9 @@ func (self *SApsaraClient) getDefaultClient(regionId string) (*sdk.Client, error
 					return nil, errors.Wrapf(err, "ParseQuery(%s)", req.URL.RawQuery)
 				}
 				action := params.Get("OpenApiAction")
+				if len(action) == 0 {
+					action = params.Get("Action")
+				}
 				service := strings.ToLower(params.Get("Product"))
 				respCheck := func(resp *http.Response) {
 					if self.cpcfg.UpdatePermission != nil {
@@ -287,7 +290,7 @@ func (self *SApsaraClient) getDefaultClient(regionId string) (*sdk.Client, error
 						}
 					}
 				}
-				if self.cpcfg.ReadOnly {
+				if self.cpcfg.ReadOnly && len(action) > 0 {
 					for _, prefix := range []string{"Get", "List", "Describe"} {
 						if strings.HasPrefix(action, prefix) {
 							return respCheck, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

固定 sqlchemy 版本号，不然每次更新 master 分支代码会导致不兼容。

```bash
$ make
build ./cmd/yunionapi
# yunion.io/x/onecloud/pkg/util/splitable
vendor/yunion.io/x/onecloud/pkg/util/splitable/splitable.go:93:35: cannot use t (variable of type *SSplitTableSpec) as sqlchemy.ITableSpec value in argument to sqlchemy.NewTableInstance: *SSplitTableSpec does not implement sqlchemy.ITableSpec (missing method GetExtraOptions)
```

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.10 only
/cc @swordqiu 
/area util