### PR TITLE
fix(host): check qga is init on check qga runing

### DIFF
--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -493,6 +493,10 @@ func (m *SGuestManager) GetQgaRunningGuests() []string {
 			return true
 		}
 
+		if guest.guestAgent == nil {
+			// in case guestAgent not init
+			return true
+		}
 		if guest.guestAgent.TryLock() {
 			defer guest.guestAgent.Unlock()
 			err := guest.guestAgent.GuestPing(1)


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.11
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
