### PR TITLE
fix(climc): wire is required when using network-create

### DIFF
--- a/pkg/mcclient/options/compute/network.go
+++ b/pkg/mcclient/options/compute/network.go
@@ -89,6 +89,7 @@ type NetworkCreateOptions struct {
 func (opts *NetworkCreateOptions) Params() (jsonutils.JSONObject, error) {
 	params := jsonutils.NewDict()
 
+	params.Add(jsonutils.NewString(opts.WIRE), "wire")
 	params.Add(jsonutils.NewString(opts.NETWORK), "name")
 	params.Add(jsonutils.NewString(opts.STARTIP), "guest_ip_start")
 	params.Add(jsonutils.NewString(opts.ENDIP), "guest_ip_end")


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.11
/area climc
/cc @swordqiu 