### PR TITLE
Automated cherry pick of #22700: fix: remove cgo deps for ioctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,6 @@ vet:
 # cmd/esxi-agent: prepare_dir
 # 	CGO_ENABLED=0 $(GO_BUILD) -o $(BIN_DIR)/$(shell basename $@) $(REPO_PREFIX)/$@
 
-cmd/host: prepare_dir
-	CGO_ENABLED=1 $(GO_BUILD) -o $(BIN_DIR)/$(shell basename $@) $(REPO_PREFIX)/$@
-
 cmd/%: prepare_dir
 	CGO_ENABLED=0 $(GO_BUILD) -o $(BIN_DIR)/$(shell basename $@) $(REPO_PREFIX)/$@
 

--- a/pkg/util/losetup/ioctl/remove.go
+++ b/pkg/util/losetup/ioctl/remove.go
@@ -17,7 +17,7 @@ package ioctl
 /*
 #include <linux/loop.h>
 */
-import "C"
+//import "C"
 import (
 	"fmt"
 	"os"
@@ -38,9 +38,9 @@ import (
 const (
 	LOOP_CTL_PATH = "/dev/loop-control"
 
-	LOOP_CTL_REMOVE = C.LOOP_CTL_REMOVE
+	LOOP_CTL_REMOVE = 0x4c81 // 19585 C.LOOP_CTL_REMOVE
 	// LOOP_CTL_GET_FREE = C.LOOP_CTL_GET_FREE
-	LOOP_CTL_ADD = C.LOOP_CTL_ADD
+	LOOP_CTL_ADD = 0x4c80 // 19584 C.LOOP_CTL_ADD
 )
 
 func AddDevice(devNumber int) (string, error) {


### PR DESCRIPTION
Cherry pick of #22700 on release/4.0.0.

#22700: fix: remove cgo deps for ioctl