### PR TITLE
[fix]: fix error when create vm with ceph disk

### DIFF
--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -1942,8 +1942,10 @@ func (s *SKVMGuestInstance) DeployFs(ctx context.Context, userCred mcclient.Toke
 	}
 	var sysDisk storageman.IDisk
 	disks := s.Desc.Disks
+	var diskPaths = make([]string, len(disks))
 	for i := range disks {
 		diskPath := disks[i].Path
+		diskPaths[i] = diskPath
 		// GetDiskByPath will probe disks
 		disk, err := storageman.GetManager().GetDiskByPath(diskPath)
 		if err != nil {
@@ -1954,11 +1956,13 @@ func (s *SKVMGuestInstance) DeployFs(ctx context.Context, userCred mcclient.Toke
 			diskInfo.Path = disk.GetPath()
 			sysDisk = disk
 		}
+		disks[i].Path = disk.GetPath()
 	}
 
 	ret, err := sysDisk.DeployGuestFs(&diskInfo, s.Desc, deployInfo)
-	for i := range disks {
-		diskPath := disks[i].Path
+	for i := range diskPaths {
+		diskPath := diskPaths[i]
+		disks[i].Path = diskPath
 		disk, e := storageman.GetManager().GetDiskByPath(diskPath)
 		if e != nil {
 			log.Errorf("failed get disk bypath %s %s", diskPath, e)


### PR DESCRIPTION
**What this PR does / why we need it**:
修复3.11.9版本使用ceph盘创建虚拟机时创建失败问题

问题原因在于3.11.9版本创建qemu虚拟机时传入了disk的Path不带ceph的mon信息。 

**Does this PR need to be backport to the previous release branch?**:
release-3.11.9
