### PR TITLE
Automated cherry pick of #19377: fix(baremetal): admin nic is reset when added secondly

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -2135,6 +2135,10 @@ func (b *SBaremetalInstance) SendNicInfo(nic *types.SNicDevInfo, idx int, nicTyp
 			params.Add(jsonutils.JSONTrue, "reserve")
 		}
 	}
+	localNic := b.GetNicByMac(nic.Mac)
+	if localNic != nil {
+		params.Add(jsonutils.NewString(localNic.WireId), "wire_id")
+	}
 	resp, err := modules.Hosts.PerformAction(
 		b.GetClientSession(),
 		b.GetId(),


### PR DESCRIPTION
Cherry pick of #19377 on release/3.10.

#19377: fix(baremetal): admin nic is reset when added secondly