### PR TITLE
Automated cherry pick of #20983: fix(region): validate guestdisk cache/io mode on upadte

### DIFF
--- a/pkg/compute/models/guestdisks.go
+++ b/pkg/compute/models/guestdisks.go
@@ -92,6 +92,21 @@ func (self *SGuestdisk) ValidateUpdateData(ctx context.Context, userCred mcclien
 			return input, httperrors.NewInputParameterError("DISK Index %d has been occupied", index)
 		}
 	}
+	if self.CacheMode != input.CacheMode {
+		if input.CacheMode != "none" {
+			input.AioMode = "threads"
+		}
+	}
+	if self.AioMode != input.AioMode {
+		cacheMode := self.CacheMode
+		if input.CacheMode != "" {
+			cacheMode = input.CacheMode
+		}
+		if input.AioMode == "native" && cacheMode != "none" {
+			return input, httperrors.NewBadRequestError("Aio mode %s with cache mode %s not supported", input.AioMode, cacheMode)
+		}
+	}
+
 	var err error
 	input.GuestJointBaseUpdateInput, err = self.SGuestJointsBase.ValidateUpdateData(ctx, userCred, query, input.GuestJointBaseUpdateInput)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #20983 on release/3.11.6.

#20983: fix(region): validate guestdisk cache/io mode on upadte