### PR TITLE
feat(climc): update port_mappings of server network

### DIFF
--- a/pkg/cloudcommon/cmdline/parser.go
+++ b/pkg/cloudcommon/cmdline/parser.go
@@ -417,6 +417,9 @@ func parseNetworkConfigPortMapping(desc string) (int, *compute.GuestPortMapping,
 				Start: start,
 				End:   end,
 			}
+		case "remote_ips", "remote_ip":
+			ips := strings.Split(val, "|")
+			pm.RemoteIps = ips
 		}
 	}
 	if pm.Port == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

```bash
climc --debug server-network-update -p port=81,host_port=20081 -p port=80,host_port=20080 b7535a4a-e3e3-4821-8d2e-1bccc4f233dd 8ca3268e-16c3-473e-8885-a56403c028e7
```

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
NONE
/area climc