### PR TITLE
Automated cherry pick of #19015: fix(region): do not clean up the running vm in the recycle bin

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -5549,6 +5549,13 @@ func (manager *SGuestManager) CleanPendingDeleteServers(ctx context.Context, use
 			DeleteEip:             options.Options.DeleteEipExpiredRelease,
 			DeleteDisks:           options.Options.DeleteDisksExpiredRelease,
 		}
+		// 跳过单独在云上开机过的虚拟机，避免误清理
+		if len(guests[i].GetExternalId()) > 0 {
+			iVm, err := guests[i].GetIVM(ctx)
+			if err == nil && iVm.GetStatus() == api.VM_RUNNING {
+				continue
+			}
+		}
 		guests[i].StartDeleteGuestTask(ctx, userCred, "", opts)
 	}
 }


### PR DESCRIPTION
Cherry pick of #19015 on release/3.11.

#19015: fix(region): do not clean up the running vm in the recycle bin