### PR TITLE
fix: host build image use go 1.21

### DIFF
--- a/build/docker/multi-arch/Dockerfile.host
+++ b/build/docker/multi-arch/Dockerfile.host
@@ -1,4 +1,4 @@
-FROM registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:3.16.0-go-1.18.2-0 as build
+FROM registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:3.19.0-go-1.21.10-0 as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN mkdir -p /root/go/src/yunion.io/x/onecloud


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: host build image use go 1.21

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.12
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi @ioito 