### PR TITLE
Automated cherry pick of #19723: fix(region): avoid duplicate zone name

### DIFF
--- a/pkg/compute/models/zones.go
+++ b/pkg/compute/models/zones.go
@@ -356,7 +356,12 @@ func (self *SZone) syncWithCloudZone(ctx context.Context, userCred mcclient.Toke
 	}
 
 	diff, err := db.UpdateWithLock(ctx, self, func() error {
-		self.Name = extZone.GetName()
+		if options.Options.EnableSyncName {
+			newName, _ := db.GenerateAlterName(self, extZone.GetName())
+			if len(newName) > 0 && newName != self.Name {
+				self.Name = newName
+			}
+		}
 		self.Status = extZone.GetStatus()
 
 		self.IsEmulated = extZone.IsEmulated()


### PR DESCRIPTION
Cherry pick of #19723 on release/3.11.

#19723: fix(region): avoid duplicate zone name