### PR TITLE
Automated cherry pick of #21308: fix(host): check qga is init on check qga runing

### DIFF
--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -493,6 +493,10 @@ func (m *SGuestManager) GetQgaRunningGuests() []string {
 			return true
 		}
 
+		if guest.guestAgent == nil {
+			// in case guestAgent not init
+			return true
+		}
 		if guest.guestAgent.TryLock() {
 			defer guest.guestAgent.Unlock()
 			err := guest.guestAgent.GuestPing(1)


### PR DESCRIPTION
Cherry pick of #21308 on release/3.11.7.

#21308: fix(host): check qga is init on check qga runing