### PR TITLE
Automated cherry pick of #19830: fix(host-deployer): deploy guest arm kernel path fix

### DIFF
--- a/pkg/hostman/diskutils/qemu_kvm/driver.go
+++ b/pkg/hostman/diskutils/qemu_kvm/driver.go
@@ -736,8 +736,8 @@ func (d *QemuARMDriver) StartGuest(sshPort, ncpu, memSizeMB int, hugePage bool, 
 		cdromDeviceOpts,
 		fwOpts,
 		socketPath,
-		manager.GetX86InitrdPath(),
-		manager.GetX86KernelPath(),
+		manager.GetARMInitrdPath(),
+		manager.GetARMKernelPath(),
 	)
 
 	log.Infof("start guest %s", cmd)


### PR DESCRIPTION
Cherry pick of #19830 on release/3.11.

#19830: fix(host-deployer): deploy guest arm kernel path fix