### PR TITLE
支持拉取容器认证镜像和相关问题修复

### DIFF
--- a/cmd/climc/shell/identity/credentials.go
+++ b/cmd/climc/shell/identity/credentials.go
@@ -21,6 +21,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/util/printutils"
 
+	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	modules "yunion.io/x/onecloud/pkg/mcclient/modules/identity"
 )
@@ -28,7 +29,7 @@ import (
 func init() {
 	type CredentialListOptions struct {
 		Scope      string `help:"scope" choices:"project|domain|system"`
-		Type       string `help:"credential type" choices:"totp|recovery_secret|aksk|enc_key"`
+		Type       string `help:"credential type" choices:"totp|recovery_secret|aksk|enc_key|container_image"`
 		User       string `help:"filter by user"`
 		UserDomain string `help:"the domain of user"`
 	}
@@ -360,6 +361,33 @@ func init() {
 			return err
 		}
 		printObject(result)
+		return nil
+	})
+
+	type CredentialContainerImageOptions struct {
+		NAME          string `help:"container image credential name"`
+		USER          string `help:"container image credential user"`
+		PASSWORD      string `help:"container image credential password"`
+		Project       string `help:"Project"`
+		ProjectDomain string `help:"domain of user"`
+	}
+	R(&CredentialContainerImageOptions{}, "credential-create-container-image", "Create container image crendential", func(s *mcclient.ClientSession, args *CredentialContainerImageOptions) error {
+		var pid string
+		var err error
+		if len(args.Project) > 0 {
+			pid, err = modules.Projects.FetchId(s, args.Project, args.ProjectDomain)
+			if err != nil {
+				return err
+			}
+		}
+		obj, err := modules.Credentials.CreateContainerImageSecret(s, pid, args.NAME, &api.CredentialContainerImageBlob{
+			Username: args.USER,
+			Password: args.PASSWORD,
+		})
+		if err != nil {
+			return err
+		}
+		printObject(obj)
 		return nil
 	})
 }

