### PR TITLE
fix(scheduler): wrong sort order of instance group selection

### DIFF
--- a/pkg/scheduler/cache/candidate/hosts.go
+++ b/pkg/scheduler/cache/candidate/hosts.go
@@ -1398,7 +1398,7 @@ func (b *HostBuilder) fillGuestsResourceInfo(desc *HostDesc, host *computemodels
 	if len(guestsCpuNumaPin) > 0 {
 		desc.HostTopo.LoadCpuNumaPin(guestsCpuNumaPin)
 	}
-	log.Infof("host topo %s", jsonutils.Marshal(desc.HostTopo))
+	log.Debugf("host topo %s", jsonutils.Marshal(desc.HostTopo))
 
 	desc.GuestCount = guestCount
 	desc.CreatingGuestCount = creatingGuestCount

--- a/pkg/scheduler/core/instancegroup_select.go
+++ b/pkg/scheduler/core/instancegroup_select.go
@@ -107,7 +107,8 @@ func sortHosts(hosts []*sSchedResultItem, guestInfo *sGuestInfo, isBackup *bool)
 		}
 		sortIndexi[1], sortIndexj[1] = hosts[i].Count, hosts[j].Count
 		sortIndexi[2], sortIndexj[2] = -(hosts[i].minInstanceGroupCapacity(guestInfo.instanceGroupsDetail)), -(hosts[j].minInstanceGroupCapacity(guestInfo.instanceGroupsDetail))
-		sortIndexi[3], sortIndexj[3] = scoreNormalization(hosts[i].Score, hosts[j].Score)
+		iScore, jScore := scoreNormalization(hosts[i].Score, hosts[j].Score)
+		sortIndexi[3], sortIndexj[3] = -iScore, -jScore
 		sortIndexi[4], sortIndexj[4] = -(hosts[i].Capacity), -(hosts[j].Capacity)
 		for i := 0; i < 5; i++ {
 			if sortIndexi[i] == sortIndexj[i] {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.11
/area scheduler