### PR TITLE
Automated cherry pick of #21849: fix(climc): host-show hide long content sys_info nic_info metadata

### DIFF
--- a/cmd/climc/shell/compute/hosts.go
+++ b/cmd/climc/shell/compute/hosts.go
@@ -37,7 +37,6 @@ import (
 func init() {
 	cmd := shell.NewResourceCmd(&modules.Hosts)
 	cmd.List(&compute.HostListOptions{})
-	cmd.Show(&options.BaseShowOptions{})
 	cmd.GetMetadata(&options.BaseIdOptions{})
 	cmd.GetProperty(&compute.HostStatusStatisticsOptions{})
 
@@ -88,6 +87,34 @@ func init() {
 			fmt.Println("error", err)
 		}
 	}, &options.BaseIdOptions{})
+
+	R(&compute.HostShowOptions{}, "host-show", "Show details of a host", func(s *mcclient.ClientSession, args *compute.HostShowOptions) error {
+		params, err := args.Params()
+		if err != nil {
+			return err
+		}
+		result, err := modules.Hosts.Get(s, args.ID, params)
+		if err != nil {
+			return err
+		}
+		resultDict := result.(*jsonutils.JSONDict)
+		if !args.ShowAll {
+			if !args.ShowMetadata {
+				print("ShowMetadata\n")
+				resultDict.Remove("metadata")
+			}
+			if !args.ShowNicInfo {
+				print("ShowMetadata\n")
+				resultDict.Remove("nic_info")
+			}
+			if !args.ShowSysInfo {
+				print("ShowSysInfo\n")
+				resultDict.Remove("sys_info")
+			}
+		}
+		printObject(resultDict)
+		return nil
+	})
 
 	R(&options.BaseIdOptions{}, "host-logininfo", "Get SSH login information of a host", func(s *mcclient.ClientSession, args *options.BaseIdOptions) error {
 		i, e := modules.Hosts.PerformAction(s, args.ID, "login-info", nil)

--- a/pkg/mcclient/options/compute/host.go
+++ b/pkg/mcclient/options/compute/host.go
@@ -87,6 +87,19 @@ func (opts *HostListOptions) Params() (jsonutils.JSONObject, error) {
 	return params, nil
 }
 
+type HostShowOptions struct {
+	options.BaseShowOptions
+	ShowMetadata bool `help:"Show host metadata in details"`
+	ShowNicInfo  bool `help:"Show host nic_info in details"`
+	ShowSysInfo  bool `help:"Show host sys_info in details"`
+	ShowAll      bool `help:"Show all of host details" short-token:"a"`
+}
+
+func (o *HostShowOptions) Params() (jsonutils.JSONObject, error) {
+	// NOTE: host show only request with base options
+	return jsonutils.Marshal(o.BaseShowOptions), nil
+}
+
 type HostReserveCpusOptions struct {
 	options.BaseIdsOptions
 	Cpus                    string


### PR DESCRIPTION
Cherry pick of #21849 on release/3.12.

#21849: fix(climc): host-show hide long content sys_info nic_info metadata