### PR TITLE
fix(host-deployer): add ext4 usage type options

### DIFF
--- a/pkg/hostman/hostdeployer/deployserver/localdeploy.go
+++ b/pkg/hostman/hostdeployer/deployserver/localdeploy.go
@@ -22,11 +22,8 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/util/netutils"
 
-	commonconsts "yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/hostman/diskutils"
-	"yunion.io/x/onecloud/pkg/hostman/guestfs/fsdriver"
 	deployapi "yunion.io/x/onecloud/pkg/hostman/hostdeployer/apis"
 	"yunion.io/x/onecloud/pkg/hostman/hostdeployer/consts"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
@@ -113,12 +110,11 @@ func LocalInitEnv() error {
 		return errors.Wrap(err, "set env path")
 	}
 
-	netutils.SetPrivatePrefixes(DeployOption.CustomizedPrivatePrefixes)
-	if err := fsdriver.Init(DeployOption.CloudrootDir); err != nil {
-		return errors.Wrap(err, "init fsdriver")
-	}
-	commonconsts.SetAllowVmSELinux(DeployOption.AllowVmSELinux)
 	winutils.SetChntpwPath("/opt/yunion/bin/chntpw.static")
+	err = InitEnvCommon()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -45,6 +45,9 @@ type SHostBaseOptions struct {
 
 	DhcpLeaseTime   int `default:"100663296" help:"DHCP lease time in seconds"`
 	DhcpRenewalTime int `default:"67108864" help:"DHCP renewal time in seconds"`
+
+	Ext4LargefileSizeGb int `default:"4096" help:"Use largefile options when the ext4 fs greater than this size"`
+	Ext4HugefileSizeGb  int `default:"512" help:"Use huge options when the ext4 fs greater than this size"`
 }
 
 type SHostOptions struct {


### PR DESCRIPTION
resize fs not required find rootfs.
format ext4 partitions select usage type by part size.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.11
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
