### PR TITLE
fix: vpc dhcp options string value should be double quoted

### DIFF
--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -520,7 +520,7 @@ func generateDhcpOptions(ctx context.Context, guestnetwork *agentmodels.Guestnet
 			dnsDomain = opts.DNSDomain
 		}
 		if len(dnsDomain) > 0 {
-			dhcpopts.Options["domain_name"] = dnsDomain
+			dhcpopts.Options["domain_name"] = "\"" + dnsDomain + "\""
 		}
 	}
 	{


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: vpc dhcp options string value should be double quoted

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi 