### PR TITLE
Automated cherry pick of #22664: fix(scheduler): wrong sort order of instance group selection

### DIFF
--- a/pkg/scheduler/core/instancegroup_select.go
+++ b/pkg/scheduler/core/instancegroup_select.go
@@ -107,7 +107,8 @@ func sortHosts(hosts []*sSchedResultItem, guestInfo *sGuestInfo, isBackup *bool)
 		}
 		sortIndexi[1], sortIndexj[1] = hosts[i].Count, hosts[j].Count
 		sortIndexi[2], sortIndexj[2] = -(hosts[i].minInstanceGroupCapacity(guestInfo.instanceGroupsDetail)), -(hosts[j].minInstanceGroupCapacity(guestInfo.instanceGroupsDetail))
-		sortIndexi[3], sortIndexj[3] = scoreNormalization(hosts[i].Score, hosts[j].Score)
+		iScore, jScore := scoreNormalization(hosts[i].Score, hosts[j].Score)
+		sortIndexi[3], sortIndexj[3] = -iScore, -jScore
 		sortIndexi[4], sortIndexj[4] = -(hosts[i].Capacity), -(hosts[j].Capacity)
 		for i := 0; i < 5; i++ {
 			if sortIndexi[i] == sortIndexj[i] {


### PR DESCRIPTION
Cherry pick of #22664 on release/4.0.

#22664: fix(scheduler): wrong sort order of instance group selection