### PR TITLE
Automated cherry pick of #19573: fix: handle label separator in organization tag value

### DIFF
--- a/pkg/apis/identity/organization.go
+++ b/pkg/apis/identity/organization.go
@@ -15,6 +15,7 @@
 package identity
 
 import (
+	"fmt"
 	"strings"
 
 	"yunion.io/x/jsonutils"
@@ -138,7 +139,9 @@ func IsValidLabel(val string) bool {
 }
 
 func trimLabel(label string) string {
-	return strings.Trim(label, OrganizationLabelSeparator+" ")
+	label = strings.Trim(label, OrganizationLabelSeparator+" ")
+	label = strings.ReplaceAll(label, "/", "\\/")
+	return label
 }
 
 func JoinLabels(seg ...string) string {
@@ -160,7 +163,12 @@ func SplitLabel(label string) []string {
 	for _, p := range parts {
 		p = trimLabel(p)
 		if len(p) > 0 {
-			ret = append(ret, p)
+			if len(ret) > 0 && strings.HasSuffix(ret[len(ret)-1], "\\") {
+				pref := ret[len(ret)-1]
+				ret[len(ret)-1] = fmt.Sprintf("%s/%s", pref[:len(pref)-1], p)
+			} else {
+				ret = append(ret, p)
+			}
 		}
 	}
 	return ret

--- a/pkg/apis/identity/organization_test.go
+++ b/pkg/apis/identity/organization_test.go
@@ -36,6 +36,10 @@ func TestJoinLabel(t *testing.T) {
 			segs: []string{"L1/ ", "/L2", "/L3/"},
 			want: "L1/L2/L3",
 		},
+		{
+			segs: []string{"L1/ ", "/L2", "/L3/", "H4/H5"},
+			want: "L1/L2/L3/H4\\/H5",
+		},
 	}
 	for _, c := range cases {
 		got := JoinLabels(c.segs...)
@@ -61,6 +65,10 @@ func TestSplitLabel(t *testing.T) {
 		{
 			in:   "/L1/L2/L3/",
 			want: []string{"L1", "L2", "L3"},
+		},
+		{
+			in:   "L1/L2/L3/H4\\/H5",
+			want: []string{"L1", "L2", "L3", "H4/H5"},
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Cherry pick of #19573 on release/3.11.

#19573: fix: handle label separator in organization tag value