### PR TITLE
Automated cherry pick of #21252: fix(region): disk metadata with server

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4450,6 +4450,13 @@ func (self *SGuest) CreateDiskOnStorage(ctx context.Context, userCred mcclient.T
 		return nil, err
 	}
 
+	if isWithServerCreate {
+		meta, _ := self.GetAllUserMetadata()
+		if len(meta) > 0 {
+			disk.SetUserMetadataAll(ctx, meta, userCred)
+		}
+	}
+
 	if pendingUsage != nil {
 		cancelUsage := SQuota{}
 		cancelUsage.Storage = disk.DiskSize


### PR DESCRIPTION
Cherry pick of #21252 on release/3.11.7.

#21252: fix(region): disk metadata with server