### PR TITLE
Automated cherry pick of #21111: fix(climc): host-ssh is not working

### DIFF
--- a/cmd/climc/shell/compute/hosts.go
+++ b/cmd/climc/shell/compute/hosts.go
@@ -602,7 +602,7 @@ func init() {
 		i, e := modules.Hosts.PerformAction(s, args.ID, "login-info", nil)
 		privateKey := ""
 		if e != nil {
-			if httputils.ErrorCode(e) == 404 || e.Error() == "ciphertext too short" {
+			if httputils.ErrorCode(e) == 404 || strings.Contains(e.Error(), "ciphertext too short") {
 				var err error
 				privateKey, err = modules.Sshkeypairs.FetchPrivateKeyBySession(context.Background(), s)
 				if err != nil {


### PR DESCRIPTION
Cherry pick of #21111 on release/3.12.

#21111: fix(climc): host-ssh is not working