### PR TITLE
Automated cherry pick of #19082: fix(host-deployer): check executor is enabled on init qemu driver

### DIFF
--- a/pkg/hostman/diskutils/kvm.go
+++ b/pkg/hostman/diskutils/kvm.go
@@ -58,7 +58,7 @@ func NewKVMGuestDisk(imageInfo qemuimg.SImageInfo, driver string, readOnly bool)
 		}
 		err = img.CreateQcow2(0, false, imageInfo.Path, imageInfo.Password, imageInfo.EncryptFormat, imageInfo.EncryptAlg)
 		if err != nil {
-			log.Errorf("fail to create overlay qcow2 for kvm disk readonly access")
+			log.Errorf("fail to create overlay qcow2 for kvm disk readonly access: %s", err)
 			return nil, errors.Wrap(err, "CreateQcow2")
 		}
 		originImage = imagePath

--- a/pkg/hostman/hostdeployer/deployserver/deployserver.go
+++ b/pkg/hostman/hostdeployer/deployserver/deployserver.go
@@ -392,6 +392,7 @@ func (s *SDeployService) PrepareEnv() error {
 		err = qemu_kvm.InitQemuDeployManager(
 			strings.TrimSpace(string(cpuArch)),
 			DeployOption.DefaultQemuVersion,
+			DeployOption.EnableRemoteExecutor,
 			DeployOption.HugepagesOption == "native",
 			DeployOption.HugepageSizeMb*1024,
 			DeployOption.DeployConcurrent,

--- a/pkg/util/qemuimg/qemuimg.go
+++ b/pkg/util/qemuimg/qemuimg.go
@@ -687,6 +687,10 @@ func (img *SQemuImage) CreateQcow2(sizeMB int, compact bool, backPath string, pa
 		} else {
 			extraArgs = append(extraArgs, "-b", backPath)
 		}
+		if len(string(backQemu.Format)) > 0 {
+			extraArgs = append(extraArgs, "-F", string(backQemu.Format))
+		}
+
 		if !compact {
 			options = append(options, "cluster_size=2M")
 		}


### PR DESCRIPTION
Cherry pick of #19082 on master.

#19082: fix(host-deployer): check executor is enabled on init qemu driver