### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/hostman/diskutils/qemu_kvm/lvm.go
+++ b/pkg/hostman/diskutils/qemu_kvm/lvm.go
@@ -92,7 +92,7 @@ func (d *LocalDiskDriver) getVgLvs(vg string) ([]LvProps, error) {
 	if len(res.Report) != 1 {
 		return nil, errors.Errorf("unexpect res %v", res)
 	}
-	lvs := make([]LvProps, len(res.Report[0].LV))
+	lvs := make([]LvProps, 0, len(res.Report[0].LV))
 	for i := 0; i < len(res.Report[0].LV); i++ {
 		if res.Report[0].LV[i].LVName == "" {
 			continue

--- a/pkg/hostman/storageman/lvmutils/lvmutils.go
+++ b/pkg/hostman/storageman/lvmutils/lvmutils.go
@@ -47,7 +47,7 @@ func GetLvNames(vg string) ([]string, error) {
 	if len(res.Report) != 1 {
 		return nil, errors.Errorf("unexpect res %v", res)
 	}
-	lvNames := make([]string, len(res.Report[0].LV))
+	lvNames := make([]string, 0, len(res.Report[0].LV))
 	for i := 0; i < len(res.Report[0].LV); i++ {
 		lvNames = append(lvNames, res.Report[0].LV[i].LVName)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

The intention here should be to initialize a slice with a capacity of len(res.Report[0].LV rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW


**Does this PR need to be backport to the previous release branch?**:

NONE
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
