### PR TITLE
Automated cherry pick of #22366: fix(cloudmon): add host access ip tag for metric

### DIFF
--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -333,6 +333,9 @@ func (self ServerDetails) GetMetricTags() map[string]string {
 		"account_id":          self.AccountId,
 		"external_id":         self.ExternalId,
 	}
+	if len(self.HostAccessIp) > 0 {
+		ret["host_ip"] = self.HostAccessIp
+	}
 
 	return AppendMetricTags(ret, self.MetadataResourceInfo, self.ProjectizedResourceInfo)
 }


### PR DESCRIPTION
Cherry pick of #22366 on release/3.11.

#22366: fix(cloudmon): add host access ip tag for metric