### PR TITLE
Automated cherry pick of #19491: fix: create params with require_ipv6

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -6344,6 +6344,9 @@ func (self *SGuest) ToNetworksConfig() []*api.NetworkConfig {
 		netConf.Wire = network.WireId
 		netConf.Network = network.Id
 		netConf.Exit = guestNetwork.IsExit()
+		if len(guestNetwork.Ip6Addr) > 0 {
+			netConf.RequireIPv6 = true
+		}
 		// netConf.Private
 		// netConf.Reserved
 		netConf.Driver = guestNetwork.Driver


### PR DESCRIPTION
Cherry pick of #19491 on release/3.11.

#19491: fix: create params with require_ipv6