### PR TITLE
Automated cherry pick of #21225: fix(cloudmon): vendor update for aws gcp cpu metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	k8s.io/cluster-bootstrap v0.19.3
 	k8s.io/cri-api v0.22.17
 	moul.io/http2curl/v2 v2.3.0
-	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240906024748-a9bd6344aaf8
+	yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240913034224-f786ec11d173
 	yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32
 	yunion.io/x/jsonutils v1.0.1-0.20240203102553-4096f103b401
 	yunion.io/x/log v1.0.1-0.20240305175729-7cf2d6cd5a91

--- a/go.sum
+++ b/go.sum
@@ -1214,8 +1214,8 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240906024748-a9bd6344aaf8 h1:lSB6Gm2QmAYZozENmA1AjwbM3/nQaEA6F3ZSVDhC+rw=
-yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240906024748-a9bd6344aaf8/go.mod h1:iLoBHVR2Eur/1WJSGcbZaEwpzh/iqXvbFCsX9/xt8CI=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240913034224-f786ec11d173 h1:UuSwRaqQkCCJhe73es1IZOtfJRZUmSxnAaoHVnNKqFA=
+yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240913034224-f786ec11d173/go.mod h1:iLoBHVR2Eur/1WJSGcbZaEwpzh/iqXvbFCsX9/xt8CI=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32 h1:v7POYkQwo1XzOxBoIoRVr/k0V9Y5JyjpshlIFa9raug=
 yunion.io/x/executor v0.0.0-20230705125604-c5ac3141db32/go.mod h1:Uxuou9WQIeJXNpy7t2fPLL0BYLvLiMvGQwY7Qc6aSws=
 yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH3WE/H1BjUQdFiWu50JGCFQuuy+Z634=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1489,7 +1489,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240906024748-a9bd6344aaf8
+# yunion.io/x/cloudmux v0.3.10-0-alpha.1.0.20240913034224-f786ec11d173
 ## explicit; go 1.18
 yunion.io/x/cloudmux/pkg/apis
 yunion.io/x/cloudmux/pkg/apis/billing

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/aws/monitor.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/aws/monitor.go
@@ -95,7 +95,7 @@ type Datapoint struct {
 }
 
 func (self Datapoint) GetValue() float64 {
-	return self.Average + self.Average + self.Minimum + self.Sum
+	return self.Average + self.Minimum + self.Sum
 }
 
 type Datapoints struct {

--- a/vendor/yunion.io/x/cloudmux/pkg/multicloud/google/monitor.go
+++ b/vendor/yunion.io/x/cloudmux/pkg/multicloud/google/monitor.go
@@ -111,6 +111,9 @@ func (self *SGoogleClient) GetEcsMetrics(opts *cloudprovider.MetricListOptions) 
 			metricValue := cloudprovider.MetricValue{}
 			metricValue.Timestamp = data[i].Points[j].Interval.StartTime
 			metricValue.Value = data[i].Points[j].Value.GetValue()
+			if opts.MetricType == cloudprovider.VM_METRIC_TYPE_CPU_USAGE {
+				metricValue.Value *= 100
+			}
 			value.Values = append(value.Values, metricValue)
 		}
 		ret = append(ret, value)


### PR DESCRIPTION
Cherry pick of #21225 on release/3.12.

#21225: fix(cloudmon): vendor update for aws gcp cpu metric