### PR TITLE
Automated cherry pick of #19473: fix(host-deployer): elfherader fd leak

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -518,6 +518,7 @@ func (l *sLinuxRootFs) GetArch(rootFs IDiskPartition) string {
 					log.Errorf("failed read file elf %s: %s", rp, err)
 					continue
 				}
+				defer elfHeader.Close()
 				// https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
 				switch elfHeader.Machine {
 				case elf.EM_X86_64:


### PR DESCRIPTION
Cherry pick of #19473 on master.

#19473: fix(host-deployer): elfherader fd leak