### PR TITLE
fix: disable webconsole watermark by default

### DIFF
--- a/pkg/webconsole/options/options.go
+++ b/pkg/webconsole/options/options.go
@@ -35,7 +35,7 @@ type WebConsoleOptions struct {
 	SshSessionTimeoutMinutes int `help:"ssh timeout session" default:"-1"`
 	RdpSessionTimeoutMinutes int `help:"rdp timeout session" default:"-1"`
 
-	EnableWatermark bool `help:"enable water mark" default:"true"`
+	EnableWatermark bool `help:"enable water mark" default:"false"`
 }
 
 func OnOptionsChange(oldO, newO interface{}) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: disable webconsole watermark by default

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.12
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @ioito @zexi 