### PR TITLE
Automated cherry pick of #21552: fix: disable default dns domain cloud.onecloud.io

### DIFF
--- a/pkg/apis/const.go
+++ b/pkg/apis/const.go
@@ -142,3 +142,11 @@ var (
 func IsARM(osArch string) bool {
 	return utils.IsInStringArray(osArch, ARCH_ARM)
 }
+
+func IsIllegalSearchDomain(domain string) bool {
+	switch domain {
+	case "cloud.onecloud.io":
+		return true
+	}
+	return false
+}

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -515,8 +515,10 @@ func (snet *SNetwork) GetNTP() string {
 func (snet *SNetwork) GetDomain() string {
 	if len(snet.GuestDomain) > 0 {
 		return snet.GuestDomain
-	} else {
+	} else if !apis.IsIllegalSearchDomain(options.Options.DNSDomain) {
 		return options.Options.DNSDomain
+	} else {
+		return ""
 	}
 }
 

--- a/pkg/hostman/guestfs/fsdriver/nicteaming.go
+++ b/pkg/hostman/guestfs/fsdriver/nicteaming.go
@@ -20,6 +20,7 @@ import (
 	"yunion.io/x/cloudmux/pkg/apis/compute"
 	"yunion.io/x/jsonutils"
 
+	"yunion.io/x/onecloud/pkg/apis"
 	computeapi "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 	deployapi "yunion.io/x/onecloud/pkg/hostman/hostdeployer/apis"
@@ -48,11 +49,15 @@ func findTeamingNic(nics []*types.SServerNic, mac string) *types.SServerNic {
 func ToServerNics(nics []*deployapi.Nic) []*types.SServerNic {
 	ret := make([]*types.SServerNic, len(nics))
 	for i := 0; i < len(nics); i++ {
+		domain := nics[i].Domain
+		if apis.IsIllegalSearchDomain(domain) {
+			domain = ""
+		}
 		ret[i] = &types.SServerNic{
 			Name:      nics[i].Name,
 			Index:     int(nics[i].Index),
 			Bridge:    nics[i].Bridge,
-			Domain:    nics[i].Domain,
+			Domain:    domain,
 			Ip:        nics[i].Ip,
 			Vlan:      int(nics[i].Vlan),
 			Driver:    nics[i].Driver,

--- a/pkg/hostman/hostdeployer/apis/utils.go
+++ b/pkg/hostman/hostdeployer/apis/utils.go
@@ -22,6 +22,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
+	"yunion.io/x/onecloud/pkg/apis"
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 	"yunion.io/x/onecloud/pkg/hostman/guestman/desc"
 )
@@ -118,6 +119,10 @@ func GuestnetworksDescToDeployDesc(guestnetworks []*desc.SGuestNetwork) []*Nic {
 
 	nics := make([]*Nic, len(guestnetworks))
 	for i, nic := range guestnetworks {
+		domain := nic.Domain
+		if apis.IsIllegalSearchDomain(domain) {
+			domain = ""
+		}
 		nics[i] = new(Nic)
 		nics[i].Mac = nic.Mac
 		nics[i].Ip = nic.Ip
@@ -126,7 +131,7 @@ func GuestnetworksDescToDeployDesc(guestnetworks []*desc.SGuestNetwork) []*Nic {
 		nics[i].Virtual = nic.Virtual
 		nics[i].Gateway = nic.Gateway
 		nics[i].Dns = nic.Dns
-		nics[i].Domain = nic.Domain
+		nics[i].Domain = domain
 		if nic.Routes != nil {
 			nics[i].Routes = nic.Routes.String()
 		}

--- a/pkg/hostman/hostinfo/hostdhcp/dhcpserver.go
+++ b/pkg/hostman/hostinfo/hostdhcp/dhcpserver.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/netutils"
 
+	"yunion.io/x/onecloud/pkg/apis"
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 	"yunion.io/x/onecloud/pkg/hostman/guestman/desc"
 	guestman "yunion.io/x/onecloud/pkg/hostman/guestman/types"
@@ -99,7 +100,9 @@ func gusetnetworkJsonDescToServerNic(nicdesc *types.SServerNic, guestNic *desc.S
 
 	nicdesc.Index = int(guestNic.Index)
 	nicdesc.Bridge = guestNic.Bridge
-	nicdesc.Domain = guestNic.Domain
+	if !apis.IsIllegalSearchDomain(guestNic.Domain) {
+		nicdesc.Domain = guestNic.Domain
+	}
 	nicdesc.Ip = guestNic.Ip
 	nicdesc.Vlan = guestNic.Vlan
 	nicdesc.Driver = guestNic.Driver

--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -29,6 +29,7 @@ import (
 	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/pkg/utils"
 
+	commonapis "yunion.io/x/onecloud/pkg/apis"
 	apis "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	agentmodels "yunion.io/x/onecloud/pkg/vpcagent/models"
@@ -524,7 +525,7 @@ func generateDhcpOptions(ctx context.Context, guestnetwork *agentmodels.Guestnet
 		if dnsDomain == "" {
 			dnsDomain = opts.DNSDomain
 		}
-		if len(dnsDomain) > 0 {
+		if len(dnsDomain) > 0 && !commonapis.IsIllegalSearchDomain(dnsDomain) {
 			dhcpopts.Options["domain_name"] = "\"" + dnsDomain + "\""
 		}
 	}


### PR DESCRIPTION
Cherry pick of #21552 on release/3.11.

#21552: fix: disable default dns domain cloud.onecloud.io