### PR TITLE
fix(host): not set container_exited status when do server-syncstatus

### DIFF
--- a/pkg/hostman/guestman/pod.go
+++ b/pkg/hostman/guestman/pod.go
@@ -324,12 +324,14 @@ func (s *sPodGuestInstance) getStatus(ctx context.Context, defaultStatus string)
 		status = computeapi.VM_RUNNING
 	}
 	for _, c := range s.containers {
-		cStatus, _, err := s.getContainerStatus(ctx, c.Id)
+		cStatus, cs, err := s.getContainerStatus(ctx, c.Id)
 		if err != nil {
 			log.Errorf("get container %s status of pod %s", c.Id, s.Id)
 			continue
 		}
-		status = GetPodStatusByContainerStatus(status, cStatus)
+		if cs != nil {
+			status = GetPodStatusByContainerStatus(status, cStatus)
+		}
 	}
 	return status
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- None
/area host
/cc @swordqiu 