--- a/pkg/apis/container.go
+++ b/pkg/apis/container.go
@@ -64,6 +64,8 @@ type ContainerSpec struct {
 	Image string `json:"image"`
 	// Image pull policy
 	ImagePullPolicy ImagePullPolicy `json:"image_pull_policy"`
+	// Image credential id
+	ImageCredentialId string `json:"image_credential_id"`
 	// Command to execute (i.e., entrypoint for docker)
 	Command []string `json:"command"`
 	// Args for the Command (i.e. command for docker)

--- a/pkg/apis/host/container.go
+++ b/pkg/apis/host/container.go
@@ -58,8 +58,9 @@ type ContainerVolumeMount struct {
 
 type ContainerSpec struct {
 	apis.ContainerSpec
-	VolumeMounts []*ContainerVolumeMount `json:"volume_mounts"`
-	Devices      []*ContainerDevice      `json:"devices"`
+	ImageCredentialToken string                  `json:"image_credential_token"`
+	VolumeMounts         []*ContainerVolumeMount `json:"volume_mounts"`
+	Devices              []*ContainerDevice      `json:"devices"`
 }
 
 type ContainerDevice struct {

--- a/pkg/apis/identity/aksk.go
+++ b/pkg/apis/identity/aksk.go
@@ -26,6 +26,7 @@ const (
 	RECOVERY_SECRETS_TYPE = "recovery_secret"
 	OIDC_CREDENTIAL_TYPE  = "oidc"
 	ENCRYPT_KEY_TYPE      = "enc_key"
+	CONTAINER_IMAGE_TYPE  = "container_image"
 )
 
 type SAccessKeySecretBlob struct {

--- a/pkg/apis/identity/credential.go
+++ b/pkg/apis/identity/credential.go
@@ -50,3 +50,15 @@ type CredentialCreateInput struct {
 	// Ignore
 	KeyHash string `json:"key_hash"`
 }
+
+type CredentialContainerImageBlob struct {
+	Username      string `json:"username"`
+	Password      string `json:"password"`
+	Auth          string `json:"auth"`
+	ServerAddress string `json:"server_address,omitempty"`
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identity_token,omitempty"`
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken string `json:"registry_token,omitempty"`
+}

--- a/pkg/compute/tasks/pod_start_task.go
+++ b/pkg/compute/tasks/pod_start_task.go
@@ -41,7 +41,6 @@ func (t *PodStartTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body
 }
 
 func (t *PodStartTask) OnPodStarted(ctx context.Context, pod *models.SGuest, _ jsonutils.JSONObject) {
-	t.SetStage("OnContainerStarted", nil)
 	pod.SetStatus(ctx, t.GetUserCred(), api.POD_STATUS_STARTING_CONTAINER, "")
 	ctrs, err := models.GetContainerManager().GetContainersByPod(pod.GetId())
 	if err != nil {

--- a/pkg/compute/tasks/pod_start_task.go
+++ b/pkg/compute/tasks/pod_start_task.go
@@ -50,7 +50,7 @@ func (t *PodStartTask) OnPodStarted(ctx context.Context, pod *models.SGuest, _ j
 	}
 	isAllStarted := true
 	for i := range ctrs {
-		if ctrs[i].GetStatus() != api.CONTAINER_STATUS_RUNNING {
+		if !api.ContainerRunningStatus.Has(ctrs[i].GetStatus()) {
 			isAllStarted = false
 			ctrs[i].StartStartTask(ctx, t.GetUserCred(), t.GetTaskId())
 		}

--- a/pkg/hostman/guestman/pod_helper.go
+++ b/pkg/hostman/guestman/pod_helper.go
@@ -91,6 +91,27 @@ func PullContainerdImage(input *hostapi.ContainerPullImageInput) error {
 	return nil
 }
 
+func trimPullImageError(err string) string {
+	maxLen := 2048
+	getLine := func(line string, maxLen int) string {
+		if len(line) < maxLen {
+			return line
+		}
+		return line[:maxLen]
+	}
+	if len(err) <= maxLen {
+		return err
+	}
+	lines := strings.Split(err, "\n")
+	if len(lines) <= 1 {
+		return getLine(lines[0], maxLen)
+	}
+	return strings.Join([]string{
+		getLine(lines[0], maxLen/2),
+		getLine(lines[len(lines)-1], maxLen/2)},
+		"\n")
+}
+
 func PushContainerdImage(input *hostapi.ContainerPushImageInput) error {
 	opt := &image.PushOptions{
 		RepoCommonOptions: image.RepoCommonOptions{

--- a/pkg/hostman/guestman/pod_sync_loop.go
+++ b/pkg/hostman/guestman/pod_sync_loop.go
@@ -117,7 +117,12 @@ func (m *SGuestManager) syncContainerLoopIteration(plegCh chan *pleg.PodLifecycl
 		}
 		if e.Type == pleg.ContainerStarted {
 			log.Infof("pod container started: %s", jsonutils.Marshal(e))
-			podMan.SyncStatus("pod container started")
+			ctrId := e.Data.(string)
+			if ctrId == podMan.GetCRIId() {
+				log.Infof("pod %s(%s) is started", podMan.GetId(), ctrId)
+			} else {
+				podMan.SyncStatus("pod container started")
+			}
 		}
 		if e.Type == pleg.ContainerRemoved {
 			/*isInternalRemoved := podMan.IsInternalRemoved(e)

--- a/pkg/mcclient/modules/identity/mod_credentials.go
+++ b/pkg/mcclient/modules/identity/mod_credentials.go
@@ -490,6 +490,21 @@ func (manager *SCredentialManager) CreateTotpSecret(s *mcclient.ClientSession, u
 	return totp.Totp, nil
 }
 
+func (manager *SCredentialManager) CreateContainerImageSecret(s *mcclient.ClientSession, projectId string, name string, blob *api.CredentialContainerImageBlob) (jsonutils.JSONObject, error) {
+	blobJson := jsonutils.Marshal(blob)
+	input := &api.CredentialCreateInput{
+		Type:      api.CONTAINER_IMAGE_TYPE,
+		ProjectId: projectId,
+		Blob:      blobJson.String(),
+	}
+	input.Name = name
+	obj, err := manager.Create(s, jsonutils.Marshal(input))
+	if err != nil {
+		return nil, errors.Wrap(err, "CreateContainerImageSecret")
+	}
+	return obj, nil
+}
+
 func (manager *SCredentialManager) SaveRecoverySecrets(s *mcclient.ClientSession, uid string, questions []SRecoverySecret) error {
 	_, err := manager.GetRecoverySecrets(s, uid)
 	if err == nil {

--- a/pkg/mcclient/options/compute/containers.go
+++ b/pkg/mcclient/options/compute/containers.go
@@ -47,6 +47,7 @@ type ContainerDeleteOptions struct {
 
 type ContainerCreateCommonOptions struct {
 	IMAGE             string   `help:"Image of container" json:"image"`
+	ImageCredentialId string   `help:"Image credential id" json:"image_credential_id"`
 	Command           []string `help:"Command to execute (i.e., entrypoint for docker)" json:"command"`
 	Args              []string `help:"Args for the Command (i.e. command for docker)" json:"args"`
 	WorkingDir        string   `help:"Current working directory of the command" json:"working_dir"`
@@ -70,6 +71,7 @@ func (o ContainerCreateCommonOptions) getCreateSpec() (*computeapi.ContainerSpec
 	req := &computeapi.ContainerSpec{
 		ContainerSpec: apis.ContainerSpec{
 			Image:              o.IMAGE,
+			ImageCredentialId:  o.ImageCredentialId,
 			Command:            o.Command,
 			Args:               o.Args,
 			WorkingDir:         o.WorkingDir,


### PR DESCRIPTION
**What this PR does / why we need it**:

- 支持拉取认证的镜像
- 修复启动容器失败日志没有记录的问题

```bash
# 创建认证credential
climc credential-create-container-image cred-name user-xxx passwd-yyy

# 创建或者更新时设置饿容器的 spec.image_credential_id
```

<img width="543" alt="image" src="https://github.com/user-attachments/assets/37bd8df5-862f-4478-b408-000fc772dd80">


<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- NONE
/area region keystone climc host
/cc @swordqiu 