### PR TITLE
fix: separate default admin secgroup id for kvm and pod

### DIFF
--- a/pkg/compute/models/guest_secgroups.go
+++ b/pkg/compute/models/guest_secgroups.go
@@ -180,24 +180,25 @@ func (self *SGuest) PerformRevokeSecgroup(
 }
 
 // 解绑管理员安全组
-func (self *SGuest) PerformRevokeAdminSecgroup(
+func (guest *SGuest) PerformRevokeAdminSecgroup(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,
 	query jsonutils.JSONObject,
 	input api.GuestRevokeSecgroupInput,
 ) (jsonutils.JSONObject, error) {
-	if !db.IsAdminAllowPerform(ctx, userCred, self, "revoke-admin-secgroup") {
+	if !db.IsAdminAllowPerform(ctx, userCred, guest, "revoke-admin-secgroup") {
 		return nil, httperrors.NewForbiddenError("not allow to revoke admin secgroup")
 	}
 
-	if !utils.IsInStringArray(self.Status, []string{api.VM_READY, api.VM_RUNNING, api.VM_SUSPEND}) {
-		return nil, httperrors.NewInputParameterError("Cannot assign security rules in status %s", self.Status)
+	if !utils.IsInStringArray(guest.Status, []string{api.VM_READY, api.VM_RUNNING, api.VM_SUSPEND}) {
+		return nil, httperrors.NewInputParameterError("Cannot assign security rules in status %s", guest.Status)
 	}
 
 	var notes string
+	optAdminSecGrpId := options.Options.GetDefaultAdminSecurityGroupId(guest.Hypervisor)
 	adminSecgrpId := ""
-	if len(options.Options.DefaultAdminSecurityGroupId) > 0 {
-		adminSecgrp, _ := SecurityGroupManager.FetchSecgroupById(options.Options.DefaultAdminSecurityGroupId)
+	if len(optAdminSecGrpId) > 0 {
+		adminSecgrp, _ := SecurityGroupManager.FetchSecgroupById(optAdminSecGrpId)
 		if adminSecgrp != nil {
 			adminSecgrpId = adminSecgrp.Id
 			notes = fmt.Sprintf("reset admin secgroup to %s(%s)", adminSecgrp.Name, adminSecgrp.Id)
@@ -207,13 +208,13 @@ func (self *SGuest) PerformRevokeAdminSecgroup(
 		notes = "clean admin secgroup"
 	}
 
-	err := self.saveDefaultSecgroupId(userCred, adminSecgrpId, true)
+	err := guest.saveDefaultSecgroupId(userCred, adminSecgrpId, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "saveDefaultSecgroupId")
 	}
 
-	logclient.AddActionLogWithContext(ctx, self, logclient.ACT_VM_REVOKESECGROUP, notes, userCred, true)
-	return nil, self.StartSyncTask(ctx, userCred, true, "")
+	logclient.AddActionLogWithContext(ctx, guest, logclient.ACT_VM_REVOKESECGROUP, notes, userCred, true)
+	return nil, guest.StartSyncTask(ctx, userCred, true, "")
 }
 
 // +onecloud:swagger-gen-ignore
@@ -400,8 +401,8 @@ func (self *SGuest) newGuestSecgroup(ctx context.Context, secgroupId string) err
 	return GuestsecgroupManager.TableSpec().Insert(ctx, gs)
 }
 
-func (self *SGuest) RevokeAllSecgroups(ctx context.Context, userCred mcclient.TokenCredential) error {
-	gss, err := self.GetGuestSecgroups()
+func (guest *SGuest) RevokeAllSecgroups(ctx context.Context, userCred mcclient.TokenCredential) error {
+	gss, err := guest.GetGuestSecgroups()
 	if err != nil {
 		return errors.Wrapf(err, "GetGuestSecgroups")
 	}
@@ -411,5 +412,5 @@ func (self *SGuest) RevokeAllSecgroups(ctx context.Context, userCred mcclient.To
 			return errors.Wrap(err, "Delete")
 		}
 	}
-	return self.saveDefaultSecgroupId(userCred, options.Options.DefaultSecurityGroupId, false)
+	return guest.saveDefaultSecgroupId(userCred, options.Options.GetDefaultSecurityGroupId(guest.Hypervisor), false)
 }

--- a/pkg/compute/models/secgroups.go
+++ b/pkg/compute/models/secgroups.go
@@ -1038,8 +1038,20 @@ func (self *SSecurityGroup) ValidateDeleteCondition(ctx context.Context, info ap
 	if self.Id == options.Options.DefaultSecurityGroupId {
 		return httperrors.NewProtectedResourceError("not allow to delete default security group")
 	}
+	if self.Id == options.Options.DefaultSecurityGroupIdForKvm {
+		return httperrors.NewProtectedResourceError("not allow to delete default security group for kvm")
+	}
+	if self.Id == options.Options.DefaultSecurityGroupIdForContainer {
+		return httperrors.NewProtectedResourceError("not allow to delete default security group for container")
+	}
 	if self.Id == options.Options.DefaultAdminSecurityGroupId {
 		return httperrors.NewProtectedResourceError("not allow to delete default admin security group")
+	}
+	if self.Id == options.Options.DefaultAdminSecurityGroupIdForKvm {
+		return httperrors.NewProtectedResourceError("not allow to delete default admin security group for kvm")
+	}
+	if self.Id == options.Options.DefaultAdminSecurityGroupIdForContainer {
+		return httperrors.NewProtectedResourceError("not allow to delete default admin security group for container")
 	}
 	if info.TotalCnt > 0 {
 		return httperrors.NewNotEmptyError("the security group %s is in use cnt: %d", self.Id, info.TotalCnt)

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -18,6 +18,7 @@ import (
 	"yunion.io/x/cloudmux/pkg/multicloud/esxi"
 	"yunion.io/x/log"
 
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/cloudcommon/pending_delete"
 )
@@ -34,8 +35,12 @@ type ComputeOptions struct {
 	DefaultMemoryOvercommitBound  float32 `default:"1.0" help:"Default memory overcommit bound for host, default to 1"`
 	DefaultStorageOvercommitBound float32 `default:"1.0" help:"Default storage overcommit bound for storage, default to 1"`
 
-	DefaultSecurityGroupId      string `help:"Default security rules" default:"default"`
-	DefaultAdminSecurityGroupId string `help:"Default admin security rules" default:""`
+	DefaultSecurityGroupId                  string `help:"Default security rules" default:"default"`
+	DefaultSecurityGroupIdForKvm            string `help:"Default security rules for KVM" default:"default"`
+	DefaultSecurityGroupIdForContainer      string `help:"Default security rules for Container" default:"default"`
+	DefaultAdminSecurityGroupId             string `help:"Default admin security rules" default:""`
+	DefaultAdminSecurityGroupIdForKvm       string `help:"Default admin security rules for KVM" default:""`
+	DefaultAdminSecurityGroupIdForContainer string `help:"Default admin security rules for Container" default:""`
 
 	DefaultDiskSizeMB int `default:"10240" help:"Default disk size in MB if not specified, default to 10GiB" json:"default_disk_size"`
 
@@ -277,4 +282,22 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 	}
 
 	return changed
+}
+
+func (o ComputeOptions) GetDefaultSecurityGroupId(hypervisor string) string {
+	if hypervisor == api.HYPERVISOR_KVM && len(o.DefaultSecurityGroupIdForKvm) > 0 {
+		return o.DefaultSecurityGroupIdForKvm
+	} else if hypervisor == api.HYPERVISOR_POD && len(o.DefaultSecurityGroupIdForContainer) > 0 {
+		return o.DefaultSecurityGroupIdForContainer
+	}
+	return o.DefaultSecurityGroupId
+}
+
+func (o ComputeOptions) GetDefaultAdminSecurityGroupId(hypervisor string) string {
+	if hypervisor == api.HYPERVISOR_KVM && len(o.DefaultAdminSecurityGroupIdForKvm) > 0 {
+		return o.DefaultAdminSecurityGroupIdForKvm
+	} else if hypervisor == api.HYPERVISOR_POD && len(o.DefaultAdminSecurityGroupIdForContainer) > 0 {
+		return o.DefaultAdminSecurityGroupIdForContainer
+	}
+	return o.DefaultAdminSecurityGroupId
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: separate default admin secgroup id for kvm and pod

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi @ioito 