### PR TITLE
Automated cherry pick of #18987: fix(region): set status available for kvm secgroup rule after created

### DIFF
--- a/pkg/compute/models/secgrouprules.go
+++ b/pkg/compute/models/secgrouprules.go
@@ -371,6 +371,7 @@ func (self *SSecurityGroupRule) PostCreate(ctx context.Context, userCred mcclien
 	if secgroup, _ := self.GetSecGroup(); secgroup != nil {
 		logclient.AddSimpleActionLog(secgroup, logclient.ACT_ALLOCATE, data, userCred, true)
 		if len(secgroup.ManagerId) == 0 {
+			self.SetStatus(userCred, apis.STATUS_AVAILABLE, "")
 			secgroup.DoSync(ctx, userCred)
 			return
 		}


### PR DESCRIPTION
Cherry pick of #18987 on release/3.11.

#18987: fix(region): set status available for kvm secgroup rule after created