### PR TITLE
Automated cherry pick of #21971: fix(host): wrap qemu machine info error

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1009,7 +1009,7 @@ func (h *SHostInfo) detectQemuCapabilities(version string) error {
 	var machineInfoList = make([]monitor.MachineInfo, 0)
 	err = res.Unmarshal(&machineInfoList, "return")
 	if err != nil {
-		return errors.Errorf("failed unmarshal machineinfo return %s: %s", segs[3], err)
+		return errors.Wrapf(err, "failed unmarshal machineinfo return %s", res.PrettyString())
 	}
 	h.qemuMachineInfoList = machineInfoList
 	qemuCaps := &QemuCaps{


### PR DESCRIPTION
Cherry pick of #21971 on release/3.11.

#21971: fix(host): wrap qemu machine info error