### PR TITLE
Automated cherry pick of #21794: fix(region): skip cloudpods vm kernel check

### DIFF
--- a/pkg/mcclient/cloudpods/instance.go
+++ b/pkg/mcclient/cloudpods/instance.go
@@ -362,8 +362,9 @@ func (self *SInstance) LiveMigrateVM(hostId string) error {
 	input := api.GuestLiveMigrateInput{}
 	input.PreferHost = hostId
 	input.PreferHostId = hostId
-	skipCpuCheck := true
-	input.SkipCpuCheck = &skipCpuCheck
+	skipCheck := true
+	input.SkipCpuCheck = &skipCheck
+	input.SkipKernelCheck = &skipCheck
 	_, err := self.host.zone.region.perform(&modules.Servers, self.Id, "live-migrate", input)
 	return err
 }


### PR DESCRIPTION
Cherry pick of #21794 on release/3.11.9.

#21794: fix(region): skip cloudpods vm kernel check