### PR TITLE
fix: set db connection keepalive options

### DIFF
--- a/pkg/cloudcommon/database.go
+++ b/pkg/cloudcommon/database.go
@@ -94,6 +94,16 @@ func InitDB(options *common_options.DBOptions) {
 	}
 	sqlchemy.SetDBWithNameBackend(dbConn, sqlchemy.DefaultDB, backend)
 
+	if options.DbMaxWaitTimeoutSeconds <= 300 {
+		options.DbMaxWaitTimeoutSeconds = 3600
+	}
+	// ConnMaxLifetime is the maximum amount of time a connection may be reused.
+	// mysql default max_waitimeout is 28800 seconds, 1 hour should be enough
+	// but if user set a customized mysql max_waittimeout, the value should be adjusted accordingly
+	dbConn.SetConnMaxLifetime(time.Duration(options.DbMaxWaitTimeoutSeconds) * time.Second)
+	// ConnMaxIdleTime should be half of ConnMaxLifetime
+	dbConn.SetConnMaxIdleTime(time.Duration(options.DbMaxWaitTimeoutSeconds/2) * time.Second)
+
 	dialect, sqlStr, err = options.GetClickhouseConnStr()
 	if err == nil {
 		// connect to clickcloud

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -173,6 +173,8 @@ type DBOptions struct {
 
 	Clickhouse string `help:"Connection string for click house"`
 
+	DbMaxWaitTimeoutSeconds int `help:"max wait timeout for db connection, default 1 hour" default:"3600"`
+
 	OpsLogWithClickhouse   bool `help:"store operation logs with clickhouse" default:"false"`
 	EnableDBChecksumTables bool `help:"Enable DB tables with record checksum for consistency"`
 	DBChecksumSkipInit     bool `help:"Skip DB tables with record checksum calculation when init" default:"false"`


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: set db connection keepalive options

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11
- release/3.11.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @ioito @wanyaoqi 