### PR TITLE
fix: handle label separator in organization tag value

### DIFF
--- a/pkg/apis/identity/organization.go
+++ b/pkg/apis/identity/organization.go
@@ -15,6 +15,7 @@
 package identity
 
 import (
+	"fmt"
 	"strings"
 
 	"yunion.io/x/jsonutils"
@@ -138,7 +139,9 @@ func IsValidLabel(val string) bool {
 }
 
 func trimLabel(label string) string {
-	return strings.Trim(label, OrganizationLabelSeparator+" ")
+	label = strings.Trim(label, OrganizationLabelSeparator+" ")
+	label = strings.ReplaceAll(label, "/", "\\/")
+	return label
 }
 
 func JoinLabels(seg ...string) string {
@@ -160,7 +163,12 @@ func SplitLabel(label string) []string {
 	for _, p := range parts {
 		p = trimLabel(p)
 		if len(p) > 0 {
-			ret = append(ret, p)
+			if len(ret) > 0 && strings.HasSuffix(ret[len(ret)-1], "\\") {
+				pref := ret[len(ret)-1]
+				ret[len(ret)-1] = fmt.Sprintf("%s/%s", pref[:len(pref)-1], p)
+			} else {
+				ret = append(ret, p)
+			}
 		}
 	}
 	return ret

--- a/pkg/apis/identity/organization_test.go
+++ b/pkg/apis/identity/organization_test.go
@@ -36,6 +36,10 @@ func TestJoinLabel(t *testing.T) {
 			segs: []string{"L1/ ", "/L2", "/L3/"},
 			want: "L1/L2/L3",
 		},
+		{
+			segs: []string{"L1/ ", "/L2", "/L3/", "H4/H5"},
+			want: "L1/L2/L3/H4\\/H5",
+		},
 	}
 	for _, c := range cases {
 		got := JoinLabels(c.segs...)
@@ -61,6 +65,10 @@ func TestSplitLabel(t *testing.T) {
 		{
 			in:   "/L1/L2/L3/",
 			want: []string{"L1", "L2", "L3"},
+		},
+		{
+			in:   "L1/L2/L3/H4\\/H5",
+			want: []string{"L1", "L2", "L3", "H4/H5"},
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: handle label separator in organization tag value

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito 