### PR TITLE
fix: always add static routes for metadata server

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -906,6 +906,7 @@ func (d *sDebianLikeRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics 
 
 	// ToServerNics(nics)
 	allNics, bondNics := convertNicConfigs(nics)
+	nicCnt := len(allNics) - len(bondNics)
 
 	mainNic := getMainNic(allNics)
 	var mainIp string
@@ -953,7 +954,7 @@ func (d *sDebianLikeRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics 
 				cmds.WriteString(fmt.Sprintf("    mtu %d\n", nicDesc.Mtu))
 			}
 			var routes = make([][]string, 0)
-			routes = netutils2.AddNicRoutes(routes, nicDesc, mainIp, len(nics))
+			routes = netutils2.AddNicRoutes(routes, nicDesc, mainIp, nicCnt)
 			for _, r := range routes {
 				cmds.WriteString(fmt.Sprintf("    up route add -net %s gw %s || true\n", r[0], r[1]))
 				cmds.WriteString(fmt.Sprintf("    down route del -net %s gw %s || true\n", r[0], r[1]))
@@ -1348,6 +1349,7 @@ func (r *sRedhatLikeRootFs) deployNetworkingScripts(rootFs IDiskPartition, nics 
 			return errors.Wrap(err, "enableBondingModule")
 		}
 	}
+	nicCnt := len(allNics) - len(bondNics)
 
 	mainNic := getMainNic(allNics)
 	var mainIp string
@@ -1416,7 +1418,7 @@ func (r *sRedhatLikeRootFs) deployNetworkingScripts(rootFs IDiskPartition, nics 
 				cmds.WriteString("\n")
 			}
 			var routes = make([][]string, 0)
-			routes = netutils2.AddNicRoutes(routes, nicDesc, mainIp, len(nics))
+			routes = netutils2.AddNicRoutes(routes, nicDesc, mainIp, nicCnt)
 			var rtbl strings.Builder
 			for _, r := range routes {
 				rtbl.WriteString(r[0])

--- a/pkg/hostman/guestfs/fsdriver/netplan_test.go
+++ b/pkg/hostman/guestfs/fsdriver/netplan_test.go
@@ -123,6 +123,12 @@ func TestNewNetplanConfig(t *testing.T) {
 									},
 								},
 								Mtu: 1500,
+								Routes: []*netplan.Route{
+									&netplan.Route{
+										To:  "169.254.169.254/32",
+										Via: "0.0.0.0",
+									},
+								},
 							},
 							Interfaces: []string{
 								"eth0",
@@ -249,11 +255,11 @@ func TestNewNetplanConfig(t *testing.T) {
 			},
 		},
 	}
-	for _, c := range cases {
+	for i, c := range cases {
 		allNics, bondNics := convertNicConfigs(c.nics)
 		netplanConfig := NewNetplanConfig(allNics, bondNics, c.mainIp)
 		if jsonutils.Marshal(netplanConfig).String() != jsonutils.Marshal(c.want).String() {
-			t.Errorf("nics: %s want: %s got: %s", jsonutils.Marshal(c.nics), jsonutils.Marshal(c.want).PrettyString(), jsonutils.Marshal(netplanConfig).PrettyString())
+			t.Errorf("nics %d: %s want: %s got: %s", i, jsonutils.Marshal(c.nics), jsonutils.Marshal(c.want).PrettyString(), jsonutils.Marshal(netplanConfig).PrettyString())
 		}
 	}
 }

--- a/pkg/hostman/guestfs/fsdriver/suse.go
+++ b/pkg/hostman/guestfs/fsdriver/suse.go
@@ -99,6 +99,8 @@ func (r *sSuseLikeRootFs) deployNetworkingScripts(rootFs IDiskPartition, nics []
 		}
 	}
 
+	nicCnt := len(allNics) - len(bondNics)
+
 	var dnsSrv []string
 	mainNic := getMainNic(allNics)
 	var mainIp string
@@ -144,7 +146,7 @@ func (r *sSuseLikeRootFs) deployNetworkingScripts(rootFs IDiskPartition, nics []
 			}
 
 			var routes = make([][]string, 0)
-			routes = netutils2.AddNicRoutes(routes, nicDesc, mainIp, len(nics))
+			routes = netutils2.AddNicRoutes(routes, nicDesc, mainIp, nicCnt)
 			if len(nicDesc.Gateway) > 0 && nicDesc.Ip == mainIp {
 				routes = append(routes, []string{
 					"default",

--- a/pkg/hostman/hostinfo/hostdhcp/dhcpserver.go
+++ b/pkg/hostman/hostinfo/hostdhcp/dhcpserver.go
@@ -185,7 +185,7 @@ func (s *SGuestDHCPServer) getGuestConfig(
 		if !strings.HasPrefix(strings.ToLower(osName), "win") {
 			route = append(route, []string{"0.0.0.0/0", nicdesc.Gateway})
 		}
-		route = append(route, []string{"169.254.169.254/32", nicdesc.Gateway})
+		route = append(route, []string{"169.254.169.254/32", "0.0.0.0"})
 	}
 	route = netutils2.AddNicRoutes(route, nicdesc, mainIp, len(guestNics))
 	conf.Routes = route

--- a/pkg/util/netutils2/netutils.go
+++ b/pkg/util/netutils2/netutils.go
@@ -172,6 +172,11 @@ func AddNicRoutes(routes [][]string, nicDesc *types.SServerNic, mainIp string, n
 			}
 		}
 	}
+
+	if nicDesc.Ip == mainIp {
+		// always add 169.254.169.254 for default NIC
+		routes = addRoute(routes, "169.254.169.254/32", "0.0.0.0")
+	}
 	return routes
 }
 

--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -456,7 +456,7 @@ func generateDhcpOptions(ctx context.Context, guestnetwork *agentmodels.Guestnet
 	var (
 		network = guestnetwork.Network
 		dhcpMac = mac.HashSubnetDhcpMac(network.Id)
-		mdIp    = "169.254.169.254"
+		mdIp    = "169.254.169.254/32"
 
 		ocDhcpRef = fmt.Sprintf("dhcp/%s/%s", guestnetwork.GuestId, guestnetwork.Ifname)
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: always add static routes for metadata server


<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.12
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi @ioito 