### PR TITLE
Automated cherry pick of #21944: fix(region): host list add hide cpu topo info option

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3598,6 +3598,7 @@ func (manager *SHostManager) FetchCustomizeColumns(
 	if query.Contains("show_fail_reason") {
 		showReason = true
 	}
+	var hideCpuTypoInfo = jsonutils.QueryBoolean(query, "hide_cpu_topo_info", false)
 	hostIds := make([]string, len(objs))
 	hosts := make([]*SHost, len(objs))
 	for i := range rows {
@@ -3762,6 +3763,16 @@ func (manager *SHostManager) FetchCustomizeColumns(
 		rows[i].Schedtags, _ = schedtags[hostIds[i]]
 		rows[i].NicInfo, _ = nics[hostIds[i]]
 		rows[i].NicCount = len(rows[i].NicInfo)
+
+		if hideCpuTypoInfo {
+			sysInfo, ok := hosts[i].SysInfo.(*jsonutils.JSONDict)
+			if ok {
+				sysInfo.Remove("cpu_info")
+				sysInfo.Remove("topology")
+			}
+			delete(rows[i].Metadata, "cpu_info")
+			delete(rows[i].Metadata, "topology")
+		}
 	}
 	return rows
 }

--- a/pkg/mcclient/options/compute/host.go
+++ b/pkg/mcclient/options/compute/host.go
@@ -64,6 +64,8 @@ type HostListOptions struct {
 	OrderByCpuCommit   string `help:"Order by cpu commit" choices:"desc|asc"`
 	OrderByMemCommit   string `help:"Order by mem commit" choices:"desc|asc"`
 
+	HideCpuTopoInfo *bool `help:"Host list will remove cpu_info and topology info from sysinfo and metadata"`
+
 	options.BaseListOptions
 }
 


### PR DESCRIPTION
Cherry pick of https://github.com/yunionio/cloudpods/pull/21944 on release/3.11.

https://github.com/yunionio/cloudpods/pull/21944: fix(region): host list add hide cpu topo info option