### PR TITLE
Automated cherry pick of #19820: fix(region): cloudpods region sync

### DIFF
--- a/pkg/mcclient/cloudpods/cloudpods.go
+++ b/pkg/mcclient/cloudpods/cloudpods.go
@@ -281,6 +281,10 @@ func (self *SCloudpodsClient) GetRegions() ([]SRegion, error) {
 	return ret, self.list(&compute.Cloudregions, nil, &ret)
 }
 
+func (self *SCloudpodsClient) GetCloudRegionExternalIdPrefix() string {
+	return fmt.Sprintf("%s/%s", api.CLOUD_PROVIDER_CLOUDPODS, self.cpcfg.Id)
+}
+
 func (self *SCloudpodsClient) GetCapabilities() []string {
 	return []string{
 		cloudprovider.CLOUD_CAPABILITY_PROJECT + cloudprovider.READ_ONLY_SUFFIX,

--- a/pkg/mcclient/cloudpods/provider/provider.go
+++ b/pkg/mcclient/cloudpods/provider/provider.go
@@ -111,6 +111,10 @@ func (self *SCloudpodsProvider) GetAccountId() string {
 	return self.client.GetAccountId()
 }
 
+func (self *SCloudpodsProvider) GetCloudRegionExternalIdPrefix() string {
+	return self.client.GetCloudRegionExternalIdPrefix()
+}
+
 func (self *SCloudpodsProvider) GetBalance() (*cloudprovider.SBalanceInfo, error) {
 	return &cloudprovider.SBalanceInfo{
 		Currency: "CNY",


### PR DESCRIPTION
Cherry pick of #19820 on release/3.10.

#19820: fix(region): cloudpods region sync