### PR TITLE
Automated cherry pick of #19781: fix: fail to parse ipv6 addr of fc00::1:1004:ffff:ffff:ffff:ffff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	yunion.io/x/jsonutils v1.0.1-0.20240203102553-4096f103b401
 	yunion.io/x/log v1.0.1-0.20240305175729-7cf2d6cd5a91
 	yunion.io/x/ovsdb v0.0.0-20230306173834-f164f413a900
-	yunion.io/x/pkg v1.10.1-0.20240303050651-73685b15a96e
+	yunion.io/x/pkg v1.10.1-0.20240324150220-11d9be90fa6c
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 	yunion.io/x/sqlchemy v1.1.3-0.20240315065533-9ede1267a826
 	yunion.io/x/structarg v0.0.0-20231017124457-df4d5009457c

--- a/go.sum
+++ b/go.sum
@@ -1219,8 +1219,8 @@ yunion.io/x/ovsdb v0.0.0-20230306173834-f164f413a900 h1:Hu/4ERvoWaN6aiFs4h4/yvVB
 yunion.io/x/ovsdb v0.0.0-20230306173834-f164f413a900/go.mod h1:0vLkNEhlmA64HViPBAnSTUMrx5QP1CLsxXmxDKQ80tc=
 yunion.io/x/pkg v0.0.0-20190620104149-945c25821dbf/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20190628082551-f4033ba2ea30/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
-yunion.io/x/pkg v1.10.1-0.20240303050651-73685b15a96e h1:NuYu+z0dOT93aoNjg3W3PkLidy3E3cdNFZqz2Aua6UE=
-yunion.io/x/pkg v1.10.1-0.20240303050651-73685b15a96e/go.mod h1:ksCJVQ+DwKrJ5QBEoU8pzrDFfDaZVAFH/iJ6yQCYxJk=
+yunion.io/x/pkg v1.10.1-0.20240324150220-11d9be90fa6c h1:c71AlEenWHcA6xJQN8dbtwXxIQA5Uts+wnv87OH7Eas=
+yunion.io/x/pkg v1.10.1-0.20240324150220-11d9be90fa6c/go.mod h1:ksCJVQ+DwKrJ5QBEoU8pzrDFfDaZVAFH/iJ6yQCYxJk=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
 yunion.io/x/sqlchemy v1.1.3-0.20240315065533-9ede1267a826 h1:RLPGmjYWGXmxL1rq9a/bs3VSp2tAwtVMxsa/uXOV2xI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1568,7 +1568,7 @@ yunion.io/x/log/hooks
 yunion.io/x/ovsdb/cli_util
 yunion.io/x/ovsdb/schema/ovn_nb
 yunion.io/x/ovsdb/types
-# yunion.io/x/pkg v1.10.1-0.20240303050651-73685b15a96e
+# yunion.io/x/pkg v1.10.1-0.20240324150220-11d9be90fa6c
 ## explicit; go 1.18
 yunion.io/x/pkg/appctx
 yunion.io/x/pkg/errors

--- a/vendor/yunion.io/x/pkg/util/netutils/ipv6.go
+++ b/vendor/yunion.io/x/pkg/util/netutils/ipv6.go
@@ -155,8 +155,12 @@ func normalizeIpv6Addr(addrStr string) ([8]uint16, error) {
 		}
 	} else {
 		for i := 0; i < len(parts); i++ {
+			partStr := strings.TrimSpace(parts[i])
+			if len(partStr) == 0 {
+				continue
+			}
 			var err error
-			addr[i], err = hex2Number(strings.TrimSpace(parts[i]))
+			addr[i], err = hex2Number(partStr)
 			if err != nil {
 				return addr, errors.Wrapf(err, "hex2Number %s", addrStr)
 			}


### PR DESCRIPTION
Cherry pick of #19781 on release/3.11.

#19781: fix: fail to parse ipv6 addr of fc00::1:1004:ffff:ffff:ffff:ffff