### PR TITLE
Automated cherry pick of #20530: fix: enable image cache cleanup by default

### DIFF
--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -52,7 +52,7 @@ type SHostBaseOptions struct {
 	ImageCacheExpireDays        int  `help:"Image cache expire duration in days" default:"30"`
 	ImageCacheCleanupPercentage int  `help:"The cleanup threshold ratio of image cache size v.s. total storage size" default:"12"`
 	ImageCacheCleanupOnStartup  bool `help:"Cleanup image cache on host startup" default:"false"`
-	ImageCacheCleanupDryRun     bool `help:"Dry run cleanup image cache" default:"true"`
+	ImageCacheCleanupDryRun     bool `help:"Dry run cleanup image cache" default:"false"`
 }
 
 type SHostOptions struct {


### PR DESCRIPTION
Cherry pick of #20530 on release/3.12.

#20530: fix: enable image cache cleanup by default