### PR TITLE
fix: deploy user ssh keypair for user account only

### DIFF
--- a/cmd/climc/shell/compute/sshkeypairs.go
+++ b/cmd/climc/shell/compute/sshkeypairs.go
@@ -102,7 +102,7 @@ func init() {
 			oldKeys = string(output)
 		}
 		pubKeys := &deployapi.SSHKeys{AdminPublicKey: pubKey}
-		newKeys := fsdriver.MergeAuthorizedKeys(oldKeys, pubKeys)
+		newKeys := fsdriver.MergeAuthorizedKeys(oldKeys, pubKeys, true)
 		if output, err := procutils.NewCommand(
 			"sh", "-c", fmt.Sprintf("echo '%s' > %s", newKeys, authFile)).Output(); err != nil {
 			return errors.Wrapf(err, "write public keys: %s", output)

--- a/pkg/hostman/guestfs/fsdriver/base_test.go
+++ b/pkg/hostman/guestfs/fsdriver/base_test.go
@@ -26,22 +26,33 @@ func TestMergeAuthorizedKeys(t *testing.T) {
 		pubkeys *deployapi.SSHKeys
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name  string
+		args  args
+		admin bool
+		want  string
 	}{
 		{
 			name: "MergeAuthorizedKeys",
 			args: args{
-				oldKeys: "Test KEY",
+				oldKeys: "ssh-rsa KEY",
 				pubkeys: &deployapi.SSHKeys{},
 			},
-			want: "Test KEY\n",
+			admin: true,
+			want:  "ssh-rsa KEY\n",
+		},
+		{
+			name: "MergeAuthorizedKeys",
+			args: args{
+				oldKeys: "ssh-rsa KEY " + sshKeySignature,
+				pubkeys: &deployapi.SSHKeys{},
+			},
+			admin: true,
+			want:  "\n",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := MergeAuthorizedKeys(tt.args.oldKeys, tt.args.pubkeys); got != tt.want {
+			if got := MergeAuthorizedKeys(tt.args.oldKeys, tt.args.pubkeys, tt.admin); got != tt.want {
 				t.Errorf("MergeAuthorizedKeys() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -216,7 +216,7 @@ func (l *sLinuxRootFs) DeployPublicKey(rootFs IDiskPartition, selUsr string, pub
 	} else {
 		usrDir = path.Join("/home", selUsr)
 	}
-	return DeployAuthorizedKeys(rootFs, usrDir, pubkeys, false)
+	return DeployAuthorizedKeys(rootFs, usrDir, pubkeys, false, false)
 }
 
 func (d *SCoreOsRootFs) DeployQgaBlackList(rootFs IDiskPartition) error {
@@ -270,7 +270,7 @@ func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *deployap
 		return errors.Wrap(err, "unable to CheckOrAddUser")
 	}
 	log.Infof("DeployYunionroot %s home %s", yunionroot, rootdir)
-	err = DeployAuthorizedKeys(rootFs, rootdir, pubkeys, true)
+	err = DeployAuthorizedKeys(rootFs, rootdir, pubkeys, true, true)
 	if err != nil {
 		log.Infof("DeployAuthorizedKeys error: %s", err.Error())
 		return fmt.Errorf("DeployAuthorizedKeys: %v", err)
@@ -1849,7 +1849,7 @@ func (d *SOpenWrtRootFs) DeployPublicKey(rootFs IDiskPartition, selUsr string, p
 			gid      = 0
 			replace  = false
 		)
-		return deployAuthorizedKeys(rootFs, authFile, uid, gid, pubkeys, replace)
+		return deployAuthorizedKeys(rootFs, authFile, uid, gid, pubkeys, replace, false)
 	}
 	return d.sLinuxRootFs.DeployPublicKey(rootFs, selUsr, pubkeys)
 }

--- a/pkg/hostman/guestfs/fsdriver/macos.go
+++ b/pkg/hostman/guestfs/fsdriver/macos.go
@@ -75,7 +75,7 @@ func (m *SMacOSRootFs) RootSignatures() []string {
 
 func (m *SMacOSRootFs) DeployPublicKey(rootfs IDiskPartition, uname string, pubkeys *deployapi.SSHKeys) error {
 	usrDir := fmt.Sprintf("/Users/%s", uname)
-	return DeployAuthorizedKeys(m.rootFs, usrDir, pubkeys, false)
+	return DeployAuthorizedKeys(m.rootFs, usrDir, pubkeys, false, false)
 }
 
 func (m *SMacOSRootFs) addScripts(lines []string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: deploy user ssh keypair for user account only

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 