### PR TITLE
feat(region): support custom user data in Google Cloud VM rebuild

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	k8s.io/client-go v0.19.3
 	k8s.io/cluster-bootstrap v0.19.3
 	moul.io/http2curl/v2 v2.3.0
-	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231227060638-40a1db02d028
+	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231227093150-e2e631e15be3
 	yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32
 	yunion.io/x/jsonutils v1.0.1-0.20230613121553-0f3b41e2ef19
 	yunion.io/x/log v1.0.1-0.20230411060016-feb3f46ab361

--- a/go.sum
+++ b/go.sum
@@ -1201,8 +1201,8 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231227060638-40a1db02d028 h1:Q04t1Xfw9uqR7ba1AJm4tERJ2qwPLysaz9Iekrb0f8U=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231227060638-40a1db02d028/go.mod h1:aj1gR9PPb6eqqKOwvANe26CoZFY8ydmXy0fuvgKYXH0=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231227093150-e2e631e15be3 h1:xOL1kecvOkgAkHxmjbDvqHQiDih+qS7LPPJ5r0lEZCo=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231227093150-e2e631e15be3/go.mod h1:aj1gR9PPb6eqqKOwvANe26CoZFY8ydmXy0fuvgKYXH0=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32 h1:v7POYkQwo1XzOxBoIoRVr/k0V9Y5JyjpshlIFa9raug=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32/go.mod h1:Uxuou9WQIeJXNpy7t2fPLL0BYLvLiMvGQwY7Qc6aSws=
 yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH3WE/H1BjUQdFiWu50JGCFQuuy+Z634=

--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -742,6 +742,11 @@ type ServerDeployInputBase struct {
 	ResetPassword bool `json:"reset_password"`
 	// 重置指定密码
 	Password string `json:"password"`
+	// 用户自定义启动脚本
+	// 支持 #cloud-config yaml 格式及shell脚本
+	// 支持特殊user data平台: Aliyun, Qcloud, Azure, Apsara, Ucloud
+	// required: false
+	UserData string `json:"user_data"`
 
 	// swagger: ignore
 	Restart bool `json:"restart"`

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -544,6 +544,10 @@ func (drv *SManagedVirtualizedGuestDriver) RequestDeployGuestOnHost(ctx context.
 			return guest.GetDriver().RemoteDeployGuestForDeploy(ctx, guest, ihost, task, desc)
 		})
 	case "rebuild":
+		userData, err := task.GetParams().GetString("user_data")
+		if err == nil {
+			desc.UserData = userData
+		}
 		taskman.LocalTaskRun(task, func() (jsonutils.JSONObject, error) {
 			return guest.GetDriver().RemoteDeployGuestForRebuildRoot(ctx, guest, ihost, task, desc)
 		})
@@ -737,6 +741,7 @@ func (drv *SManagedVirtualizedGuestDriver) RemoteDeployGuestForDeploy(ctx contex
 		Username:  desc.Account,
 		PublicKey: desc.PublicKey,
 		Password:  desc.Password,
+		UserData:  desc.UserData,
 	}
 	opts.DeleteKeypair = jsonutils.QueryBoolean(params, "__delete_keypair__", false)
 
@@ -805,6 +810,7 @@ func (drv *SManagedVirtualizedGuestDriver) RemoteDeployGuestForRebuildRoot(ctx c
 			PublicKey: desc.PublicKey,
 			SysSizeGB: desc.SysDisk.SizeGB,
 			OsType:    desc.OsType,
+			UserData:  desc.UserData,
 		}
 		return iVM.RebuildRoot(ctx, &conf)
 	}()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1465,7 +1465,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231227060638-40a1db02d028
+# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20231227093150-e2e631e15be3
 ## explicit; go 1.18
 yunion.io/x/cloudmux/pkg/apis
 yunion.io/x/cloudmux/pkg/apis/billing

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/google/instance.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/google/instance.go
@@ -164,7 +164,7 @@ func (self *SInstance) Refresh() error {
 	return nil
 }
 
-//PROVISIONING, STAGING, RUNNING, STOPPING, STOPPED, SUSPENDING, SUSPENDED, and TERMINATED.
+// PROVISIONING, STAGING, RUNNING, STOPPING, STOPPED, SUSPENDING, SUSPENDED, and TERMINATED.
 func (instance *SInstance) GetStatus() string {
 	switch instance.Status {
 	case "PROVISIONING":
@@ -416,6 +416,7 @@ func (instance *SInstance) RebuildRoot(ctx context.Context, opts *cloudprovider.
 	deployOpts := &cloudprovider.SInstanceDeployOptions{
 		Username:  opts.Account,
 		Password:  opts.Password,
+		UserData:  opts.UserData,
 		PublicKey: opts.PublicKey,
 	}
 	return diskId, instance.DeployVM(ctx, deployOpts)
@@ -424,6 +425,12 @@ func (instance *SInstance) RebuildRoot(ctx context.Context, opts *cloudprovider.
 func (instance *SInstance) DeployVM(ctx context.Context, opts *cloudprovider.SInstanceDeployOptions) error {
 	conf := cloudinit.SCloudConfig{
 		SshPwauth: cloudinit.SSH_PASSWORD_AUTH_ON,
+	}
+	if len(opts.UserData) > 0 {
+		config, err := cloudinit.ParseUserData(opts.UserData)
+		if err == nil {
+			conf.Merge(config)
+		}
 	}
 	user := cloudinit.NewUser(opts.Username)
 	if len(opts.Password) > 0 {

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/huawei/eip.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/huawei/eip.go
@@ -330,6 +330,7 @@ func (self *SRegion) GetEips(portId string, addrs []string) ([]SEipAddress, erro
 	if len(portId) > 0 {
 		query.Set("port_id", portId)
 	}
+	query.Set("ip_version", "4")
 	eips := []SEipAddress{}
 	for {
 		resp, err := self.list(SERVICE_VPC_V3, "eip/publicips", query)

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/huawei/instance.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/huawei/instance.go
@@ -407,7 +407,7 @@ func (self *SInstance) GetIEIP() (cloudprovider.ICloudEIP, error) {
 	ips := make([]string, 0)
 	for _, addresses := range self.Addresses {
 		for _, address := range addresses {
-			if address.OSEXTIPSType != "fixed" && !strings.HasPrefix(address.Addr, "100.") {
+			if address.OSEXTIPSType != "fixed" && !strings.HasPrefix(address.Addr, "100.") && address.Version == "4" {
 				ips = append(ips, address.Addr)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

这个 PR 解决了 [Cloudpods Issue 19069](https://github.com/yunionio/cloudpods/issues/19069)

主要的改动包括：
- ServerDeployInputBase结构体添加UserData字段用于配置虚拟机时获取用户自定义数据
- docs/swagger/swagger_compute.yaml中的ServerRebuildRootInput添加user_data字段
- RequestDeployGuestOnHost方法中添加对rebuild重装系统获取user_data的逻辑