### PR TITLE
Automated cherry pick of #20558: fix(host-deployer): ignore fatal exit when host.conf not exists

### DIFF
--- a/pkg/hostman/hostdeployer/deployserver/options.go
+++ b/pkg/hostman/hostdeployer/deployserver/options.go
@@ -52,7 +52,7 @@ var DeployOption SDeployOptions
 
 func Parse() SDeployOptions {
 	var hostOpts SDeployOptions
-	common_options.ParseOptions(&hostOpts, os.Args, "host.conf", "host")
+	common_options.ParseOptionsIgnoreNoConfigfile(&hostOpts, os.Args, "host.conf", "host")
 	if len(hostOpts.CommonConfigFile) > 0 && fileutils2.Exists(hostOpts.CommonConfigFile) {
 		commonCfg := &host_options.SHostBaseOptions{}
 		commonCfg.Config = hostOpts.CommonConfigFile


### PR DESCRIPTION
Cherry pick of #20558 on release/3.11.

#20558: fix(host-deployer): ignore fatal exit when host.conf not exists