### PR TITLE
Automated cherry pick of #20648: fix(climc,webconsole): use OS_AUTH_TOKEN for cloud shell running inside compose environment

### DIFF
--- a/build/climc/root/opt/yunion/scripts/motd/climc.sh
+++ b/build/climc/root/opt/yunion/scripts/motd/climc.sh
@@ -6,6 +6,14 @@ fi
 
 test -f /etc/yunion/rcadmin && source /etc/yunion/rcadmin
 
+if [ -n "$OS_AUTH_TOKEN" ]; then
+    test -n "$OS_USERNAME" && unset OS_USERNAME
+    test -n "$OS_PASSWORD" && unset OS_PASSWORD
+    test -n "$OS_DOMAIN_NAME" && unset OS_DOMAIN_NAME
+    test -n "$OS_ACCESS_KEY" && unset OS_ACCESS_KEY
+    test -n "$OS_SECRET_KEY" && unset OS_SECRET_KEY
+fi
+
 source <(climc --completion bash)
 source <(kubectl completion bash)
 


### PR DESCRIPTION
Cherry pick of #20648 on master.

#20648: fix(climc,webconsole): use OS_AUTH_TOKEN for cloud shell running inside compose environment