### PR TITLE
Automated cherry pick of #19272: fix: automatically refresh invalid admin token

### DIFF
--- a/pkg/mcclient/auth/auth.go
+++ b/pkg/mcclient/auth/auth.go
@@ -27,6 +27,7 @@ import (
 	"yunion.io/x/pkg/appctx"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/cache"
+	"yunion.io/x/pkg/util/httputils"
 
 	"yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
@@ -212,10 +213,15 @@ func (a *authManager) verifyRequest(req http.Request, virtualHost bool) (mcclien
 
 func (a *authManager) verify(ctx context.Context, token string) (mcclient.TokenCredential, error) {
 	if a.adminCredential == nil {
+		a.reAuth()
 		return nil, errors.Wrap(httperrors.ErrInvalidCredential, "No valid admin token credential")
 	}
 	cred, err := a.tokenCacheVerify.Verify(ctx, a.client, a.adminCredential.GetTokenString(), token)
 	if err != nil {
+		if httputils.ErrorCode(err) == 403 {
+			// adminCredential need to be refresh
+			a.reAuth()
+		}
 		return nil, errors.Wrap(err, "tokenCacheVerify.Verify")
 	}
 	return cred, nil


### PR DESCRIPTION
Cherry pick of #19272 on release/3.10.

#19272: fix: automatically refresh invalid admin token