### PR TITLE
feat(region,host): set container RunAsUser and RunAsGroup

### DIFF
--- a/pkg/apis/container.go
+++ b/pkg/apis/container.go
@@ -43,6 +43,11 @@ type ContainerLifecyle struct {
 	PostStart *ContainerLifecyleHandler `json:"post_start"`
 }
 
+type ContainerSecurityContext struct {
+	RunAsUser  *int64 `json:"run_as_user,omitempty"`
+	RunAsGroup *int64 `json:"run_as_group,omitempty"`
+}
+
 type ContainerSpec struct {
 	// Image to use.
 	Image string `json:"image"`
@@ -57,13 +62,14 @@ type ContainerSpec struct {
 	// List of environment variable to set in the container.
 	Envs []*ContainerKeyValue `json:"envs"`
 	// Enable lxcfs
-	EnableLxcfs        bool                 `json:"enable_lxcfs"`
-	Capabilities       *ContainerCapability `json:"capabilities"`
-	Privileged         bool                 `json:"privileged"`
-	Lifecyle           *ContainerLifecyle   `json:"lifecyle"`
-	CgroupDevicesAllow []string             `json:"cgroup_devices_allow"`
-	SimulateCpu        bool                 `json:"simulate_cpu"`
-	ShmSizeMB          int                  `json:"shm_size_mb"`
+	EnableLxcfs        bool                      `json:"enable_lxcfs"`
+	Capabilities       *ContainerCapability      `json:"capabilities"`
+	Privileged         bool                      `json:"privileged"`
+	Lifecyle           *ContainerLifecyle        `json:"lifecyle"`
+	CgroupDevicesAllow []string                  `json:"cgroup_devices_allow"`
+	SimulateCpu        bool                      `json:"simulate_cpu"`
+	ShmSizeMB          int                       `json:"shm_size_mb"`
+	SecurityContext    *ContainerSecurityContext `json:"security_context,omitempty"`
 }
 
 type ContainerCapability struct {
@@ -124,6 +130,9 @@ type ContainerVolumeMount struct {
 	SelinuxRelabel bool `json:"selinux_relabel,omitempty"`
 	// Requested propagation mode.
 	Propagation ContainerMountPropagation `json:"propagation,omitempty"`
+	// Owner permissions
+	FsUser  *int64 `json:"fs_user,omitempty"`
+	FsGroup *int64 `json:"fs_group,omitempty"`
 }
 
 type ContainerOverlayDiskImage struct {

--- a/pkg/apis/host/container.go
+++ b/pkg/apis/host/container.go
@@ -41,6 +41,8 @@ type ContainerVolumeMount struct {
 	SelinuxRelabel bool `json:"selinux_relabel,omitempty"`
 	// Requested propagation mode.
 	Propagation apis.ContainerMountPropagation `json:"propagation,omitempty"`
+	FsUser      *int64                         `json:"fs_user,omitempty"`
+	FsGroup     *int64                         `json:"fs_group,omitempty"`
 }
 
 type ContainerSpec struct {

--- a/pkg/hostman/container/volume_mount/helper.go
+++ b/pkg/hostman/container/volume_mount/helper.go
@@ -1,0 +1,32 @@
+package volume_mount
+
+import (
+	"fmt"
+
+	"yunion.io/x/pkg/errors"
+
+	hostapi "yunion.io/x/onecloud/pkg/apis/host"
+	"yunion.io/x/onecloud/pkg/util/procutils"
+)
+
+func ChangeDirOwner(pod IPodInfo, drv IVolumeMount, ctrId string, vol *hostapi.ContainerVolumeMount) error {
+	if vol.FsUser == nil && vol.FsGroup == nil {
+		return errors.Errorf("specify fs_user or fs_group")
+	}
+	hostPath, err := drv.GetRuntimeMountHostPath(pod, ctrId, vol)
+	if err != nil {
+		return errors.Wrap(err, "GetRuntimeMountHostPath")
+	}
+	args := ""
+	if vol.FsUser != nil {
+		args = fmt.Sprintf("%d", *vol.FsUser)
+	}
+	if vol.FsGroup != nil {
+		args = fmt.Sprintf("%s:%d", args, *vol.FsGroup)
+	}
+	out, err := procutils.NewRemoteCommandAsFarAsPossible("chown", "-R", args, hostPath).Output()
+	if err != nil {
+		return errors.Wrapf(err, "chown -R %s %s: %s", args, hostPath, string(out))
+	}
+	return nil
+}

--- a/pkg/hostman/container/volume_mount/host_path.go
+++ b/pkg/hostman/container/volume_mount/host_path.go
@@ -50,6 +50,9 @@ func (h hostLocal) GetRuntimeMountHostPath(pod IPodInfo, ctrId string, vm *hosta
 	if host == nil {
 		return "", httperrors.NewNotEmptyError("host_local is nil")
 	}
+	if vm.FsUser != nil || vm.FsGroup != nil {
+		return "", httperrors.NewInputParameterError("cannot use fs_user and fs_group for host_local volume")
+	}
 	switch host.Type {
 	case "", apis.CONTAINER_VOLUME_MOUNT_HOST_PATH_TYPE_FILE:
 		return host.Path, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

```bash
# testing command
climc --debug pod-create --allow-delete --auto-start \
        --disk disk_type=data,size=1g,format=raw,fs=ext4 \
        --uid 1000 --gid 1000 \
        --volume-mount disk_index=0,mount_path=/data,fs_user=1000,fs_group=1000 \
        --command sh --args '-c' --args 'sleep 1h' \
        test-pod12 512 busybox:1.28
```

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
NONE
/area region host climc