### PR TITLE
Automated cherry pick of #19051: fix(region): avoid rds vcpu count is zero

### DIFF
--- a/pkg/compute/models/dbinstances.go
+++ b/pkg/compute/models/dbinstances.go
@@ -1673,8 +1673,21 @@ func (self *SDBInstance) SyncWithCloudDBInstance(ctx context.Context, userCred m
 		self.Engine = ext.GetEngine()
 		self.EngineVersion = ext.GetEngineVersion()
 		self.InstanceType = ext.GetInstanceType()
-		self.VcpuCount = ext.GetVcpuCount()
-		self.VmemSizeMb = ext.GetVmemSizeMB()
+		cpu := ext.GetVcpuCount()
+		mem := ext.GetVmemSizeMB()
+		if (cpu == 0 || mem == 0) && len(self.InstanceType) > 0 {
+			skus, _ := self.GetAvailableDBInstanceSkus(true)
+			for _, sku := range skus {
+				cpu, mem = sku.VcpuCount, sku.VmemSizeMb
+				break
+			}
+		}
+		if cpu > 0 {
+			self.VcpuCount = cpu
+		}
+		if mem > 0 {
+			self.VmemSizeMb = mem
+		}
 		self.DiskSizeGB = ext.GetDiskSizeGB()
 		self.DiskSizeUsedMB = ext.GetDiskSizeUsedMB()
 		self.StorageType = ext.GetStorageType()


### PR DESCRIPTION
Cherry pick of #19051 on release/3.11.

#19051: fix(region): avoid rds vcpu count is zero