### PR TITLE
Automated cherry pick of #19222: fix(host-deployer): add cmdline vsyscall=emulate on ramfs guest

### DIFF
--- a/pkg/hostman/diskutils/qemu_kvm/driver.go
+++ b/pkg/hostman/diskutils/qemu_kvm/driver.go
@@ -663,6 +663,7 @@ func (d *QemuX86Driver) StartGuest(sshPort, ncpu, memSizeMB int, hugePage bool, 
 	}
 	cmd += __("-drive id=ide0-cd0,if=none,media=cdrom,file=%s", DEPLOY_ISO)
 	cmd += __("-device ide-cd,drive=ide0-cd0,bus=ide.1")
+	cmd += __("-append vsyscall=emulate")
 
 	log.Infof("start guest %s", cmd)
 	out, err := manager.startQemu(cmd)
@@ -739,6 +740,7 @@ func (d *QemuARMDriver) StartGuest(sshPort, ncpu, memSizeMB int, hugePage bool, 
 	}
 	cmd += __("-drive if=none,file=%s,id=cd0,media=cdrom", DEPLOY_ISO)
 	cmd += __("-device scsi-cd,drive=cd0,share-rw=true")
+	cmd += __("-append vsyscall=emulate")
 
 	log.Infof("start guest %s", cmd)
 	out, err := manager.startQemu(cmd)


### PR DESCRIPTION
Cherry pick of #19222 on release/3.11.

#19222: fix(host-deployer): add cmdline vsyscall=emulate on ramfs guest