### PR TITLE
Automated cherry pick of #21510: fix(region): not set PrimaryZone when no dns_domain configured

### DIFF
--- a/pkg/dns/setup.go
+++ b/pkg/dns/setup.go
@@ -64,7 +64,7 @@ func setup(c *caddy.Controller) error {
 			rDNS.PrimaryZone += "."
 		}
 	} else {
-		rDNS.PrimaryZone = "."
+		rDNS.PrimaryZone = ""
 	}
 	rDNS.primaryZoneLabelCount = dns.CountLabel(rDNS.PrimaryZone)
 


### PR DESCRIPTION
Cherry pick of #21510 on release/3.11.

#21510: fix(region): not set PrimaryZone when no dns_domain configured