### PR TITLE
Automated cherry pick of #22840: fix(region): 避免删除虚拟机时，未能正常删除后挂载的磁盘

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -911,9 +911,10 @@ func (drv *SManagedVirtualizedGuestDriver) RequestUndeployGuestOnHost(ctx contex
 			return nil, errors.Wrapf(err, "GetDisks")
 		}
 
-		for _, disk := range disks {
+		for i := range disks {
+			disk := disks[i]
 			storage, _ := disk.GetStorage()
-			if !disk.AutoDelete && !utils.IsInStringArray(storage.StorageType, api.STORAGE_LOCAL_TYPES) && disk.DiskType != api.DISK_TYPE_SYS {
+			if !utils.IsInStringArray(storage.StorageType, api.STORAGE_LOCAL_TYPES) && disk.DiskType != api.DISK_TYPE_SYS {
 				idisk, err := disk.GetIDisk(ctx)
 				if err != nil {
 					if errors.Cause(err) == cloudprovider.ErrNotFound {


### PR DESCRIPTION
Cherry pick of #22840 on release/3.11.11.

#22840: fix(region): 避免删除虚拟机时，未能正常删除后挂载的磁盘