### PR TITLE
Automated cherry pick of #22585: fix(cloudmon): add vm_ip metric for vm

### DIFF
--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -314,6 +314,7 @@ func (self ServerDetails) GetMetricTags() map[string]string {
 		"host":                self.Host,
 		"host_id":             self.HostId,
 		"ips":                 self.IPs,
+		"vm_ip":               self.IPs,
 		"vm_id":               self.Id,
 		"vm_name":             self.Name,
 		"zone":                self.Zone,


### PR DESCRIPTION
Cherry pick of #22585 on release/3.11.

#22585: fix(cloudmon): add vm_ip metric for vm