### PR TITLE
Automated cherry pick of #19353: fix(apigateway): ignore empty rows when registering baremetal host

### DIFF
--- a/pkg/apigateway/handler/misc.go
+++ b/pkg/apigateway/handler/misc.go
@@ -250,7 +250,12 @@ func (mh *MiscHandler) DoBatchHostRegister(ctx context.Context, w http.ResponseW
 
 	ips := []string{}
 	hosts := bytes.Buffer{}
-	for _, row := range rows[1:] {
+	for idx, row := range rows[1:] {
+		rowStr := strings.Join(row, "")
+		if len(rowStr) == 0 {
+			log.Warningf("empty row: %d, skipping it", idx+1)
+			continue
+		}
 		var e *httputils.JSONClientError
 		if i1 >= 0 && len(row[i1]) > 0 {
 			i1Ip := fmt.Sprintf("%d-%s", i1, row[i1])

--- a/pkg/mcclient/modules/compute/mod_hosts.go
+++ b/pkg/mcclient/modules/compute/mod_hosts.go
@@ -96,7 +96,7 @@ func parseHosts(titles []string, data string) []*jsonutils.JSONDict {
 	for i, host := range hosts {
 		host = strings.TrimSpace(host)
 		if len(host) == 0 {
-			log.Debugf(fmt.Sprintf("DoBatchRegister 第%d行： 空白行（已忽略）\n", i))
+			log.Warningf(fmt.Sprintf("DoBatchRegister 第%d行： 空白行（已忽略）\n", i))
 			continue
 		}
 


### PR DESCRIPTION
Cherry pick of #19353 on release/3.11.

#19353: fix(apigateway): ignore empty rows when registering baremetal host