### PR TITLE
fix(region): not change container exited status to net_failed

### DIFF
--- a/pkg/compute/models/containers.go
+++ b/pkg/compute/models/containers.go
@@ -905,7 +905,7 @@ func (c *SContainer) GetReleasedDevices(ctx context.Context, userCred mcclient.T
 
 func (c *SContainer) PerformStatus(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input api.ContainerPerformStatusInput) (jsonutils.JSONObject, error) {
 	if api.ContainerExitedStatus.Has(c.GetStatus()) {
-		if input.Status == api.CONTAINER_STATUS_PROBE_FAILED {
+		if sets.NewString(api.CONTAINER_STATUS_PROBE_FAILED, api.CONTAINER_STATUS_NET_FAILED).Has(input.Status) {
 			return nil, httperrors.NewInputParameterError("can't set container status to %s when %s", input.Status, c.Status)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area region