### PR TITLE
Automated cherry pick of #20135: fix(monitor): filter alerts by monitor_resource_id

### DIFF
--- a/pkg/apis/monitor/alert.go
+++ b/pkg/apis/monitor/alert.go
@@ -155,6 +155,7 @@ type AlertListInput struct {
 	apis.StatusStandaloneResourceListInput
 	// 以报警是否启用/禁用过滤列表
 	// Enabled *bool `json:"enabled"`
+	MonitorResourceId []string `json:"monitor_resource_id"`
 }
 
 type AlertDetails struct {

--- a/pkg/mcclient/options/monitor/commonalert.go
+++ b/pkg/mcclient/options/monitor/commonalert.go
@@ -27,8 +27,9 @@ import (
 type CommonAlertListOptions struct {
 	options.BaseListOptions
 	// 报警类型
-	AlertType string `help:"common alert type" choices:"normal|system"`
-	Level     string `help:"common alert notify level" choices:"normal|important|fatal"`
+	AlertType         string   `help:"common alert type" choices:"normal|system"`
+	Level             string   `help:"common alert notify level" choices:"normal|important|fatal"`
+	MonitorResourceId []string `help:"monitor resource id"`
 }
 
 func (o *CommonAlertListOptions) Params() (jsonutils.JSONObject, error) {

--- a/pkg/monitor/models/alert.go
+++ b/pkg/monitor/models/alert.go
@@ -292,6 +292,10 @@ func (man *SAlertManager) ListItemFilter(
 	if err != nil {
 		return nil, errors.Wrap(err, "SEnabledResourceBaseManager.ListItemFilter")
 	}
+	if len(input.MonitorResourceId) != 0 {
+		sq := MonitorResourceAlertManager.Query("alert_id").In("monitor_resource_id", input.MonitorResourceId).SubQuery()
+		q = q.In("id", sq)
+	}
 	return q, nil
 }
 


### PR DESCRIPTION
Cherry pick of #20135 on master.

#20135: fix(monitor): filter alerts by monitor_resource_id