### PR TITLE
Automated cherry pick of #19163: fix: vpc dhcp options string value should be double quoted

### DIFF
--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -520,7 +520,7 @@ func generateDhcpOptions(ctx context.Context, guestnetwork *agentmodels.Guestnet
 			dnsDomain = opts.DNSDomain
 		}
 		if len(dnsDomain) > 0 {
-			dhcpopts.Options["domain_name"] = dnsDomain
+			dhcpopts.Options["domain_name"] = "\"" + dnsDomain + "\""
 		}
 	}
 	{


### PR DESCRIPTION
Cherry pick of #19163 on master.

#19163: fix: vpc dhcp options string value should be double quoted