### PR TITLE
Automated cherry pick of #19003: fix(cloudcommon): service config informer doesn't start watching

### DIFF
--- a/pkg/cloudcommon/options/manager.go
+++ b/pkg/cloudcommon/options/manager.go
@@ -60,12 +60,12 @@ func StartOptionManager(option interface{}, refreshSeconds int, serviceType, ser
 }
 
 func StartOptionManagerWithSessionDriver(options interface{}, refreshSeconds int, serviceType, serviceVersion string, onChange TOptionsChangeFunc, session IServiceConfigSession) {
-	log.Infof("OptionManager start to fetch service configs ...")
 	if refreshSeconds <= MIN_REFRESH_INTERVAL_SECONDS {
 		// a minimal 30 seconds refresh interval
 		refreshSeconds = MIN_REFRESH_INTERVAL_SECONDS
 	}
 	refreshInterval := time.Duration(refreshSeconds) * time.Second
+	log.Infof("OptionManager start to fetch service configs with interval %s ...", refreshInterval)
 	OptionManager = &SOptionManager{
 		serviceType:     serviceType,
 		serviceVersion:  serviceVersion,
@@ -77,7 +77,9 @@ func StartOptionManagerWithSessionDriver(options interface{}, refreshSeconds int
 
 	OptionManager.InitSync(OptionManager)
 
-	OptionManager.FirstSync()
+	if err := OptionManager.FirstSync(); err != nil {
+		log.Errorf("OptionManager.FirstSync error: %v", err)
+	}
 
 	if session.IsRemote() {
 		var opts *CommonOptions

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -137,7 +137,7 @@ type CommonOptions struct {
 
 	TenantCacheExpireSeconds int `help:"expire seconds of cached tenant/domain info. defailt 15 minutes" default:"900"`
 
-	SessionEndpointType string `help:"Client session end point type"`
+	SessionEndpointType string `help:"Client session end point type" default:"internal"`
 
 	BaseOptions
 }


### PR DESCRIPTION
Cherry pick of #19003 on release/3.11.

#19003: fix(cloudcommon): service config informer doesn't start watching