### PR TITLE
Automated cherry pick of #20115: fix(mcclient): read me

### DIFF
--- a/pkg/mcclient/README.md
+++ b/pkg/mcclient/README.md
@@ -49,7 +49,7 @@ func main() {
 		"",
 		"publicURL",
 		token,
-		"")
+		)
 
 	result, err := modules.Servers.List(s, nil)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #20115 on release/3.11.

#20115: fix(mcclient): read me