### PR TITLE
fix(climc): monitor-alert-test-run prints result error

### DIFF
--- a/cmd/climc/shell/monitor/alert.go
+++ b/cmd/climc/shell/monitor/alert.go
@@ -15,7 +15,6 @@
 package monitor
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"yunion.io/x/pkg/errors"
@@ -46,11 +45,7 @@ func init() {
 			if err != nil {
 				return errors.Wrap(err, "DoTestRun")
 			}
-			jsonBytes, err := json.MarshalIndent(ret, "", "  ")
-			if err != nil {
-				return errors.Wrap(err, "MarshalIndent")
-			}
-			fmt.Printf("%s\n", jsonBytes)
+			fmt.Printf("%s\n", ret.PrettyString())
 			return nil
 		})
 }

--- a/pkg/mcclient/modules/monitor/alert.go
+++ b/pkg/mcclient/modules/monitor/alert.go
@@ -15,8 +15,6 @@
 package monitor
 
 import (
-	"encoding/json"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 
@@ -125,14 +123,10 @@ func (m *SAlertManager) DoCreate(s *mcclient.ClientSession, config *AlertConfig)
 	return m.Create(s, input.JSON(input))
 }
 
-func (m *SAlertManager) DoTestRun(s *mcclient.ClientSession, id string, input *monitor.AlertTestRunInput) (*monitor.AlertTestRunOutput, error) {
+func (m *SAlertManager) DoTestRun(s *mcclient.ClientSession, id string, input *monitor.AlertTestRunInput) (jsonutils.JSONObject, error) {
 	ret, err := m.PerformAction(s, id, "test-run", input.JSON(input))
 	if err != nil {
 		return nil, errors.Wrap(err, "call test-run")
 	}
-	out := new(monitor.AlertTestRunOutput)
-	if err := json.Unmarshal([]byte(ret.String()), out); err != nil {
-		return nil, errors.Wrapf(err, "Unmarshal %s", ret.String())
-	}
-	return out, nil
+	return ret, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.10
/area climc