### PR TITLE
Automated cherry pick of #19900: fix(region): show local task stack info

### DIFF
--- a/pkg/cloudcommon/db/taskman/localtaskworker.go
+++ b/pkg/cloudcommon/db/taskman/localtaskworker.go
@@ -55,7 +55,7 @@ func (t *localTask) Run() {
 			yunionconf.BugReport.SendBugReport(context.Background(), version.GetShortString(), string(debug.Stack()), errors.Errorf("%s", r))
 			log.Errorf("LocalTaskRun error: %s", r)
 			debug.PrintStack()
-			t.task.ScheduleRun(Error2TaskData(fmt.Errorf("LocalTaskRun error: %s", r)))
+			t.task.ScheduleRun(Error2TaskData(fmt.Errorf("LocalTaskRun error: %s stack: %s", r, string(debug.Stack()))))
 		}
 	}()
 	data, err := t.proc()


### PR DESCRIPTION
Cherry pick of #19900 on release/3.12.

#19900: fix(region): show local task stack info