### PR TITLE
fix: glance always init s3 client

### DIFF
--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -83,3 +83,7 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 
 	return changed
 }
+
+func (opt SImageOptions) HasValidS3Options() bool {
+	return len(opt.S3Endpoint) > 0 && len(opt.S3AccessKey) > 0 && len(opt.S3SecretKey) > 0 && len(opt.S3BucketName) > 0
+}

--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -140,12 +140,13 @@ func StartService() {
 		deployclient.Init(options.Options.DeployServerSocketPath)
 	}
 
-	if options.Options.StorageDriver == api.IMAGE_STORAGE_DRIVER_S3 {
-		go initS3()
-	} else {
-		// Check the images after everything is ready
-		go models.CheckImages()
-	}
+	go func() {
+		if options.Options.HasValidS3Options() {
+			initS3()
+		}
+		// check image after s3 mounted
+		models.CheckImages()
+	}()
 
 	if !opts.IsSlaveNode {
 		err := taskman.TaskManager.InitializeData()
@@ -262,7 +263,4 @@ func initS3() {
 			break
 		}
 	}
-
-	// check image after s3 mounted
-	models.CheckImages()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: glance always init s3 client

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi 