### PR TITLE
Automated cherry pick of #21263: fix: host build image use go 1.21

### DIFF
--- a/build/docker/multi-arch/Dockerfile.host
+++ b/build/docker/multi-arch/Dockerfile.host
@@ -1,4 +1,4 @@
-FROM registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:3.16.0-go-1.18.2-0 as build
+FROM registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:3.19.0-go-1.21.10-0 as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN mkdir -p /root/go/src/yunion.io/x/onecloud


### PR DESCRIPTION
Cherry pick of #21263 on release/3.12.

#21263: fix: host build image use go 1.21