### PR TITLE
Automated cherry pick of #22753: fix(region): support skip sync server by tag value

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1656,7 +1656,7 @@ func (manager *SDiskManager) SyncDisks(ctx context.Context, userCred mcclient.To
 	for i := 0; i < len(commondb); i += 1 {
 		skip, key := IsNeedSkipSync(commonext[i])
 		if skip {
-			log.Infof("delete disk %s(%s) with tag key: %s", commonext[i].GetName(), commonext[i].GetGlobalId(), key)
+			log.Infof("delete disk %s(%s) with tag key or value: %s", commonext[i].GetName(), commonext[i].GetGlobalId(), key)
 			err := commondb[i].RealDelete(ctx, userCred)
 			if err != nil {
 				syncResult.DeleteError(err)
@@ -1680,7 +1680,7 @@ func (manager *SDiskManager) SyncDisks(ctx context.Context, userCred mcclient.To
 	for i := 0; i < len(added); i += 1 {
 		skip, key := IsNeedSkipSync(added[i])
 		if skip {
-			log.Infof("skip disk %s(%s) sync with tag key: %s", added[i].GetName(), added[i].GetGlobalId(), key)
+			log.Infof("skip disk %s(%s) sync with tag key or value: %s", added[i].GetName(), added[i].GetGlobalId(), key)
 			continue
 		}
 		extId := added[i].GetGlobalId()

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2694,7 +2694,7 @@ type SGuestSyncResult struct {
 }
 
 func IsNeedSkipSync(ext cloudprovider.ICloudResource) (bool, string) {
-	if len(options.Options.SkipServerBySysTagKeys) == 0 && len(options.Options.SkipServerByUserTagKeys) == 0 {
+	if len(options.Options.SkipServerBySysTagKeys) == 0 && len(options.Options.SkipServerByUserTagKeys) == 0 && len(options.Options.SkipServerByUserTagValues) == 0 {
 		return false, ""
 	}
 	if keys := strings.Split(options.Options.SkipServerBySysTagKeys, ","); len(keys) > 0 {
@@ -2711,6 +2711,15 @@ func IsNeedSkipSync(ext cloudprovider.ICloudResource) (bool, string) {
 			key = strings.Trim(key, "")
 			if len(key) > 0 && utils.IsInStringArray(key, userKeys) {
 				return true, key
+			}
+		}
+	}
+	if len(options.Options.SkipServerByUserTagValues) > 0 {
+		tags, _ := ext.GetTags()
+		for _, value := range tags {
+			value = strings.Trim(value, "")
+			if len(value) > 0 && utils.IsInStringArray(value, options.Options.SkipServerByUserTagValues) {
+				return true, value
 			}
 		}
 	}
@@ -2879,7 +2888,7 @@ func (hh *SHost) SyncHostVMs(ctx context.Context, userCred mcclient.TokenCredent
 		for i := 0; i < len(commondb); i += 1 {
 			skip, key := IsNeedSkipSync(commonext[i])
 			if skip {
-				log.Infof("delete server %s(%s) with system tag key: %s", commonext[i].GetName(), commonext[i].GetGlobalId(), key)
+				log.Infof("delete server %s(%s) with tag key or value: %s", commonext[i].GetName(), commonext[i].GetGlobalId(), key)
 				err := commondb[i].purge(ctx, userCred)
 				if err != nil {
 					syncResult.DeleteError(err)
@@ -2906,7 +2915,7 @@ func (hh *SHost) SyncHostVMs(ctx context.Context, userCred mcclient.TokenCredent
 	for i := 0; i < len(added); i += 1 {
 		skip, key := IsNeedSkipSync(added[i])
 		if skip {
-			log.Infof("skip server %s(%s) sync with system tag key: %s", added[i].GetName(), added[i].GetGlobalId(), key)
+			log.Infof("skip server %s(%s) sync with tag key or value: %s", added[i].GetName(), added[i].GetGlobalId(), key)
 			continue
 		}
 		vm, err := db.FetchByExternalIdAndManagerId(GuestManager, added[i].GetGlobalId(), func(q *sqlchemy.SQuery) *sqlchemy.SQuery {

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -196,8 +196,9 @@ type ComputeOptions struct {
 
 	KeepDeletedSnapshotDays int `help:"The day of cleanup snapshot" default:"30"`
 	// 弹性伸缩中的ecs一般会有特殊的系统标签，通过指定这些标签可以忽略这部分ecs的同步, 指定多个key需要以 ',' 分隔
-	SkipServerBySysTagKeys  string `help:"skip server,disk sync and create with system tags" default:""`
-	SkipServerByUserTagKeys string `help:"skip server,disk sync and create with user tags" default:""`
+	SkipServerBySysTagKeys    string   `help:"skip server,disk sync and create with system tags" default:""`
+	SkipServerByUserTagKeys   string   `help:"skip server,disk sync and create with user tags" default:""`
+	SkipServerByUserTagValues []string `help:"skip server,disk sync and create with user tag values"`
 	// 修改标签时不再同步至云上, 云账号同步资源时不会冲掉本地打的标签(key相同的会覆盖), 云账号开启只读同步和此参数效果相同,且仅影响开启只读同步的账号
 	KeepTagLocalization bool `help:"keep tag localization, not synchronized to the cloud" default:"false"`
 


### PR DESCRIPTION
Cherry pick of #22753 on release/4.0.0.

#22753: fix(region): support skip sync server by tag value