### PR TITLE
fix(apigateway): set GOMAXPROCS to 2 when executing climc

### DIFF
--- a/pkg/mcclient/modules/webconsole/mod_webconsole.go
+++ b/pkg/mcclient/modules/webconsole/mod_webconsole.go
@@ -216,6 +216,7 @@ func (m WebConsoleManager) doCloudShell(s *mcclient.ClientSession, info *webcons
 		"OS_ACCESS_KEY":           "",
 		"OS_SECRET_KEY":           "",
 		"OS_TRY_TERM_WIDTH":       "false",
+		"GOMAXPROCS":              "2",
 	}
 	return m.doCloudSshShell(s, info, cmd, args, env)
 	/*return m.doActionWithClimcPod(s, func(s *mcclient.ClientSession, clusterId string, pod jsonutils.JSONObject) (jsonutils.JSONObject, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

k3s 部署的节点默认会设置 pod pid limit 到 1024 限制一个容器能启动的线程总数，climc pod 在多核的宿主机上运行时，go runtime 会根据 ncpu 启动很多线程来运行 goroutine ，就会出现 `fatal error: newosproc` 的错误

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area apigateway
/cc @swordqiu @wanyaoqi @ioito 