### PR TITLE
1、裸金属删除时，GuestUndeployTask会出现无法调用任务完成方法OnGuestUndeployComplete，导致任务卡住的情况

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -630,8 +630,10 @@ func (b *SBaremetalInstance) SaveDesc(ctx context.Context, desc jsonutils.JSONOb
 	b.descLock.Lock()
 	defer b.descLock.Unlock()
 	if desc != nil {
+		if desc != nil && b.desc != nil && b.desc.Contains("server_id") && !desc.Contains("server_id") {
+			desc.(*jsonutils.JSONDict).Set("server_id", jsonutils.NewString(b.server.GetId()))
+		}
 		b.desc = desc.(*jsonutils.JSONDict)
-
 		if b.desc.Contains("sys_info") {
 			sysInfo := types.SSystemInfo{}
 			err := b.desc.Unmarshal(&sysInfo, "sys_info")

--- a/pkg/compute/tasks/guest_undeploy_task.go
+++ b/pkg/compute/tasks/guest_undeploy_task.go
@@ -57,6 +57,7 @@ func (self *GuestUndeployTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 		if err != nil {
 			self.OnStartDeleteGuestFail(ctx, err)
 		}
+		self.SetStageComplete(ctx, nil)
 	} else {
 		self.SetStageComplete(ctx, nil)
 	}

--- a/pkg/compute/tasks/guest_undeploy_task.go
+++ b/pkg/compute/tasks/guest_undeploy_task.go
@@ -57,7 +57,6 @@ func (self *GuestUndeployTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 		if err != nil {
 			self.OnStartDeleteGuestFail(ctx, err)
 		}
-		self.SetStageComplete(ctx, nil)
 	} else {
 		self.SetStageComplete(ctx, nil)
 	}


### PR DESCRIPTION
2、裸金属删除时，回调用baremetal-agent的sync-config接口不止一次，调用时出现请求参数没有传递server_id情况，导致在OnPXEBoot调用getServer时删除了baremetal的server信息，致使后面的DoEraseDisk方法报错

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
