### PR TITLE
Automated cherry pick of #22369: fix(host): ignore errors on reconfigure vfio nic bandwidth

### DIFF
--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -2658,7 +2658,7 @@ func (s *SKVMGuestInstance) onNicChange(oldNic, newNic *desc.SGuestNetwork) erro
 	if oldNic.Driver == "vfio-pci" {
 		err := s.reconfigureVfioNicsBandwidth(oldNic)
 		if err != nil {
-			return err
+			log.Errorf("failed configure %s:%s vfio nics bandwidth %s", s.GetId(), oldNic.Mac, err)
 		}
 		return nil
 	}


### PR DESCRIPTION
Cherry pick of #22369 on release/3.11.

#22369: fix(host): ignore errors on reconfigure vfio nic bandwidth