### PR TITLE
Automated cherry pick of #22802: fix(esxi-agent): avoid esxi cache image error

### DIFF
--- a/pkg/hostman/storageman/imagecachemanager_agent.go
+++ b/pkg/hostman/storageman/imagecachemanager_agent.go
@@ -27,6 +27,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	comapi "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/hostman/hostutils"
@@ -149,7 +150,9 @@ func (c *SAgentImageCacheManager) prefetchImageCacheByCopy(ctx context.Context, 
 func (c *SAgentImageCacheManager) prefetchImageCacheByUpload(ctx context.Context, data *sImageCacheData,
 	origin *jsonutils.JSONDict) (jsonutils.JSONObject, error) {
 
-	localImage, err := c.imageCacheManger.PrefetchImageCache(ctx, origin)
+	input := api.CacheImageInput{}
+	origin.Unmarshal(&input)
+	localImage, err := c.imageCacheManger.PrefetchImageCache(ctx, input)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry pick of #22802 on release/4.0.

#22802: fix(esxi-agent): avoid esxi cache image error