### PR TITLE
Automated cherry pick of #20219: fix: ceph stats backward compatible with ceph 12.x

### DIFF
--- a/pkg/util/cephutils/ceph.go
+++ b/pkg/util/cephutils/ceph.go
@@ -146,11 +146,15 @@ func (self *CephClient) CreateImage(name string, sizeMb int64) (*SImage, error) 
 	return image, self.run("rbd", opts)
 }
 
-func (self *CephClient) GetCapacity() (*SCapacity, error) {
+/*
+ * {"kb_used":193408,"bytes_used":198049792,"percent_used":0.32,"bytes_used2":0,"percent_used2":0.00,"osd_max_used":0,"osd_max_used_ratio":0.32,"max_avail":61003137024,"objects":1,"origin_bytes":0,"compress_bytes":0}
+ * {"stored":6198990973173,"objects":1734699,"kb_used":12132844593,"bytes_used":12424032862699,"percent_used":0.30800202488899231,"max_avail":13956734255104}
+ */
+func (cli *CephClient) GetCapacity() (*SCapacity, error) {
 	result := &SCapacity{}
-	opts := self.options()
+	opts := cli.options()
 	opts = append(opts, "df")
-	resp, err := self.output("ceph", opts)
+	resp, err := cli.output("ceph", opts)
 	if err != nil {
 		return nil, errors.Wrapf(err, "output")
 	}
@@ -162,10 +166,14 @@ func (self *CephClient) GetCapacity() (*SCapacity, error) {
 	result.CapacitySizeKb = stats.Stats.TotalBytes / 1024
 	result.UsedCapacitySizeKb = stats.Stats.TotalUsedBytes / 1024
 	for _, pool := range stats.Pools {
-		if pool.Name == self.pool {
-			result.UsedCapacitySizeKb = int64(pool.Stats.Stored / 1024)
+		if pool.Name == cli.pool {
+			if pool.Stats.Stored > 0 {
+				result.UsedCapacitySizeKb = int64(pool.Stats.Stored / 1024)
+			} else {
+				result.UsedCapacitySizeKb = int64(pool.Stats.BytesUsed / 1024)
+			}
 			if pool.Stats.MaxAvail > 0 {
-				result.CapacitySizeKb = int64(pool.Stats.MaxAvail/1024 + int64(pool.Stats.Stored/1024))
+				result.CapacitySizeKb = int64(pool.Stats.MaxAvail/1024) + result.UsedCapacitySizeKb
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick of #20219 on release/3.8.

#20219: fix: ceph stats backward compatible with ceph 12.x