### PR TITLE
Automated cherry pick of #20629: fix(region): vendor update for qcloud nat capability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	k8s.io/cluster-bootstrap v0.19.3
 	k8s.io/cri-api v0.22.17
 	moul.io/http2curl/v2 v2.3.0
-	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624063926-5714231aad47
+	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624093546-ec3bdebc874f
 	yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32
 	yunion.io/x/jsonutils v1.0.1-0.20240203102553-4096f103b401
 	yunion.io/x/log v1.0.1-0.20240305175729-7cf2d6cd5a91

--- a/go.sum
+++ b/go.sum
@@ -1215,8 +1215,8 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624063926-5714231aad47 h1:XnJCIPBQSPQNHY3BYRIILWfYBIZYkx6nxFvAxZEi1qY=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624063926-5714231aad47/go.mod h1:quoJjGTJ2PjAY0+3YeN5JuN136whECKmfkJQwIsXKjM=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624093546-ec3bdebc874f h1:YHNmkCONVacoz2tnEIy9IvmdvzLMefL8yD3LiWB0zGY=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624093546-ec3bdebc874f/go.mod h1:quoJjGTJ2PjAY0+3YeN5JuN136whECKmfkJQwIsXKjM=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32 h1:v7POYkQwo1XzOxBoIoRVr/k0V9Y5JyjpshlIFa9raug=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32/go.mod h1:Uxuou9WQIeJXNpy7t2fPLL0BYLvLiMvGQwY7Qc6aSws=
 yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH3WE/H1BjUQdFiWu50JGCFQuuy+Z634=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1489,7 +1489,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624063926-5714231aad47
+# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624093546-ec3bdebc874f
 ## explicit; go 1.18
 yunion.io/x/cloudmux/pkg/apis
 yunion.io/x/cloudmux/pkg/apis/billing

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/qcloud/qcloud.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/qcloud/qcloud.go
@@ -1122,6 +1122,7 @@ func (self *SQcloudClient) GetCapabilities() []string {
 		cloudprovider.CLOUD_CAPABILITY_CDN + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_CONTAINER + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_CERT,
+		cloudprovider.CLOUD_CAPABILITY_NAT + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_SNAPSHOT_POLICY,
 		cloudprovider.CLOUD_CAPABILITY_WAF + cloudprovider.READ_ONLY_SUFFIX,
 	}


### PR DESCRIPTION
Cherry pick of #20629 on release/3.12.

#20629: fix(region): vendor update for qcloud nat capability