### PR TITLE
fix(region): container is not started when pod's flavor changed

### DIFF
--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -471,7 +471,7 @@ func (self *SBaremetalGuestDriver) RequestRebuildRootDisk(ctx context.Context, g
 	return nil
 }
 
-func (self *SBaremetalGuestDriver) PerformStart(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, data *jsonutils.JSONDict) error {
+func (self *SBaremetalGuestDriver) PerformStart(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, data *jsonutils.JSONDict, parentTaskId string) error {
 	return guest.StartGueststartTask(ctx, userCred, data, "")
 }
 

--- a/pkg/compute/guestdrivers/pod.go
+++ b/pkg/compute/guestdrivers/pod.go
@@ -247,8 +247,8 @@ func (p *SPodDriver) RequestGuestHotAddIso(ctx context.Context, guest *models.SG
 	return task.ScheduleRun(nil)
 }
 
-func (p *SPodDriver) PerformStart(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, data *jsonutils.JSONDict) error {
-	task, err := taskman.TaskManager.NewTask(ctx, "PodStartTask", guest, userCred, nil, "", "", nil)
+func (p *SPodDriver) PerformStart(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, data *jsonutils.JSONDict, parentTaskId string) error {
+	task, err := taskman.TaskManager.NewTask(ctx, "PodStartTask", guest, userCred, nil, parentTaskId, "", nil)
 	if err != nil {
 		return errors.Wrap(err, "New PodStartTask")
 	}

--- a/pkg/compute/guestdrivers/virtualization.go
+++ b/pkg/compute/guestdrivers/virtualization.go
@@ -318,8 +318,8 @@ func (self *SVirtualizedGuestDriver) ValidateCreateDataOnHost(ctx context.Contex
 	return input, nil
 }
 
-func (self *SVirtualizedGuestDriver) PerformStart(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, data *jsonutils.JSONDict) error {
-	return guest.StartGueststartTask(ctx, userCred, data, "")
+func (self *SVirtualizedGuestDriver) PerformStart(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, data *jsonutils.JSONDict, parentTaskId string) error {
+	return guest.StartGueststartTask(ctx, userCred, data, parentTaskId)
 }
 
 func (self *SVirtualizedGuestDriver) CheckDiskTemplateOnStorage(ctx context.Context, userCred mcclient.TokenCredential, imageId string, format string, storageId string, task taskman.ITask) error {

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -1129,7 +1129,7 @@ func (self *SGuest) PerformStart(
 			if err != nil {
 				return nil, errors.Wrapf(err, "GetDriver")
 			}
-			err = driver.PerformStart(ctx, userCred, self, kwargs)
+			err = driver.PerformStart(ctx, userCred, self, kwargs, "")
 			return nil, err
 		} else {
 			return nil, httperrors.NewInvalidStatusError("Some disk not ready")

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -129,7 +129,7 @@ type IGuestDriver interface {
 
 	OnDeleteGuestFinalCleanup(ctx context.Context, guest *SGuest, userCred mcclient.TokenCredential) error
 
-	PerformStart(ctx context.Context, userCred mcclient.TokenCredential, guest *SGuest, data *jsonutils.JSONDict) error
+	PerformStart(ctx context.Context, userCred mcclient.TokenCredential, guest *SGuest, data *jsonutils.JSONDict, parentTaskId string) error
 
 	CheckDiskTemplateOnStorage(ctx context.Context, userCred mcclient.TokenCredential, imageId string, format string, storageId string, task taskman.ITask) error
 

--- a/pkg/compute/tasks/guest_change_config_task.go
+++ b/pkg/compute/tasks/guest_change_config_task.go
@@ -453,7 +453,11 @@ func (task *GuestChangeConfigTask) OnSyncStatusComplete(ctx context.Context, obj
 	guest := obj.(*models.SGuest)
 	if guest.Status == api.VM_READY && jsonutils.QueryBoolean(task.Params, "auto_start", false) {
 		task.SetStage("OnGuestStartComplete", nil)
-		guest.StartGueststartTask(ctx, task.UserCred, nil, task.GetTaskId())
+		drv, _ := guest.GetDriver()
+		if err := drv.PerformStart(ctx, task.GetUserCred(), guest, nil, task.GetTaskId()); err != nil {
+			task.OnGuestStartCompleteFailed(ctx, guest, jsonutils.NewString(err.Error()))
+			return
+		}
 	} else {
 		dt := jsonutils.NewDict()
 		dt.Add(jsonutils.NewString(guest.Id), "id")


### PR DESCRIPTION
**What this PR does / why we need it**:

可以合并到 3.11 ，主要是能够在 task 里面调用 guest.GetDriver() 的 PerformStart 函数

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.11
/area region