### PR TITLE
fix(cloudmon): add host access ip tag for metric

### DIFF
--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -344,6 +344,9 @@ func (self ServerDetails) GetMetricTags() map[string]string {
 		"account_id":          self.AccountId,
 		"external_id":         self.ExternalId,
 	}
+	if len(self.HostAccessIp) > 0 {
+		ret["host_ip"] = self.HostAccessIp
+	}
 
 	return AppendMetricTags(ret, self.MetadataResourceInfo, self.ProjectizedResourceInfo)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- [ ] Smoke testing completed


