### PR TITLE
Automated cherry pick of #21861: fix(cloudmon): skip pull k8s service info

### DIFF
--- a/pkg/cloudmon/misc/system.go
+++ b/pkg/cloudmon/misc/system.go
@@ -78,6 +78,7 @@ func CollectServiceMetrics(ctx context.Context, userCred mcclient.TokenCredentia
 				apis.SERVICE_TYPE_IMAGE,
 				apis.SERVICE_TYPE_MONITOR,
 				apis.SERVICE_TYPE_VICTORIA_METRICS,
+				"k8s",
 			}) {
 				continue
 			}


### PR DESCRIPTION
Cherry pick of #21861 on release/3.11.

#21861: fix(cloudmon): skip pull k8s service info