### PR TITLE
fix: host-deploy options struct consistent with host options

### DIFF
--- a/pkg/hostman/hostdeployer/deployserver/options.go
+++ b/pkg/hostman/hostdeployer/deployserver/options.go
@@ -18,10 +18,12 @@ import (
 	"os"
 
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
+	host_options "yunion.io/x/onecloud/pkg/hostman/options"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 )
 
 type SDeployOptions struct {
-	common_options.HostCommonOptions
+	host_options.SHostBaseOptions
 
 	// PrivatePrefixes []string `help:"IPv4 private prefixes"`
 	ChntpwPath string `help:"path to chntpw tool" default:"/usr/local/bin/chntpw.static"`
@@ -33,9 +35,9 @@ type SDeployOptions struct {
 
 	AllowVmSELinux bool `help:"turn off vm selinux" default:"false" json:"allow_vm_selinux"`
 
-	HugepagesOption      string   `help:"Hugepages option: disable|native|transparent" default:"transparent"`
-	HugepageSizeMb       int      `help:"hugepage size mb default 1G" default:"1024"`
-	DefaultQemuVersion   string   `help:"Default qemu version" default:"4.2.0"`
+	HugepagesOption string `help:"Hugepages option: disable|native|transparent" default:"transparent"`
+	HugepageSizeMb  int    `help:"hugepage size mb default 1G" default:"1024"`
+	// DefaultQemuVersion   string   `help:"Default qemu version" default:"4.2.0"`
 	DeployGuestMemSizeMb int      `help:"Deploy guest mem size mb" default:"320"`
 	ListenInterface      string   `help:"Master address of host server"`
 	Networks             []string `help:"Network interface information"`
@@ -51,12 +53,12 @@ var DeployOption SDeployOptions
 func Parse() SDeployOptions {
 	var hostOpts SDeployOptions
 	common_options.ParseOptions(&hostOpts, os.Args, "host.conf", "host")
-	if len(hostOpts.CommonConfigFile) > 0 {
-		commonCfg := &common_options.HostCommonOptions{}
+	if len(hostOpts.CommonConfigFile) > 0 && fileutils2.Exists(hostOpts.CommonConfigFile) {
+		commonCfg := &host_options.SHostBaseOptions{}
 		commonCfg.Config = hostOpts.CommonConfigFile
 		common_options.ParseOptions(commonCfg, []string{os.Args[0]}, "common.conf", "host")
 		baseOpt := hostOpts.BaseOptions.BaseOptions
-		hostOpts.HostCommonOptions = *commonCfg
+		hostOpts.SHostBaseOptions = *commonCfg
 		// keep base options
 		hostOpts.BaseOptions.BaseOptions = baseOpt
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: host-deploy options struct consistent with host options

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11
- release/3.10
- release/3.9

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi 