### PR TITLE
Automated cherry pick of #21098: fix(monitor): only show MEAN and SUM aggregators

### DIFF
--- a/pkg/apis/monitor/unifiedmonitor_query.go
+++ b/pkg/apis/monitor/unifiedmonitor_query.go
@@ -23,9 +23,8 @@ var (
 	UNIFIED_MONITOR_FIELD_OPT_TYPE   = []string{"Aggregations", "Selectors"}
 	UNIFIED_MONITOR_GROUPBY_OPT_TYPE = []string{"time", "tag", "fill"}
 	UNIFIED_MONITOR_FIELD_OPT_VALUE  = map[string][]string{
-		"Aggregations": {"COUNT", "DISTINCT", "INTEGRAL",
-			"MEAN", "MEDIAN", "MODE", "STDDEV", "SUM"},
-		"Selectors": {"BOTTOM", "FIRST", "LAST", "MAX", "MIN", "TOP"},
+		"Aggregations": {"MEAN", "SUM"}, // {"COUNT", "DISTINCT", "INTEGRAL", "MEAN", "MEDIAN", "MODE", "STDDEV", "SUM"},
+		"Selectors":    {"BOTTOM", "FIRST", "LAST", "MAX", "MIN", "TOP"},
 	}
 	UNIFIED_MONITOR_GROUPBY_OPT_VALUE = map[string][]string{
 		"fill": {"linear", "none", "previous", "0"},


### PR DESCRIPTION
Cherry pick of #21098 on release/3.10.

#21098: fix(monitor): only show MEAN and SUM aggregators