### PR TITLE
bugfix:fix baremetal delete bug

### DIFF
--- a/pkg/baremetal/tasks/worker.go
+++ b/pkg/baremetal/tasks/worker.go
@@ -111,7 +111,11 @@ func SetTaskFail(task ITask, err error) {
 
 func onTaskEnd(task ITask) {
 	task.SetStage(nil)
-	ExecuteTask(task.GetTaskQueue().PopTask(), nil)
+	task.GetTaskQueue().PopTask()
+	nextTask := task.GetTaskQueue().GetTask()
+	if nextTask != nil {
+		ExecuteTask(nextTask, nil)
+	}
 }
 
 func OnInitStage(task ITask) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
修复裸金属删除时，多次删除会导致删除失败的bug。
问题在于，在task结束时，本应取出下一个task继续执行，但是错误的取成了当前task。
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
UNKNOWN
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
