### PR TITLE
fix: use host service status storing online/offline status

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -997,13 +997,14 @@ func (guest *SGuest) ValidateDeleteCondition(ctx context.Context, info *api.Serv
 		}
 		info.HostType = host.HostType
 		info.HostEnabled = host.Enabled.Bool()
-		info.HostStatus = host.HostStatus
+		info.HostStatus = host.Status
+		info.HostServiceStatus = host.HostStatus
 	}
 	if len(info.HostType) > 0 && guest.GetHypervisor() != api.HYPERVISOR_BAREMETAL {
 		if !info.HostEnabled {
 			return httperrors.NewInputParameterError("Cannot delete server on disabled host")
 		}
-		if info.HostStatus != api.HOST_ONLINE {
+		if info.HostServiceStatus != api.HOST_ONLINE {
 			return httperrors.NewInputParameterError("Cannot delete server on offline host")
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: use host service status storing online/offline status

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito @wanyaoqi 