### PR TITLE
Automated cherry pick of #21412: fix(scheduler): avoid_same_host 策略分数过高导致调度分配不均

### DIFF
--- a/pkg/scheduler/algorithm/priorities/guest/avoid_same_host.go
+++ b/pkg/scheduler/algorithm/priorities/guest/avoid_same_host.go
@@ -36,7 +36,7 @@ func (p *AvoidSameHostPriority) Map(u *core.Unit, c core.Candidater) (core.HostP
 
 	ownerTenantID := u.SchedData().Project
 	if count, ok := c.Getter().ProjectGuests()[ownerTenantID]; ok && count > 0 {
-		h.SetScore(-1 * int(count))
+		h.SetScore(-1 * int(float64(count)*0.1))
 	}
 
 	return h.GetResult()


### PR DESCRIPTION
Cherry pick of #21412 on release/3.12.

#21412: fix(scheduler): avoid_same_host 策略分数过高导致调度分配不均