### PR TITLE
Automated cherry pick of #20629: fix(region): vendor update for qcloud nat capability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	k8s.io/client-go v0.19.3
 	k8s.io/cluster-bootstrap v0.19.3
 	moul.io/http2curl/v2 v2.3.0
-	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624063928-b28073129fb4
+	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624093555-d4f124f8faed
 	yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32
 	yunion.io/x/jsonutils v1.0.1-0.20240203102553-4096f103b401
 	yunion.io/x/log v1.0.1-0.20240305175729-7cf2d6cd5a91

--- a/go.sum
+++ b/go.sum
@@ -1210,8 +1210,8 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624063928-b28073129fb4 h1:FN5Ll6CC+AJ3oOzK+jGt1Pk7zIz+xCkkIY9x1ECKees=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624063928-b28073129fb4/go.mod h1:quoJjGTJ2PjAY0+3YeN5JuN136whECKmfkJQwIsXKjM=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624093555-d4f124f8faed h1:czdXz3ti2I8JOM/3WVUydETQfcVzdEFiF4k63aTb73g=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624093555-d4f124f8faed/go.mod h1:quoJjGTJ2PjAY0+3YeN5JuN136whECKmfkJQwIsXKjM=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32 h1:v7POYkQwo1XzOxBoIoRVr/k0V9Y5JyjpshlIFa9raug=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32/go.mod h1:Uxuou9WQIeJXNpy7t2fPLL0BYLvLiMvGQwY7Qc6aSws=
 yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH3WE/H1BjUQdFiWu50JGCFQuuy+Z634=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1485,7 +1485,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624063928-b28073129fb4
+# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240624093555-d4f124f8faed
 ## explicit; go 1.18
 yunion.io/x/cloudmux/pkg/apis
 yunion.io/x/cloudmux/pkg/apis/billing

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/qcloud/qcloud.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/qcloud/qcloud.go
@@ -1053,6 +1053,7 @@ func (self *SQcloudClient) GetCapabilities() []string {
 		cloudprovider.CLOUD_CAPABILITY_CDN + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_CONTAINER + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_CERT,
+		cloudprovider.CLOUD_CAPABILITY_NAT + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_SNAPSHOT_POLICY,
 		cloudprovider.CLOUD_CAPABILITY_WAF + cloudprovider.READ_ONLY_SUFFIX,
 	}


### PR DESCRIPTION
Cherry pick of #20629 on release/3.11.

#20629: fix(region): vendor update for qcloud nat capability