### PR TITLE
Automated cherry pick of #22147: fix(host): check has vga use desc dev_type instead of host dev object

### DIFF
--- a/pkg/hostman/guestman/guesttasks.go
+++ b/pkg/hostman/guestman/guesttasks.go
@@ -926,7 +926,7 @@ func (t *SGuestIsolatedDeviceSyncTask) addDevice(dev *desc.SGuestIsolatedDevice)
 		id := devObj.GetQemuId()
 		dev.VfioDevs = make([]*desc.VFIODevice, 0)
 		vfioDev := desc.NewVfioDevice(
-			*cType, "vfio-pci", id, devObj.GetAddr(), devObj.GetDeviceType() == api.GPU_VGA_TYPE,
+			*cType, "vfio-pci", id, devObj.GetAddr(), dev.DevType == api.GPU_VGA_TYPE,
 		)
 		dev.VfioDevs = append(dev.VfioDevs, vfioDev)
 

--- a/pkg/hostman/guestman/pci.go
+++ b/pkg/hostman/guestman/pci.go
@@ -351,7 +351,7 @@ func (s *SKVMGuestInstance) initIsolatedDevices(pciRoot, pciBridge *desc.PCICont
 			id := dev.GetQemuId()
 			s.Desc.IsolatedDevices[i].VfioDevs = make([]*desc.VFIODevice, 0)
 			vfioDev := desc.NewVfioDevice(
-				*cType, "vfio-pci", id, dev.GetAddr(), dev.GetDeviceType() == api.GPU_VGA_TYPE,
+				*cType, "vfio-pci", id, dev.GetAddr(), s.Desc.IsolatedDevices[i].DevType == api.GPU_VGA_TYPE,
 			)
 			s.Desc.IsolatedDevices[i].VfioDevs = append(s.Desc.IsolatedDevices[i].VfioDevs, vfioDev)
 


### PR DESCRIPTION
Cherry pick of #22147 on release/3.11.10.

#22147: fix(host): check has vga use desc dev_type instead of host dev object