### PR TITLE
Automated cherry pick of #22651: fix(host): losetup package initialization order

### DIFF
--- a/pkg/hostman/host_services.go
+++ b/pkg/hostman/host_services.go
@@ -38,6 +38,7 @@ import (
 	"yunion.io/x/onecloud/pkg/hostman/storageman"
 	"yunion.io/x/onecloud/pkg/hostman/storageman/diskhandlers"
 	"yunion.io/x/onecloud/pkg/hostman/storageman/storagehandler"
+	losetupman "yunion.io/x/onecloud/pkg/util/losetup/manager"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 	"yunion.io/x/onecloud/pkg/util/sysutils"
 )
@@ -67,6 +68,7 @@ func (host *SHostService) InitService() {
 		execlient.SetTimeoutSeconds(options.HostOptions.ExecutorConnectTimeoutSeconds)
 		procutils.SetRemoteExecutor()
 	}
+	losetupman.Init()
 }
 
 func (host *SHostService) OnExitService() {}

--- a/pkg/util/losetup/manager/manager.go
+++ b/pkg/util/losetup/manager/manager.go
@@ -15,6 +15,8 @@
 package manager
 
 import (
+	"sync"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
@@ -22,10 +24,18 @@ import (
 	"yunion.io/x/onecloud/pkg/util/losetup"
 )
 
-var managerObj iManager
+var (
+	managerObj      iManager
+	managerInitLock sync.Mutex
+)
 
-func init() {
-	managerObj = newManager()
+func Init() {
+	managerInitLock.Lock()
+	defer managerInitLock.Unlock()
+
+	if managerObj == nil {
+		managerObj = newManager()
+	}
 }
 
 func ListDevices() (*losetup.Devices, error) {


### PR DESCRIPTION
Cherry pick of #22651 on release/4.0.

#22651: fix(host): losetup package initialization order