### PR TITLE
Automated cherry pick of #19421: fix(host): init from guest mem obj miss size

### DIFF
--- a/pkg/hostman/guestman/guesttasks.go
+++ b/pkg/hostman/guestman/guesttasks.go
@@ -2540,7 +2540,7 @@ func (task *SGuestHotplugCpuMemTask) onGetSlotIndex(index int) {
 			"size": fmt.Sprintf("%dM", task.addMemSize),
 		}
 	}
-	options["id"] = id
+	// options["id"] = id
 	cb := func(reason string) {
 		if reason == "" {
 			memObj := desc.NewObject(objType, id)

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -950,9 +950,13 @@ func (s *SKVMGuestInstance) initMemDescFromMemoryInfo(
 			return errors.Errorf("unsupported memory device type %s", memoryDevicesInfoList[i].Type)
 		}
 		memSize -= (memoryDevicesInfoList[i].Data.Size / 1024 / 1024)
+		memObj := desc.NewObject(s.memObjectType(), path.Base(memoryDevicesInfoList[i].Data.Memdev))
+		memObj.Options = map[string]string{
+			"size": fmt.Sprintf("%dM", memoryDevicesInfoList[i].Data.Size/1024/1024),
+		}
 		memSlots = append(memSlots, &desc.SMemSlot{
 			SizeMB: memoryDevicesInfoList[i].Data.Size / 1024 / 1024,
-			MemObj: desc.NewObject(s.memObjectType(), path.Base(memoryDevicesInfoList[i].Data.Memdev)),
+			MemObj: memObj,
 			MemDev: &desc.SMemDevice{
 				Type: "pc-dimm", Id: *memoryDevicesInfoList[i].Data.ID,
 			},


### PR DESCRIPTION
Cherry pick of #19421 on master.

#19421: fix(host): init from guest mem obj miss size