### PR TITLE
Automated cherry pick of #20448: fix(host-deployer): split guest dns by comma

### DIFF
--- a/pkg/util/netutils2/netutils.go
+++ b/pkg/util/netutils2/netutils.go
@@ -172,7 +172,9 @@ func AddNicRoutes(routes *[][]string, nicDesc *types.SServerNic, mainIp string, 
 func GetNicDns(nicdesc *types.SServerNic) []string {
 	dnslist := []string{}
 	if len(nicdesc.Dns) > 0 {
-		dnslist = append(dnslist, nicdesc.Dns)
+		for _, dns := range strings.Split(nicdesc.Dns, ",") {
+			dnslist = append(dnslist, dns)
+		}
 	}
 	return dnslist
 }


### PR DESCRIPTION
Cherry pick of #20448 on release/3.10.

#20448: fix(host-deployer): split guest dns by comma