### PR TITLE
fix(host-deployer): ignore fatal exit when host.conf not exists

### DIFF
--- a/pkg/hostman/hostdeployer/deployserver/options.go
+++ b/pkg/hostman/hostdeployer/deployserver/options.go
@@ -52,7 +52,7 @@ var DeployOption SDeployOptions
 
 func Parse() SDeployOptions {
 	var hostOpts SDeployOptions
-	common_options.ParseOptions(&hostOpts, os.Args, "host.conf", "host")
+	common_options.ParseOptionsIgnoreNoConfigfile(&hostOpts, os.Args, "host.conf", "host")
 	if len(hostOpts.CommonConfigFile) > 0 && fileutils2.Exists(hostOpts.CommonConfigFile) {
 		commonCfg := &host_options.SHostBaseOptions{}
 		commonCfg.Config = hostOpts.CommonConfigFile


### PR DESCRIPTION
**What this PR does / why we need it**:

docker compose 启动的 host-deployer 会没有 /etc/yunion/host.conf 文件，可以忽略这个错误

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.11
/area host-deployer
