### PR TITLE
Automated cherry pick of #22143: fix(monitor): always skip_check_series for metric-measurement api

### DIFF
--- a/pkg/monitor/models/datasource.go
+++ b/pkg/monitor/models/datasource.go
@@ -463,7 +463,7 @@ func (m *SDataSourceManager) GetMetricMeasurement(userCred mcclient.TokenCredent
 		return nil, errors.Wrap(err, "getFromAndToFromParam")
 	}
 
-	skipCheckSeries := jsonutils.QueryBoolean(query, "skip_check_series", false)
+	//skipCheckSeries := jsonutils.QueryBoolean(query, "skip_check_series", false)
 
 	output := new(monitor.InfluxMeasurement)
 	output.Measurement = measurement
@@ -471,7 +471,7 @@ func (m *SDataSourceManager) GetMetricMeasurement(userCred mcclient.TokenCredent
 	output.TagValue = make(map[string][]string, 0)
 
 	output.FieldKey = []string{field}
-	if err := getTagValues(userCred, output, timeF, tagFilter, skipCheckSeries); err != nil {
+	if err := getTagValues(userCred, output, timeF, tagFilter, true); err != nil {
 		return jsonutils.JSONNull, errors.Wrap(err, "getTagValues error")
 	}
 


### PR DESCRIPTION
Cherry pick of #22143 on release/3.11.10.

#22143: fix(monitor): always skip_check_series for metric-measurement api