### PR TITLE
Automated cherry pick of #21432: fix: host bond slave nic should use permaddr as mac

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1705,7 +1705,7 @@ func (h *SHostInfo) ensureNicsHostwires(hostInfo *api.HostDetails) error {
 func (h *SHostInfo) isVirtualFunction(nic string) bool {
 	physPortName, err := fileutils2.FileGetContents(path.Join("/sys/class/net", nic, "phys_port_name"))
 	if err != nil {
-		log.Warningf("failed get nic %s phys_port_name: %s", nic, err)
+		// log.Warningf("failed get nic %s phys_port_name: %s", nic, err)
 		return false
 	}
 	if strings.Contains(physPortName, "vf") {
@@ -1721,13 +1721,15 @@ func (h *SHostInfo) uploadNetworkInfo() error {
 	if err != nil {
 		return errors.Wrap(err, "parse physical nics info")
 	}
-	for _, pnic := range phyNics {
+	for i, pnic := range phyNics {
 		if h.isVirtualFunction(pnic.Dev) {
+			log.Warningf("phyNics %d %#v is a virtual function", i, pnic)
 			continue
 		}
 		nic := h.getMatchNic(pnic.Mac.String(), 1)
 		if nic != nil {
 			// no need to report managed NIC
+			log.Warningf("phyNics %d %#v is managed interface", i, pnic)
 			continue
 		}
 		// only report unmanaged physical NIC

--- a/pkg/util/sysutils/nics.go
+++ b/pkg/util/sysutils/nics.go
@@ -71,7 +71,17 @@ func Nics() ([]*types.SNicDevInfo, error) {
 			if carrier == "1" {
 				up = true
 			}
-			mac, _ := net.ParseMAC(GetSysConfigQuiet(filepath.Join(netPath, "address")))
+			macStr := GetSysConfigQuiet(filepath.Join(netPath, "address"))
+			permMacStr := GetSysConfigQuiet(filepath.Join(netPath, "bonding_slave/perm_hwaddr"))
+			var mac net.HardwareAddr
+			if len(permMacStr) > 0 {
+				mac, _ = net.ParseMAC(permMacStr)
+			} else if len(macStr) > 0 {
+				mac, _ = net.ParseMAC(macStr)
+			} else {
+				// no valid mac address
+				continue
+			}
 			mtuStr := GetSysConfigQuiet(filepath.Join(netPath, "mtu"))
 			mtu := 0
 			if len(mtuStr) > 0 {


### PR DESCRIPTION
Cherry pick of #21432 on release/3.11.

#21432: fix: host bond slave nic should use permaddr as mac