### PR TITLE
Automated cherry pick of #20903: fix: opsadmin deny host perform login-info

### DIFF
--- a/pkg/keystone/locale/predefined_yaml.go
+++ b/pkg/keystone/locale/predefined_yaml.go
@@ -44,6 +44,11 @@ policy:
       '*': deny
       list: allow
       get: allow
+    hosts:
+      '*': allow
+      perform:
+        '*': allow
+        login-info: deny
     servers:
       '*': allow
       perform:


### PR DESCRIPTION
Cherry pick of #20903 on release/3.10.

#20903: fix: opsadmin deny host perform login-info