### PR TITLE
fix(host-deployer): check executor is enabled on init qemu driver

### DIFF
--- a/pkg/hostman/diskutils/kvm.go
+++ b/pkg/hostman/diskutils/kvm.go
@@ -58,7 +58,7 @@ func NewKVMGuestDisk(imageInfo qemuimg.SImageInfo, driver string, readOnly bool)
 		}
 		err = img.CreateQcow2(0, false, imageInfo.Path, imageInfo.Password, imageInfo.EncryptFormat, imageInfo.EncryptAlg)
 		if err != nil {
-			log.Errorf("fail to create overlay qcow2 for kvm disk readonly access")
+			log.Errorf("fail to create overlay qcow2 for kvm disk readonly access: %s", err)
 			return nil, errors.Wrap(err, "CreateQcow2")
 		}
 		originImage = imagePath

--- a/pkg/hostman/hostdeployer/deployserver/deployserver.go
+++ b/pkg/hostman/hostdeployer/deployserver/deployserver.go
@@ -392,6 +392,7 @@ func (s *SDeployService) PrepareEnv() error {
 		err = qemu_kvm.InitQemuDeployManager(
 			strings.TrimSpace(string(cpuArch)),
 			DeployOption.DefaultQemuVersion,
+			DeployOption.EnableRemoteExecutor,
 			DeployOption.HugepagesOption == "native",
 			DeployOption.HugepageSizeMb*1024,
 			DeployOption.DeployConcurrent,

--- a/pkg/util/qemuimg/qemuimg.go
+++ b/pkg/util/qemuimg/qemuimg.go
@@ -687,6 +687,10 @@ func (img *SQemuImage) CreateQcow2(sizeMB int, compact bool, backPath string, pa
 		} else {
 			extraArgs = append(extraArgs, "-b", backPath)
 		}
+		if len(string(backQemu.Format)) > 0 {
+			extraArgs = append(extraArgs, "-F", string(backQemu.Format))
+		}
+
 		if !compact {
 			options = append(options, "cluster_size=2M")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
