### PR TITLE
Automated cherry pick of #18912: fix: guacd docker file mkdir required dir

### DIFF
--- a/build/docker/Dockerfile.guacd
+++ b/build/docker/Dockerfile.guacd
@@ -197,6 +197,8 @@ ARG UID=1000
 ARG GID=1000
 RUN groupadd --gid $GID guacd
 RUN useradd --system --create-home --shell /sbin/nologin --uid $UID --gid $GID guacd
+RUN mkdir -p /opt/cloudpods
+RUN chown -R guacd:guacd /opt/cloudpods
 
 # Run with user guacd
 USER guacd


### PR DESCRIPTION
Cherry pick of #18912 on release/3.11.

#18912: fix: guacd docker file mkdir required dir