### PR TITLE
Automated cherry pick of #22165: fix: disable server TLS 1.0, 1.x and 1.2 SHA1

### DIFF
--- a/pkg/cloudcommon/app/app.go
+++ b/pkg/cloudcommon/app/app.go
@@ -40,6 +40,9 @@ func InitApp(options *common_options.BaseOptions, dbAccess bool) *appsrv.Applica
 	if options.EnableAppProfiling {
 		app.EnableProfiling()
 	}
+	if options.AllowTLS1x {
+		app.AllowTLS1x()
+	}
 	return app
 }
 

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -119,6 +119,7 @@ type BaseOptions struct {
 	PlatformNames map[string]string `help:"identity name of this platform by language"`
 
 	EnableAppProfiling bool `help:"enable profiling API" default:"false"`
+	AllowTLS1x         bool `help:"allow obsolete insecure TLS V1.0&1.1" default:"false" json:"allow_tls1x"`
 }
 
 const (


### PR DESCRIPTION
Cherry pick of #22165 on release/3.10.

#22165: fix: disable server TLS 1.0, 1.x and 1.2 SHA1