### PR TITLE
Automated cherry pick of #22721: fix: panic when there is no secondary IP on the host.

### DIFF
--- a/pkg/hostman/metadata/metadatahandler.go
+++ b/pkg/hostman/metadata/metadatahandler.go
@@ -222,6 +222,9 @@ func (s *Service) metaData(ctx context.Context, w http.ResponseWriter, r *http.R
 			ips := make([]string, 0)
 			guestNics := guestDesc.Nics
 			for _, nic := range guestNics {
+				if nic.Networkaddresses == nil {
+					continue
+				}
 				nas, _ := nic.Networkaddresses.GetArray()
 				for _, na := range nas {
 					if typ, _ := na.GetString("type"); typ == "sub_ip" {


### PR DESCRIPTION
Cherry pick of #22721 on release/4.0.0.

#22721: fix: panic when there is no secondary IP on the host.