### PR TITLE
Automated cherry pick of #21079: 1、裸金属删除时，GuestUndeployTask会出现无法调用任务完成方法OnGuestUndeployComplete，导致任务卡住的情况

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -630,8 +630,10 @@ func (b *SBaremetalInstance) SaveDesc(ctx context.Context, desc jsonutils.JSONOb
 	b.descLock.Lock()
 	defer b.descLock.Unlock()
 	if desc != nil {
+		if desc != nil && b.desc != nil && b.desc.Contains("server_id") && !desc.Contains("server_id") {
+			desc.(*jsonutils.JSONDict).Set("server_id", jsonutils.NewString(b.server.GetId()))
+		}
 		b.desc = desc.(*jsonutils.JSONDict)
-
 		if b.desc.Contains("sys_info") {
 			sysInfo := types.SSystemInfo{}
 			err := b.desc.Unmarshal(&sysInfo, "sys_info")

--- a/pkg/compute/tasks/guest_undeploy_task.go
+++ b/pkg/compute/tasks/guest_undeploy_task.go
@@ -52,7 +52,6 @@ func (self *GuestUndeployTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 		if err != nil {
 			self.OnStartDeleteGuestFail(ctx, err)
 		}
-		self.SetStageComplete(ctx, nil)
 	} else {
 		self.SetStageComplete(ctx, nil)
 	}

--- a/pkg/compute/tasks/guest_undeploy_task.go
+++ b/pkg/compute/tasks/guest_undeploy_task.go
@@ -52,6 +52,7 @@ func (self *GuestUndeployTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 		if err != nil {
 			self.OnStartDeleteGuestFail(ctx, err)
 		}
+		self.SetStageComplete(ctx, nil)
 	} else {
 		self.SetStageComplete(ctx, nil)
 	}


### PR DESCRIPTION
Cherry pick of #21079 on release/3.11.

#21079: 1、裸金属删除时，GuestUndeployTask会出现无法调用任务完成方法OnGuestUndeployComplete，导致任务卡住的情况