### PR TITLE
Automated cherry pick of #21399: fix(host-deployer): do not clean spool dir on save image

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -606,10 +606,10 @@ func (l *sLinuxRootFs) PrepareFsForTemplate(rootFs IDiskPartition) error {
 		}
 	}
 	for _, dir := range []string{
-		"/var/spool",
+		// "/var/spool",
 		"/var/run",
 		"/run",
-		"/usr/local/var/spool",
+		// "/usr/local/var/spool",
 		"/usr/local/var/run",
 		"/etc/openvswitch",
 	} {


### PR DESCRIPTION
Cherry pick of #21399 on release/3.12.

#21399: fix(host-deployer): do not clean spool dir on save image