### PR TITLE
Automated cherry pick of #21808: fix(host): fix the rtl8139 NIC information is missing

### DIFF
--- a/pkg/hostman/guestman/pci.go
+++ b/pkg/hostman/guestman/pci.go
@@ -324,6 +324,8 @@ func (s *SKVMGuestInstance) initGuestNetworks(pciRoot, pciBridge *desc.PCIContro
 				s.Desc.Nics[i].Pci = desc.NewPCIDevice(cont.CType, "e1000-82545em", id)
 			case "vmxnet3":
 				s.Desc.Nics[i].Pci = desc.NewPCIDevice(cont.CType, "vmxnet3", id)
+			case "rtl8139":
+				s.Desc.Nics[i].Pci = desc.NewPCIDevice(cont.CType, "rtl8139", id)
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick of #21808 on release/3.11.

#21808: fix(host): fix the rtl8139 NIC information is missing