### PR TITLE
Automated cherry pick of #19785: fix: create lb listener rules fail due to domain not found

### DIFF
--- a/pkg/cloudcommon/db/fetch.go
+++ b/pkg/cloudcommon/db/fetch.go
@@ -271,7 +271,7 @@ var (
 		"project_domain_id",
 		"domain_id",
 		"project_domain",
-		"domain",
+		// "domain",
 	}
 )
 

--- a/pkg/compute/models/loadbalancerlistenerrules.go
+++ b/pkg/compute/models/loadbalancerlistenerrules.go
@@ -513,18 +513,19 @@ func (manager *SLoadbalancerListenerRuleManager) FilterByUniqValues(q *sqlchemy.
 
 func (man *SLoadbalancerListenerRuleManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential,
 	ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject,
-	input *api.LoadbalancerListenerRuleCreateInput) (*api.LoadbalancerListenerRuleCreateInput, error) {
+	input *api.LoadbalancerListenerRuleCreateInput,
+) (*api.LoadbalancerListenerRuleCreateInput, error) {
 	var err error
 	input.StatusStandaloneResourceCreateInput, err = man.SStatusStandaloneResourceBaseManager.ValidateCreateData(ctx, userCred, ownerId, query, input.StatusStandaloneResourceCreateInput)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "SStatusStandaloneResourceBaseManager.ValidateCreateData")
 	}
 	if len(input.Status) == 0 {
 		input.Status = api.LB_STATUS_ENABLED
 	}
 	listenerObj, err := validators.ValidateModel(userCred, LoadbalancerListenerManager, &input.ListenerId)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "ValidateModel LoadbalancerListenerManager")
 	}
 	listener := listenerObj.(*SLoadbalancerListener)
 	if listener.ListenerType != api.LB_LISTENER_TYPE_HTTP && listener.ListenerType != api.LB_LISTENER_TYPE_HTTPS {
@@ -532,12 +533,12 @@ func (man *SLoadbalancerListenerRuleManager) ValidateCreateData(ctx context.Cont
 	}
 	region, err := listener.GetRegion()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "listener.GetRegion")
 	}
 	if region.GetDriver().IsSupportLoadbalancerListenerRuleRedirect() {
 		_, err := validators.ValidateModel(userCred, LoadbalancerBackendGroupManager, &input.BackendGroupId)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "ValidateModel LoadbalancerBackendGroupManager")
 		}
 	}
 	return region.GetDriver().ValidateCreateLoadbalancerListenerRuleData(ctx, userCred, ownerId, input)


### PR DESCRIPTION
Cherry pick of #19785 on release/3.10.

#19785: fix: create lb listener rules fail due to domain not found