### PR TITLE
fix(climc,webconsole): use OS_AUTH_TOKEN for cloud shell running inside compose environment

### DIFF
--- a/build/climc/root/opt/yunion/scripts/motd/climc.sh
+++ b/build/climc/root/opt/yunion/scripts/motd/climc.sh
@@ -6,6 +6,14 @@ fi
 
 test -f /etc/yunion/rcadmin && source /etc/yunion/rcadmin
 
+if [ -n "$OS_AUTH_TOKEN" ]; then
+    test -n "$OS_USERNAME" && unset OS_USERNAME
+    test -n "$OS_PASSWORD" && unset OS_PASSWORD
+    test -n "$OS_DOMAIN_NAME" && unset OS_DOMAIN_NAME
+    test -n "$OS_ACCESS_KEY" && unset OS_ACCESS_KEY
+    test -n "$OS_SECRET_KEY" && unset OS_SECRET_KEY
+fi
+
 source <(climc --completion bash)
 source <(kubectl completion bash)
 


### PR DESCRIPTION


**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.11
/area climc webconsole
