### PR TITLE
Automated cherry pick of #21233: fix(region): guest without cpunumapin don't set params on save schedule result

### DIFF
--- a/pkg/compute/tasks/guest_live_migrate_task.go
+++ b/pkg/compute/tasks/guest_live_migrate_task.go
@@ -130,8 +130,6 @@ func (task *GuestMigrateTask) SaveScheduleResult(ctx context.Context, obj ISched
 	body.Set("target_host_id", jsonutils.NewString(targetHostId))
 	if len(target.CpuNumaPin) > 0 {
 		body.Set("target_cpu_numa_pin", jsonutils.Marshal(target.CpuNumaPin))
-	} else {
-		body.Set("target_cpu_numa_pin", jsonutils.JSONNull)
 	}
 
 	// for params notes


### PR DESCRIPTION
Cherry pick of #21233 on master.

#21233: fix(region): guest without cpunumapin don't set params on save schedule result