### PR TITLE
fix(apigateway): compose environment without k8s service

### DIFF
--- a/pkg/mcclient/modules/webconsole/mod_webconsole.go
+++ b/pkg/mcclient/modules/webconsole/mod_webconsole.go
@@ -16,6 +16,7 @@ package webconsole
 
 import (
 	"fmt"
+	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
@@ -77,16 +78,23 @@ func (m WebConsoleManager) DoCloudShell(s *mcclient.ClientSession, _ jsonutils.J
 	query.Add(jsonutils.NewString("system"), "scope")
 	query.Add(jsonutils.NewString("system-default"), "name")
 	clusters, err := k8s.KubeClusters.List(adminSession, query)
-	if err != nil {
-		return nil, errors.Wrap(err, "KubeClusters")
-	}
-	if len(clusters.Data) == 0 {
+
+	climcSshConnect := func(s *mcclient.ClientSession) (jsonutils.JSONObject, error) {
 		// maybe running in docker compose environment, so try to use ssh way
 		if data, err := m.DoClimcSshConnect(s, "climc", 22); err != nil {
 			return nil, httperrors.NewNotFoundError(errors.Wrap(err, "cluster system-default not found, try to use ssh way").Error())
 		} else {
 			return data, nil
 		}
+	}
+	if err != nil {
+		if errors.Cause(err) == errors.ErrNotFound && strings.Contains(err.Error(), "No such service k8s") {
+			return climcSshConnect(s)
+		}
+		return nil, errors.Wrap(err, "KubeClusters")
+	}
+	if len(clusters.Data) == 0 {
+		return climcSshConnect(s)
 	}
 	clusterId, _ := clusters.Data[0].GetString("id")
 	if len(clusterId) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.11
/area apigateway