### PR TITLE
fix: is_classic is missing from network details

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1293,6 +1293,9 @@ func (manager *SNetworkManager) FetchCustomizeColumns(
 		if network.IsExitNetwork() {
 			rows[i].Exit = true
 		}
+		if network.IsClassic() {
+			rows[i].IsClassic = true
+		}
 		rows[i].Ports = network.GetPorts()
 		rows[i].Routes = network.GetRoutes()
 		rows[i].Schedtags = GetSchedtagsDetailsToResourceV2(network, ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: is_classic is missing from network details

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11
- release/3.12

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito @wanyaoqi 