### PR TITLE
fix: ceph stats backward compatible with ceph 12.x

### DIFF
--- a/pkg/util/cephutils/ceph.go
+++ b/pkg/util/cephutils/ceph.go
@@ -156,6 +156,10 @@ func (cli *CephClient) CreateImage(name string, sizeMb int64) (*SImage, error) {
 	return image, cli.run("rbd", opts, false)
 }
 
+/*
+ * {"kb_used":193408,"bytes_used":198049792,"percent_used":0.32,"bytes_used2":0,"percent_used2":0.00,"osd_max_used":0,"osd_max_used_ratio":0.32,"max_avail":61003137024,"objects":1,"origin_bytes":0,"compress_bytes":0}
+ * {"stored":6198990973173,"objects":1734699,"kb_used":12132844593,"bytes_used":12424032862699,"percent_used":0.30800202488899231,"max_avail":13956734255104}
+ */
 func (cli *CephClient) GetCapacity() (*SCapacity, error) {
 	result := &SCapacity{}
 	opts := cli.options()
@@ -173,9 +177,13 @@ func (cli *CephClient) GetCapacity() (*SCapacity, error) {
 	result.UsedCapacitySizeKb = stats.Stats.TotalUsedBytes / 1024
 	for _, pool := range stats.Pools {
 		if pool.Name == cli.pool {
-			result.UsedCapacitySizeKb = int64(pool.Stats.Stored / 1024)
+			if pool.Stats.Stored > 0 {
+				result.UsedCapacitySizeKb = int64(pool.Stats.Stored / 1024)
+			} else {
+				result.UsedCapacitySizeKb = int64(pool.Stats.BytesUsed / 1024)
+			}
 			if pool.Stats.MaxAvail > 0 {
-				result.CapacitySizeKb = int64(pool.Stats.MaxAvail/1024 + int64(pool.Stats.Stored/1024))
+				result.CapacitySizeKb = int64(pool.Stats.MaxAvail/1024) + result.UsedCapacitySizeKb
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: ceph stats backward compatible with ceph 12.x

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.12
- release/3.11
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @ioito @wanyaoqi @zexi 