### PR TITLE
Automated cherry pick of #19061: fix(region): vendor update for volcengine network and aws dnsrecords sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	k8s.io/client-go v0.19.3
 	k8s.io/cluster-bootstrap v0.19.3
 	moul.io/http2curl/v2 v2.3.0
-	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231214030217-89fcd0f9264f
+	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231220031836-8010ab81be1e
 	yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32
 	yunion.io/x/jsonutils v1.0.1-0.20230613121553-0f3b41e2ef19
 	yunion.io/x/log v1.0.1-0.20230411060016-feb3f46ab361

--- a/go.sum
+++ b/go.sum
@@ -1195,8 +1195,8 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231214030217-89fcd0f9264f h1:s1+DVFe1Ua4GAeb9ng4XuqHkV1je5/6pmKHV0dBW/QE=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231214030217-89fcd0f9264f/go.mod h1:2sgCN7nRPQL3woLfdgqLDd92vwAHqtlz3KKiHxC5BAw=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231220031836-8010ab81be1e h1:Fe7kU1Vvfy8xUpDbX8aUfFUcRY/f0xoXYP25d5MclvU=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231220031836-8010ab81be1e/go.mod h1:2sgCN7nRPQL3woLfdgqLDd92vwAHqtlz3KKiHxC5BAw=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32 h1:v7POYkQwo1XzOxBoIoRVr/k0V9Y5JyjpshlIFa9raug=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32/go.mod h1:Uxuou9WQIeJXNpy7t2fPLL0BYLvLiMvGQwY7Qc6aSws=
 yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH3WE/H1BjUQdFiWu50JGCFQuuy+Z634=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1473,7 +1473,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231214030217-89fcd0f9264f
+# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231220031836-8010ab81be1e
 ## explicit; go 1.18
 yunion.io/x/cloudmux/pkg/apis
 yunion.io/x/cloudmux/pkg/apis/billing

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/aws/dnsrecord.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/aws/dnsrecord.go
@@ -92,10 +92,7 @@ func (self *SDnsRecord) GetEnabled() bool {
 }
 
 func (self *SDnsRecord) GetGlobalId() string {
-	if len(self.SetIdentifier) > 0 {
-		return self.SetIdentifier
-	}
-	return fmt.Sprintf("%s %s %s", self.Type, self.Name, self.GetDnsValue())
+	return fmt.Sprintf("%s %s %s %s", self.SetIdentifier, self.Type, self.Name, self.GetDnsValue())
 }
 
 func (self *SDnsRecord) GetDnsName() string {


### PR DESCRIPTION
Cherry pick of #19061 on release/3.10.

#19061: fix(region): vendor update for volcengine network and aws dnsrecords sync