### PR TITLE
fix: vmware change config with cpu sockets

### DIFF
--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -787,8 +787,7 @@ type ServerChangeConfigInput struct {
 	// cpu卡槽数
 	// vmware 若开机调整配置时,需要保证调整前及调整后 vcpu_count / cpu_sockets 保持不变
 	// vmware开机调整配置同样需要注意 https://kb.vmware.com/s/article/2008405
-	// swagger: ignore
-	// CpuSockets *int `json:"cpu_sockets"`
+	CpuSockets *int `json:"cpu_sockets"`
 
 	// cpu大小
 	VcpuCount *int `json:"vcpu_count"`

--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -869,6 +869,10 @@ func (esxi *SESXiGuestDriver) ValidateGuestChangeConfigInput(ctx context.Context
 		return nil, errors.Wrap(err, "SBaseGuestDriver.ValidateGuestChangeConfigInput")
 	}
 
+	if input.CpuSockets != nil && *input.CpuSockets > 0 {
+		confs.CpuSockets = *input.CpuSockets
+	}
+
 	defaultStorageId := ""
 	if root, _ := guest.GetSystemDisk(); root != nil {
 		defaultStorageId = root.StorageId


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: vmware change config with cpu sockets
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 