### PR TITLE
fix(cloudmon): skip pull k8s service info

### DIFF
--- a/pkg/cloudmon/misc/system.go
+++ b/pkg/cloudmon/misc/system.go
@@ -78,6 +78,7 @@ func CollectServiceMetrics(ctx context.Context, userCred mcclient.TokenCredentia
 				apis.SERVICE_TYPE_IMAGE,
 				apis.SERVICE_TYPE_MONITOR,
 				apis.SERVICE_TYPE_VICTORIA_METRICS,
+				"k8s",
 			}) {
 				continue
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

- [ ] Smoke testing completed



If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11
