### PR TITLE
fix(region,scheduler): sub pending usage on select cpu numa pin

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -1565,6 +1565,11 @@ func (self *SGuest) StartGueststartTask(
 		}
 	}
 
+	if self.CpuNumaPin != nil {
+		// clean cpu numa pin
+		self.SetCpuNumaPin(ctx, userCred, nil, nil)
+	}
+
 	if schedStart {
 		return self.GuestSchedStartTask(ctx, userCred, data, parentTaskId)
 	} else {

--- a/pkg/compute/tasks/guest_stop_task.go
+++ b/pkg/compute/tasks/guest_stop_task.go
@@ -68,6 +68,9 @@ func (self *GuestStopTask) OnGuestStopTaskComplete(ctx context.Context, guest *m
 	db.OpsLog.LogEvent(guest, db.ACT_STOP, guest.GetShortDesc(ctx), self.UserCred)
 	if guest.Status != api.VM_READY && !self.IsSubtask() { // for kvm
 		guest.SetStatus(ctx, self.GetUserCred(), api.VM_READY, "")
+		if guest.CpuNumaPin != nil {
+			guest.SetCpuNumaPin(ctx, self.UserCred, nil, nil)
+		}
 	}
 	models.HostManager.ClearSchedDescCache(guest.HostId)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_STOP, "success", self.UserCred, true)

--- a/pkg/scheduler/api/sched.go
+++ b/pkg/scheduler/api/sched.go
@@ -220,10 +220,6 @@ func (data *SchedInfo) reviseData() {
 	data.Raw = input.JSON(input).String()
 }
 
-func (d *SchedInfo) SkipDirtyMarkHost() bool {
-	return d.IsContainer || d.Hypervisor == computeapi.HYPERVISOR_POD
-}
-
 func (d *SchedInfo) GetCandidateHostTypes() []string {
 	switch d.Hypervisor {
 	case computeapi.HYPERVISOR_POD:

--- a/pkg/scheduler/manager/task_queue.go
+++ b/pkg/scheduler/manager/task_queue.go
@@ -129,7 +129,7 @@ func GenerateResultHelper(schedInfo *api.SchedInfo) core.IResultHelper {
 }
 
 func setSchedPendingUsage(driver computemodels.IGuestDriver, req *api.SchedInfo, resp *schedapi.ScheduleOutput) error {
-	if req.IsSuggestion || IsDriverSkipScheduleDirtyMark(driver) || req.SkipDirtyMarkHost() {
+	if req.IsSuggestion || IsDriverSkipScheduleDirtyMark(driver) {
 		return nil
 	}
 	for _, item := range resp.Candidates {

--- a/pkg/scheduler/models/pending_usage.go
+++ b/pkg/scheduler/models/pending_usage.go
@@ -21,9 +21,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 
 	schedapi "yunion.io/x/onecloud/pkg/apis/scheduler"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
@@ -291,10 +290,12 @@ func (u *SResourcePendingUsage) IsEmpty() bool {
 }
 
 type SPendingUsage struct {
-	HostId         string
-	Cpu            int
-	CpuPin         map[int]int
-	Memory         int
+	HostId string
+	Cpu    int
+	CpuPin map[int]int
+	Memory int
+
+	// nodeId: memSizeMB
 	NumaMemPin     map[int]int
 	IsolatedDevice int
 	DiskUsage      *SResourcePendingUsage
@@ -327,6 +328,8 @@ func NewPendingUsageBySchedInfo(hostId string, req *api.SchedInfo, candidate *sc
 			if cpuNumaPin.MemSizeMB != nil {
 				if v, ok := u.NumaMemPin[cpuNumaPin.NodeId]; ok {
 					u.NumaMemPin[cpuNumaPin.NodeId] = v + *cpuNumaPin.MemSizeMB
+				} else {
+					u.NumaMemPin[cpuNumaPin.NodeId] = *cpuNumaPin.MemSizeMB
 				}
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- reset guest cpu numa pin before start guest
- sub pending usage on select cpu numa pin
- hypervisor pod record pending usage
- add core:threads pair allocate, use same core threads first

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.11
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
