### PR TITLE
Automated cherry pick of #19609: Hotfix/qj organization node label contains separator2

### DIFF
--- a/pkg/keystone/models/organization_nodes.go
+++ b/pkg/keystone/models/organization_nodes.go
@@ -110,7 +110,10 @@ func generateId(orgId string, fullLabel string, level int) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func (manager *SOrganizationNodeManager) ensureNode(ctx context.Context, orgId string, label string, fullLabel string, level int, weight *int, desc string) (*SOrganizationNode, error) {
+func (manager *SOrganizationNodeManager) ensureNode(ctx context.Context, orgId string, fullLabel string, weight *int, desc string) (*SOrganizationNode, error) {
+	labels := api.SplitLabel(fullLabel)
+	level := len(labels)
+	label := labels[level-1]
 	id := generateId(orgId, fullLabel, level)
 	obj, err := manager.FetchById(id)
 	if err != nil {

--- a/pkg/keystone/models/organization_nodes.go
+++ b/pkg/keystone/models/organization_nodes.go
@@ -290,11 +290,14 @@ func tagSetList2Conditions(tagsetList tagutils.TTagSetList, keys []string, q *sq
 	conds := make([]sqlchemy.ICondition, 0)
 	paths := tagutils.TagSetList2Paths(tagsetList, keys)
 	for i := range paths {
-		label := api.JoinLabels(paths[i]...)
-		labelSlash := label + api.OrganizationLabelSeparator
-		conds = append(conds, sqlchemy.Contains(q.Field("full_label"), labelSlash))
-		conds = append(conds, sqlchemy.Startswith(q.Field("full_label"), labelSlash))
-		conds = append(conds, sqlchemy.Equals(q.Field("full_label"), label))
+		for j := range paths[i] {
+			label := api.JoinLabels(paths[i][:j+1]...)
+			conds = append(conds, sqlchemy.Equals(q.Field("full_label"), label))
+			if j == len(paths[i])-1 {
+				labelSlash := label + api.OrganizationLabelSeparator
+				conds = append(conds, sqlchemy.Startswith(q.Field("full_label"), labelSlash))
+			}
+		}
 	}
 	if len(conds) > 0 {
 		return sqlchemy.OR(conds...)

--- a/pkg/keystone/models/organizations.go
+++ b/pkg/keystone/models/organizations.go
@@ -436,7 +436,7 @@ func (org *SOrganization) PerformAddNode(
 			weight = &input.Weight
 			desc = input.Description
 		}
-		_, err := OrganizationNodeManager.ensureNode(ctx, org.Id, labels[i], api.JoinLabels(labels[0:i+1]...), i+1, weight, desc)
+		_, err := OrganizationNodeManager.ensureNode(ctx, org.Id, api.JoinLabels(labels[0:i+1]...), weight, desc)
 		if err != nil {
 			return nil, errors.Wrapf(err, "fail to insert node %s", api.JoinLabels(labels[i:i]...))
 		}
@@ -575,7 +575,7 @@ func (org *SOrganization) syncTagValueMap(ctx context.Context, tagVal map[string
 		if val, ok := tagVal[key]; ok && val != tagutils.NoValue {
 			labels = append(labels, val)
 			log.Debugf("%d %s %s %s", i, key, val, strings.Join(labels, "/"))
-			_, err := OrganizationNodeManager.ensureNode(ctx, org.Id, val, api.JoinLabels(labels...), i+1, nil, "")
+			_, err := OrganizationNodeManager.ensureNode(ctx, org.Id, api.JoinLabels(labels...), nil, "")
 			if err != nil {
 				return nil, errors.Wrapf(err, "fail to insert node %s", api.JoinLabels(labels...))
 			}


### PR DESCRIPTION
Cherry pick of #19609 on release/3.11.

#19609: Hotfix/qj organization node label contains separator2