### PR TITLE
Automated cherry pick of #19205: fix(region): avoid gcp secgroup delete failed

### DIFF
--- a/pkg/compute/tasks/security_group_delete_task.go
+++ b/pkg/compute/tasks/security_group_delete_task.go
@@ -45,13 +45,12 @@ func (self *SecurityGroupDeleteTask) taskFailed(ctx context.Context, secgroup *m
 func (self *SecurityGroupDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	secgroup := obj.(*models.SSecurityGroup)
 
-	region, err := secgroup.GetRegion()
+	driver, err := secgroup.GetRegionDriver()
 	if err != nil {
-		self.taskFailed(ctx, secgroup, errors.Wrapf(err, "GetRegion"))
+		self.taskFailed(ctx, secgroup, errors.Wrapf(err, "GetRegionDriver"))
 		return
 	}
 
-	driver := region.GetDriver()
 	self.SetStage("OnSecurityGroupDeleteComplete", nil)
 	err = driver.RequestDeleteSecurityGroup(ctx, self.GetUserCred(), secgroup, self)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #19205 on release/3.11.

#19205: fix(region): avoid gcp secgroup delete failed