### PR TITLE
fix: set disk status when requesting disk reset

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -3111,6 +3111,8 @@ func (disk *SDisk) PerformRebuild(
 		if guest.GetStatus() != api.VM_READY {
 			return nil, httperrors.NewInvalidStatusError("Guest %s status is %s", guest.GetId(), guest.GetStatus())
 		}
+		guest.SetStatus(ctx, userCred, api.VM_DISK_RESET, "disk rebuild")
 	}
+	disk.SetStatus(ctx, userCred, api.DISK_REBUILD, "disk rebuild")
 	return nil, disk.StartDiskCreateTask(ctx, userCred, true, disk.SnapshotId, "")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: set disk status when requesting disk reset

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.12
- release/3.11
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi 