### PR TITLE
Automated cherry pick of #21790: fix(baremetal-agent): adjust redfish http client timeout to 60s

### DIFF
--- a/pkg/util/redfish/redfish.go
+++ b/pkg/util/redfish/redfish.go
@@ -61,6 +61,7 @@ type SBaseRedfishClient struct {
 
 func NewBaseRedfishClient(endpoint string, username, password string, debug bool) SBaseRedfishClient {
 	client := httputils.GetDefaultClient()
+	client.Timeout = 60 * time.Second
 	cli := SBaseRedfishClient{
 		client:   client,
 		endpoint: endpoint,


### PR DESCRIPTION
Cherry pick of #21790 on release/3.11.9.

#21790: fix(baremetal-agent): adjust redfish http client timeout to 60s