### PR TITLE
Automated cherry pick of #20833: feat(monitor): update influxql-to-metricsql@v0.0.7 to support percentile aggregator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/vishvananda/netns v0.0.5-0.20240412164733-9469873f4601
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/xuri/excelize/v2 v2.7.1
-	github.com/zexi/influxql-to-metricsql v0.0.6
+	github.com/zexi/influxql-to-metricsql v0.0.7
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
 	golang.org/x/crypto v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -760,6 +760,8 @@ github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPR
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zexi/influxql-to-metricsql v0.0.6 h1:E16T4oqgjIJtSNVvhGGHnw+pmY3yGz2iRsmmmSVuOpY=
 github.com/zexi/influxql-to-metricsql v0.0.6/go.mod h1:PyRRM+3Zrzzig6J4okYLeSv+/d+5GaL5ccBaUKQABNs=
+github.com/zexi/influxql-to-metricsql v0.0.7 h1:t2Kp6neknnOnszNl3mLteK4dSmXWglfI1JYUtRWTmyQ=
+github.com/zexi/influxql-to-metricsql v0.0.7/go.mod h1:PyRRM+3Zrzzig6J4okYLeSv+/d+5GaL5ccBaUKQABNs=
 go.etcd.io/etcd/api/v3 v3.5.0 h1:GsV3S+OfZEOCNXdtNkBSR7kgLobAa/SO6tCxRa0GAYw=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0 h1:2aQv6F436YnN7I4VbI8PPYrBhu+SmrTaADcf8Mi/6PU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -983,7 +983,7 @@ github.com/xuri/nfp
 # github.com/yusufpapurcu/wmi v1.2.2
 ## explicit; go 1.16
 github.com/yusufpapurcu/wmi
-# github.com/zexi/influxql-to-metricsql v0.0.6
+# github.com/zexi/influxql-to-metricsql v0.0.7
 ## explicit; go 1.18
 github.com/zexi/influxql-to-metricsql/converter
 github.com/zexi/influxql-to-metricsql/converter/translator


### PR DESCRIPTION
Cherry pick of #20833 on release/3.12.

#20833: feat(monitor): update influxql-to-metricsql@v0.0.7 to support percentile aggregator