### PR TITLE
fix(monitor): not split resource when notifying

### DIFF
--- a/build/monitor/root/opt/yunion/share/notify_templates/monitor/content@cn/DEFAULT.email
+++ b/build/monitor/root/opt/yunion/share/notify_templates/monitor/content@cn/DEFAULT.email
@@ -68,6 +68,7 @@
     border-bottom: 1px solid #d7d7d7;
   }
 </style>
+{{$match_tags_str := .match_tags_str}}
 <body>
   <h3 class="title">报警提醒</h3>
   <table border="0" cellspacing="0" cellpadding="0" class="table">
@@ -110,6 +111,9 @@
               <td>平台</td>
               <td>指标</td>
               <td>触发值</td>
+              {{if gt (len $match_tags_str) 1}}
+              <td>标签</td>
+              {{end}}
             </tr>
           </thead>
           <tbody>
@@ -127,6 +131,9 @@
 				  </td>
 				  <td>{{ $Matche.metric }}</td>
 				  <td>{{ $Matche.value_str }}</td>
+				  {{if gt (len $match_tags_str) 1}}
+				  <td>{{ index $match_tags_str $i }}</td>
+				  {{end}}
 				</tr>
 			{{end}}
           </tbody>

--- a/build/monitor/root/opt/yunion/share/notify_templates/monitor/content@en/DEFAULT.email
+++ b/build/monitor/root/opt/yunion/share/notify_templates/monitor/content@en/DEFAULT.email
@@ -68,6 +68,7 @@
     border-bottom: 1px solid #d7d7d7;
   }
 </style>
+{{$match_tags_str := .match_tags_str}}
 <body>
   <h3 class="title">Alert</h3>
   <table border="0" cellspacing="0" cellpadding="0" class="table">
@@ -110,6 +111,9 @@
               <td>Brand</td>
               <td>Metric</td>
               <td>Trigger value</td>
+              {{if gt (len $match_tags_str) 1}}
+              <td>Tags</td>
+              {{end}}
             </tr>
           </thead>
           <tbody>
@@ -127,6 +131,9 @@
 				  </td>
 				  <td>{{ $Matche.metric }}</td>
 				  <td>{{ $Matche.value_str }}</td>
+				  {{if gt (len $match_tags_str) 1}}
+				  <td>{{ index $match_tags_str $i }}</td>
+				  {{end}}
 				</tr>
 			{{end}}
           </tbody>

--- a/pkg/apis/monitor/template.go
+++ b/pkg/apis/monitor/template.go
@@ -19,10 +19,12 @@ type NotificationTemplateCreateInput struct {
 }
 
 type NotificationTemplateConfig struct {
-	Title        string       `json:"title"`
-	Name         string       `json:"name"`
-	ResourceName string       `json:"resource_name"`
-	Matches      []*EvalMatch `json:"matches"`
+	Title        string              `json:"title"`
+	Name         string              `json:"name"`
+	ResourceName string              `json:"resource_name"`
+	Matches      []*EvalMatch        `json:"matches"`
+	MatchTags    []map[string]string `json:"match_tags"`
+	MatchTagsStr []string            `json:"match_tags_str"`
 	// PrevAlertState AlertStateType `json:"prev_alert_state"`
 	// State AlertStateType `json:"state"`
 	NoDataFound bool   `json:"no_data"`

--- a/pkg/cloudcommon/notifyclient/notify_internal.go
+++ b/pkg/cloudcommon/notifyclient/notify_internal.go
@@ -263,7 +263,10 @@ func genMsgViaLang(ctx context.Context, p sNotifyParams) ([]npk.SNotifyMessage, 
 			topic = p.event
 		}
 		msg.Topic = topic
-		body, _ := getContent(langSuffix, p.event, "content", p.channel, p.data)
+		body, err := getContent(langSuffix, p.event, "content", p.channel, p.data)
+		if err != nil {
+			log.Errorf("get content error: %s", err)
+		}
 		if len(body) == 0 {
 			body, _ = p.data.GetString()
 		}

--- a/pkg/monitor/alerting/notifiers/onecloud.go
+++ b/pkg/monitor/alerting/notifiers/onecloud.go
@@ -247,6 +247,10 @@ func getLangBystr(str string) language.Tag {
 
 func (oc *OneCloudNotifier) notifyByContextLang(ctx context.Context, evalCtx *alerting.EvalContext, uids []string) error {
 	errs := []error{}
+	if evalCtx.Rule.State == monitor.AlertStatePending {
+		log.Warningf("skip notify rule because state is pending: %s", jsonutils.Marshal(evalCtx.Rule))
+		return nil
+	}
 	if len(evalCtx.EvalMatches) > 0 {
 		if err := oc.notifyMatchesByContextLang(ctx, evalCtx, evalCtx.EvalMatches, uids, false); err != nil {
 			errs = append(errs, errors.Wrapf(err, "notify alerting matches"))
@@ -520,7 +524,7 @@ func (s *sendRobotImpl) execNotifyFunc() error {
 }
 
 func SendNotifyInfo(base *sendnotifyBase, imp Isendnotify) error {
-	tmpMatches := base.config.Matches
+	/*tmpMatches := base.config.Matches
 	batch := 100
 	for i := 0; i < len(tmpMatches); i += batch {
 		split := i + batch
@@ -535,5 +539,7 @@ func SendNotifyInfo(base *sendnotifyBase, imp Isendnotify) error {
 		}
 
 	}
-	return nil
+	return nil*/
+	base.config.ResourceName = base.evalCtx.GetResourceNameOfMatches(base.config.Matches)
+	return imp.execNotifyFunc()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.11
/area monitor