### PR TITLE
fix: disable server TLS 1.0, 1.x and 1.2 SHA1

### DIFF
--- a/pkg/appsrv/appsrv.go
+++ b/pkg/appsrv/appsrv.go
@@ -78,6 +78,8 @@ type Application struct {
 	isTLS bool
 
 	enableProfiling bool
+
+	allowTLS1x bool
 }
 
 const (
@@ -136,6 +138,12 @@ func (app *Application) OnException(exception func(method, path string, body jso
 func (app *Application) SetDefaultTimeout(to time.Duration) *Application {
 	log.Infof("adjust application default timeout to %f seconds", to.Seconds())
 	app.processTimeout = to
+	return app
+}
+
+func (app *Application) AllowTLS1x() *Application {
+	log.Infof("Allow TLS1.0&1.1")
+	app.allowTLS1x = true
 	return app
 }
 
@@ -367,6 +375,7 @@ func (app *Application) defaultHandle(w http.ResponseWriter, r *http.Request, ri
 	w.Header().Set("Server", "Yunion AppServer/Go/2018.4")
 	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	if app.isTLS {
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 	}
@@ -484,7 +493,18 @@ func (app *Application) initServer(addr string) *http.Server {
 
 	cipherSuites := []uint16{}
 	for _, suite := range tls.CipherSuites() {
-		cipherSuites = append(cipherSuites, suite.ID)
+		if !strings.HasSuffix(suite.Name, "_SHA") {
+			cipherSuites = append(cipherSuites, suite.ID)
+		}
+	}
+
+	minTLSVer := uint16(tls.VersionTLS12)
+	if app.allowTLS1x {
+		minTLSVer = tls.VersionTLS10
+	}
+	tlsConf := &tls.Config{
+		CipherSuites: cipherSuites,
+		MinVersion:   minTLSVer,
 	}
 
 	s := &http.Server{
@@ -499,9 +519,7 @@ func (app *Application) initServer(addr string) *http.Server {
 		// issue like: https://github.com/megaease/easegress/issues/481
 		ErrorLog: olog.New(io.Discard, "", olog.LstdFlags),
 
-		TLSConfig: &tls.Config{
-			CipherSuites: cipherSuites,
-		},
+		TLSConfig: tlsConf,
 	}
 	return s
 }
@@ -607,22 +625,6 @@ func (app *Application) listenAndServeInternal(s *http.Server, certFile, keyFile
 	if err != nil && err != http.ErrServerClosed {
 		log.Fatalf("ListAndServer fail: %s (cert=%s key=%s)", err, certFile, keyFile)
 	}
-}
-
-func isJsonContentType(r *http.Request) bool {
-	contType := strings.ToLower(r.Header.Get("Content-Type"))
-	if strings.HasPrefix(contType, "application/json") {
-		return true
-	}
-	return false
-}
-
-func isFormContentType(r *http.Request) bool {
-	contType := strings.ToLower(r.Header.Get("Content-Type"))
-	if strings.HasPrefix(contType, "application/json") {
-		return true
-	}
-	return false
 }
 
 type TContentType string

--- a/pkg/cloudcommon/app/app.go
+++ b/pkg/cloudcommon/app/app.go
@@ -40,6 +40,9 @@ func InitApp(options *common_options.BaseOptions, dbAccess bool) *appsrv.Applica
 	if options.EnableAppProfiling {
 		app.EnableProfiling()
 	}
+	if options.AllowTLS1x {
+		app.AllowTLS1x()
+	}
 	return app
 }
 

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -124,6 +124,7 @@ type BaseOptions struct {
 	PlatformNames map[string]string `help:"identity name of this platform by language"`
 
 	EnableAppProfiling bool `help:"enable profiling API" default:"false"`
+	AllowTLS1x         bool `help:"allow obsolete insecure TLS V1.0&1.1" default:"false" json:"allow_tls1x"`
 
 	EnableChangeOwnerAutoRename bool `help:"Allows renaming when changing names" default:"false"`
 	EnableDefaultPolicy         bool `help:"Enable defualt policies" default:"true"`


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: disable server TLS 1.0, 1.x and 1.2 SHA1

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11
- release/3.11.10
- release/3.10


<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi @ioito 