### PR TITLE
Automated cherry pick of #20685: fix(region): support use cached iso image for create cloudpods vm

### DIFF
--- a/pkg/compute/guestdrivers/cloudpods-kvm.go
+++ b/pkg/compute/guestdrivers/cloudpods-kvm.go
@@ -19,6 +19,7 @@ import (
 
 	"yunion.io/x/cloudmux/pkg/cloudprovider"
 	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/cloudinit"
 	"yunion.io/x/pkg/util/rbacscope"
 	"yunion.io/x/pkg/utils"
 
@@ -165,4 +166,14 @@ func (self *SCloudpodsGuestDriver) GetInstanceCapability() cloudprovider.SInstan
 
 func (self *SCloudpodsGuestDriver) GetMinimalSysDiskSizeGb() int {
 	return options.Options.DefaultDiskSizeMB / 1024
+}
+
+func (self *SCloudpodsGuestDriver) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, input *api.ServerCreateInput) (*api.ServerCreateInput, error) {
+	if len(input.UserData) > 0 {
+		_, err := cloudinit.ParseUserData(input.UserData)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return input, nil
 }

--- a/pkg/mcclient/cloudpods/instance.go
+++ b/pkg/mcclient/cloudpods/instance.go
@@ -516,9 +516,18 @@ func (self *SRegion) CreateInstance(hostId, hypervisor string, opts *cloudprovid
 	if opts.BillingCycle != nil {
 		input.Duration = opts.BillingCycle.String()
 	}
+	image, err := self.GetImage(opts.ExternalImageId)
+	if err != nil {
+		return nil, errors.Wrapf(err, "GetImage")
+	}
+	imageId := opts.ExternalImageId
+	if image.DiskFormat == "iso" {
+		input.Cdrom = opts.ExternalImageId
+		imageId = ""
+	}
 	input.Disks = append(input.Disks, &api.DiskConfig{
 		Index:    0,
-		ImageId:  opts.ExternalImageId,
+		ImageId:  imageId,
 		DiskType: api.DISK_TYPE_SYS,
 		SizeMb:   opts.SysDisk.SizeGB * 1024,
 		Backend:  opts.SysDisk.StorageType,


### PR DESCRIPTION
Cherry pick of #20685 on release/3.12.

#20685: fix(region): support use cached iso image for create cloudpods vm