### PR TITLE
feat(climc): migrate pod port_mappings to guest network

### DIFF
--- a/pkg/apis/compute/guestnetwork.go
+++ b/pkg/apis/compute/guestnetwork.go
@@ -85,7 +85,8 @@ type GuestnetworkUpdateInput struct {
 
 	Index *int8 `json:"index"`
 
-	IsDefault *bool `json:"is_default"`
+	IsDefault    *bool             `json:"is_default"`
+	PortMappings GuestPortMappings `json:"port_mappings"`
 }
 
 type GuestnetworkBaseDesc struct {

--- a/pkg/apis/compute/pod.go
+++ b/pkg/apis/compute/pod.go
@@ -87,3 +87,7 @@ type PodMetadataPortMapping struct {
 	HostPort      int32                  `json:"host_port,omitempty"`
 	HostIp        string                 `json:"host_ip"`
 }
+
+type GuestSetPortMappingsInput struct {
+	PortMappings []*PodPortMapping `json:"port_mappings"`
+}

--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -843,6 +843,12 @@ func (gn *SGuestnetwork) ValidateUpdateData(
 			return input, errors.Wrap(httperrors.ErrInvalidStatus, "nic of default gateway has no ip")
 		}
 	}
+	for _, pm := range input.PortMappings {
+		if err := validatePortMapping(pm); err != nil {
+			return input, err
+		}
+	}
+
 	var err error
 	input.GuestJointBaseUpdateInput, err = gn.SGuestJointsBase.ValidateUpdateData(ctx, userCred, query, input.GuestJointBaseUpdateInput)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

更新设置 port_mappings 流程：

```bash
# 先关闭容器
climc server-stop kbox-41-1

# 迁移容器 metadata 里面的 port_mappings 到 server network
climc pod-migrate-port-mappings --remote-ip x.x.x.x kbox-41-1

# 最后重启 pod
climc server-start kbox-41-1
```

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- NONE
/area region climc
