### PR TITLE
fix(host): add pod to probe manager when dirty marked

### DIFF
--- a/pkg/hostman/guestman/pod.go
+++ b/pkg/hostman/guestman/pod.go
@@ -2015,6 +2015,7 @@ func (s *sPodGuestInstance) markContainerProbeDirty(status, ctrId string, reason
 	if status == computeapi.CONTAINER_STATUS_PROBING {
 		reason = fmt.Sprintf("status is probing: %s", reason)
 		s.getProbeManager().SetDirtyContainer(ctrId, reason)
+		s.getProbeManager().AddPod(s)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area host