### PR TITLE
Automated cherry pick of #19061: fix(region): vendor update for volcengine network and aws dnsrecords sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,14 +88,14 @@ require (
 	k8s.io/client-go v0.19.3
 	k8s.io/cluster-bootstrap v0.19.3
 	moul.io/http2curl/v2 v2.3.0
-	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231219063429-4e0c70548d7b
+	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231220031827-28bfe13ab842
 	yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32
 	yunion.io/x/jsonutils v1.0.1-0.20230613121553-0f3b41e2ef19
 	yunion.io/x/log v1.0.1-0.20230411060016-feb3f46ab361
 	yunion.io/x/ovsdb v0.0.0-20230306173834-f164f413a900
 	yunion.io/x/pkg v1.0.1-0.20231101105448-abef64cdc142
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
-	yunion.io/x/sqlchemy v1.1.3-0.20231214015103-7a6c11418079
+	yunion.io/x/sqlchemy v1.1.3-0.20231219103237-8264e6ead2fc
 	yunion.io/x/structarg v0.0.0-20231017124457-df4d5009457c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1201,8 +1201,8 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231219063429-4e0c70548d7b h1:NH2QqBfEwpjxbS5Yvtnh/hTyGzVkMafDyiwJ0QX1ry0=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231219063429-4e0c70548d7b/go.mod h1:aj1gR9PPb6eqqKOwvANe26CoZFY8ydmXy0fuvgKYXH0=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231220031827-28bfe13ab842 h1:4AjLgwOnaAexsd+nrUodqg4m6cm4sB+HaA9deBkd9Tc=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231220031827-28bfe13ab842/go.mod h1:aj1gR9PPb6eqqKOwvANe26CoZFY8ydmXy0fuvgKYXH0=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32 h1:v7POYkQwo1XzOxBoIoRVr/k0V9Y5JyjpshlIFa9raug=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32/go.mod h1:Uxuou9WQIeJXNpy7t2fPLL0BYLvLiMvGQwY7Qc6aSws=
 yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH3WE/H1BjUQdFiWu50JGCFQuuy+Z634=
@@ -1220,7 +1220,7 @@ yunion.io/x/pkg v1.0.1-0.20231101105448-abef64cdc142 h1:L6LqxfP08eWUx+A6yQdrL6VB
 yunion.io/x/pkg v1.0.1-0.20231101105448-abef64cdc142/go.mod h1:ksCJVQ+DwKrJ5QBEoU8pzrDFfDaZVAFH/iJ6yQCYxJk=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
-yunion.io/x/sqlchemy v1.1.3-0.20231214015103-7a6c11418079 h1:NuDsQqqX13BjYkjZnPqZM32eQmjhtksM1H6b+g5TR2Y=
-yunion.io/x/sqlchemy v1.1.3-0.20231214015103-7a6c11418079/go.mod h1:uuPVZEyEq3sWd5vf9VjGSy6lZzof22X87OEHw9sddJQ=
+yunion.io/x/sqlchemy v1.1.3-0.20231219103237-8264e6ead2fc h1:CVg5BdiSrw8yaxT2bpTiu63JHuHKDgjaDHI3zVDT1gY=
+yunion.io/x/sqlchemy v1.1.3-0.20231219103237-8264e6ead2fc/go.mod h1:uuPVZEyEq3sWd5vf9VjGSy6lZzof22X87OEHw9sddJQ=
 yunion.io/x/structarg v0.0.0-20231017124457-df4d5009457c h1:QuLab2kSRECZRxo4Lo2KcYn6XjQFDGaZ1+x0pYDVVwQ=
 yunion.io/x/structarg v0.0.0-20231017124457-df4d5009457c/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1465,7 +1465,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231219063429-4e0c70548d7b
+# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231220031827-28bfe13ab842
 ## explicit; go 1.18
 yunion.io/x/cloudmux/pkg/apis
 yunion.io/x/cloudmux/pkg/apis/billing
@@ -1623,7 +1623,7 @@ yunion.io/x/pkg/utils
 # yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 ## explicit; go 1.12
 yunion.io/x/s3cli
-# yunion.io/x/sqlchemy v1.1.3-0.20231214015103-7a6c11418079
+# yunion.io/x/sqlchemy v1.1.3-0.20231219103237-8264e6ead2fc
 ## explicit; go 1.17
 yunion.io/x/sqlchemy
 yunion.io/x/sqlchemy/backends

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/aws/dnsrecord.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/aws/dnsrecord.go
@@ -92,10 +92,7 @@ func (self *SDnsRecord) GetEnabled() bool {
 }
 
 func (self *SDnsRecord) GetGlobalId() string {
-	if len(self.SetIdentifier) > 0 {
-		return self.SetIdentifier
-	}
-	return fmt.Sprintf("%s %s %s", self.Type, self.Name, self.GetDnsValue())
+	return fmt.Sprintf("%s %s %s %s", self.SetIdentifier, self.Type, self.Name, self.GetDnsValue())
 }
 
 func (self *SDnsRecord) GetDnsName() string {

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/volcengine/network.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/volcengine/network.go
@@ -100,7 +100,6 @@ func (subnet *SNetwork) GetIpEnd() string {
 	endIp := pref.Address.BroadcastAddr(pref.MaskLen)
 	endIp = endIp.StepDown()
 	endIp = endIp.StepDown()
-	endIp = endIp.StepDown()
 	return endIp.String()
 }
 

--- a/vendor/yunion.io/x/sqlchemy/functions.go
+++ b/vendor/yunion.io/x/sqlchemy/functions.go
@@ -365,3 +365,7 @@ func DIV(name string, fields ...IQueryField) IQueryField {
 func DATEDIFF(unit string, field1, field2 IQueryField) IQueryField {
 	return getFieldBackend(field1).DATEDIFF(unit, field1, field2)
 }
+
+func ABS(name string, field IQueryField) IQueryField {
+	return NewFunctionField(name, "ABS(%s)", field)
+}


### PR DESCRIPTION
Cherry pick of #19061 on release/3.11.

#19061: fix(region): vendor update for volcengine network and aws dnsrecords sync