### PR TITLE
Automated cherry pick of #21402: fix(host-deployer): update host-deployer-base to 1.4.9

### DIFF
--- a/build/docker/Dockerfile.host-deployer
+++ b/build/docker/Dockerfile.host-deployer
@@ -1,4 +1,4 @@
-FROM registry.cn-beijing.aliyuncs.com/yunionio/host-deployer-base:1.4.8
+FROM registry.cn-beijing.aliyuncs.com/yunionio/host-deployer-base:1.4.9
 
 MAINTAINER "Yaoqi Wan wanyaoqi@yunionyun.com"
 


### PR DESCRIPTION
Cherry pick of #21402 on release/3.11.8.

#21402: fix(host-deployer): update host-deployer-base to 1.4.9