### PR TITLE
Automated cherry pick of #22573: fix(host): ignore internal stopped event of primary container

### DIFF
--- a/pkg/hostman/guestman/pod_sync_loop.go
+++ b/pkg/hostman/guestman/pod_sync_loop.go
@@ -208,7 +208,7 @@ func (m *SGuestManager) syncContainerLoopIteration(plegCh chan *pleg.PodLifecycl
 				}
 				log.Infof("sync pod %s container %s status: %s", e.Id, ctrCriId, reason)
 				// 如果是 primary container 退出，就退出其他容器
-				if ctrObj != nil && podMan.IsPrimaryContainer(ctrObj.Id) && ccStatus == computeapi.CONTAINER_STATUS_EXITED {
+				if ctrObj != nil && !isInternalStopped && podMan.IsPrimaryContainer(ctrObj.Id) && ccStatus == computeapi.CONTAINER_STATUS_EXITED {
 					reason = fmt.Sprintf("stop all containers when primary container %s exited", ctrObj.Name)
 					if err := podMan.StopAll(context.Background()); err != nil {
 						log.Errorf("stop all pod containers error: %s", err.Error())


### PR DESCRIPTION
Cherry pick of #22573 on release/4.0.

#22573: fix(host): ignore internal stopped event of primary container