### PR TITLE
Automated cherry pick of #21861: fix(cloudmon): skip pull k8s service info

### DIFF
--- a/pkg/cloudmon/misc/system.go
+++ b/pkg/cloudmon/misc/system.go
@@ -74,7 +74,12 @@ func CollectServiceMetrics(ctx context.Context, userCred mcclient.TokenCredentia
 		}
 		metrics := []influxdb.SMetricData{}
 		for _, ep := range endpoints {
-			if utils.IsInStringArray(ep.ServiceType, apis.NO_RESOURCE_SERVICES) || ep.ServiceType == apis.SERVICE_TYPE_IMAGE {
+			if utils.IsInStringArray(ep.ServiceType, apis.NO_RESOURCE_SERVICES) || utils.IsInStringArray(ep.ServiceType, []string{
+				apis.SERVICE_TYPE_IMAGE,
+				apis.SERVICE_TYPE_MONITOR,
+				apis.SERVICE_TYPE_VICTORIA_METRICS,
+				"k8s",
+			}) {
 				continue
 			}
 			url := httputils.JoinPath(ep.Url, "version")


### PR DESCRIPTION
Cherry pick of #21861 on release/3.11.9.

#21861: fix(cloudmon): skip pull k8s service info