### PR TITLE
fix(region): not set PrimaryZone when no dns_domain configured

### DIFF
--- a/pkg/dns/setup.go
+++ b/pkg/dns/setup.go
@@ -64,7 +64,7 @@ func setup(c *caddy.Controller) error {
 			rDNS.PrimaryZone += "."
 		}
 	} else {
-		rDNS.PrimaryZone = "."
+		rDNS.PrimaryZone = ""
 	}
 	rDNS.primaryZoneLabelCount = dns.CountLabel(rDNS.PrimaryZone)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.10
/area region-dns
/cc @swordqiu @ioito 