### PR TITLE
Automated cherry pick of #19624: fix(region): vendor update for azure associate type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	k8s.io/client-go v0.19.3
 	k8s.io/cluster-bootstrap v0.19.3
 	moul.io/http2curl/v2 v2.3.0
-	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240301021159-5fd63d8bc85c
+	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240304114834-4acad53ed995
 	yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32
 	yunion.io/x/jsonutils v1.0.1-0.20240203102553-4096f103b401
 	yunion.io/x/log v1.0.1-0.20230411060016-feb3f46ab361

--- a/go.sum
+++ b/go.sum
@@ -1195,8 +1195,8 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240301021159-5fd63d8bc85c h1:nvrPQw90IlAPFOk34GzktVdL/3DkLWXCXe+C0KyMVAQ=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240301021159-5fd63d8bc85c/go.mod h1:jmuNDDZbSZwC2ACXC8c+741N8o4pzVvK0fgkA9OrKpI=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240304114834-4acad53ed995 h1:3fDd+m7JZ4wzmlSuNkLj8XMQjsnTFOzw4T0Sm4iFnYI=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240304114834-4acad53ed995/go.mod h1:jmuNDDZbSZwC2ACXC8c+741N8o4pzVvK0fgkA9OrKpI=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32 h1:v7POYkQwo1XzOxBoIoRVr/k0V9Y5JyjpshlIFa9raug=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32/go.mod h1:Uxuou9WQIeJXNpy7t2fPLL0BYLvLiMvGQwY7Qc6aSws=
 yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH3WE/H1BjUQdFiWu50JGCFQuuy+Z634=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1473,7 +1473,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240301021159-5fd63d8bc85c
+# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240304114834-4acad53ed995
 ## explicit; go 1.18
 yunion.io/x/cloudmux/pkg/apis
 yunion.io/x/cloudmux/pkg/apis/billing

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/azure/eip.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/azure/eip.go
@@ -189,6 +189,9 @@ func (self *SEipAddress) GetAssociationType() string {
 		if utils.IsInStringArray(resType, []string{"networkinterfaces"}) {
 			return api.EIP_ASSOCIATE_TYPE_SERVER
 		}
+		if utils.IsInStringArray(resType, []string{"loadbalancers"}) {
+			return api.EIP_ASSOCIATE_TYPE_LOADBALANCER
+		}
 		return resType
 	}
 	return ""


### PR DESCRIPTION
Cherry pick of #19624 on release/3.10.

#19624: fix(region): vendor update for azure associate type