### PR TITLE
fix(region): auto set provider project id when change account project info

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -3155,8 +3155,16 @@ func (account *SCloudaccount) PerformProjectMapping(ctx context.Context, userCre
 		input.ProjectId = t.Id
 	}
 
+	if len(input.ProjectId) > 0 {
+		changeOwnerInput := apis.PerformChangeProjectOwnerInput{}
+		changeOwnerInput.ProjectId = input.ProjectId
+		_, err := account.PerformChangeProject(ctx, userCred, query, changeOwnerInput)
+		if err != nil {
+			return nil, errors.Wrapf(err, "PerformChangeProject")
+		}
+	}
+
 	_, err := db.Update(account, func() error {
-		account.ProjectId = input.ProjectId
 		account.AutoCreateProject = input.AutoCreateProject
 		account.AutoCreateProjectForProvider = input.AutoCreateProjectForProvider
 		account.ProjectMappingId = input.ProjectMappingId


### PR DESCRIPTION

**What this PR does / why we need it**:

- [x] Smoke testing completed


If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

/area region
