### PR TITLE
Automated cherry pick of #18985: fix: backup storage capacity_mb field optional

### DIFF
--- a/pkg/compute/models/backup_storage.go
+++ b/pkg/compute/models/backup_storage.go
@@ -42,7 +42,8 @@ type SBackupStorage struct {
 
 	AccessInfo  *api.SBackupStorageAccessInfo
 	StorageType api.TBackupStorageType `width:"32" charset:"ascii" nullable:"false" list:"user" create:"domain_required"`
-	CapacityMb  int                    `nullable:"false" list:"user" update:"domain" create:"domain_required"`
+
+	CapacityMb int `nullable:"false" list:"user" update:"domain" create:"domain_optional"`
 }
 
 var BackupStorageManager *SBackupStorageManager


### PR DESCRIPTION
Cherry pick of #18985 on release/3.11.

#18985: fix: backup storage capacity_mb field optional