### PR TITLE
fix(apigateway): ignore empty rows when registering baremetal host

### DIFF
--- a/pkg/apigateway/handler/misc.go
+++ b/pkg/apigateway/handler/misc.go
@@ -250,7 +250,12 @@ func (mh *MiscHandler) DoBatchHostRegister(ctx context.Context, w http.ResponseW
 
 	ips := []string{}
 	hosts := bytes.Buffer{}
-	for _, row := range rows[1:] {
+	for idx, row := range rows[1:] {
+		rowStr := strings.Join(row, "")
+		if len(rowStr) == 0 {
+			log.Warningf("empty row: %d, skipping it", idx+1)
+			continue
+		}
 		var e *httputils.JSONClientError
 		if i1 >= 0 && len(row[i1]) > 0 {
 			i1Ip := fmt.Sprintf("%d-%s", i1, row[i1])

--- a/pkg/mcclient/modules/compute/mod_hosts.go
+++ b/pkg/mcclient/modules/compute/mod_hosts.go
@@ -96,7 +96,7 @@ func parseHosts(titles []string, data string) []*jsonutils.JSONDict {
 	for i, host := range hosts {
 		host = strings.TrimSpace(host)
 		if len(host) == 0 {
-			log.Debugf(fmt.Sprintf("DoBatchRegister 第%d行： 空白行（已忽略）\n", i))
+			log.Warningf(fmt.Sprintf("DoBatchRegister 第%d行： 空白行（已忽略）\n", i))
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.10
/area apigateway baremetal
/cc @swordqiu 