### PR TITLE
Automated cherry pick of #21858: fix(climc): avoid showing help twice

### DIFF
--- a/cmd/climc/entry/climc.go
+++ b/cmd/climc/entry/climc.go
@@ -335,7 +335,6 @@ func ClimcMain() {
 	}
 
 	if parser.IsHelpSet() {
-		fmt.Print(parser.HelpString())
 		return
 	}
 


### PR DESCRIPTION
Cherry pick of #21858 on release/3.11.

#21858: fix(climc): avoid showing help twice