### PR TITLE
Bump debian-base base image from 10 to 13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ deb/fetcherfs: rpm/fetcherfs
 	docker run --rm \
 		--name docker-debian-build-fetcherfs \
 		-v $(CURDIR):/data \
-		registry.cn-beijing.aliyuncs.com/yunionio/debian10-base:1.0 \
+		registry.cn-beijing.aliyuncs.com/yunionio/debian13-base:1.0 \
 		/data/build/convert_rpm2deb.sh
 
 build:

--- a/build/docker/Dockerfile.debian-base
+++ b/build/docker/Dockerfile.debian-base
@@ -1,4 +1,4 @@
-# registry.cn-beijing.aliyuncs.com/yunionio/debian10-base:1.0
+# registry.cn-beijing.aliyuncs.com/yunionio/debian13-base:1.0
 
 FROM debian:trixie
 

--- a/build/docker/Dockerfile.debian-base
+++ b/build/docker/Dockerfile.debian-base
@@ -1,6 +1,6 @@
 # registry.cn-beijing.aliyuncs.com/yunionio/debian10-base:1.0
 
-FROM debian:10
+FROM debian:trixie
 
 RUN apt update && apt install -y alien
 

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -3,9 +3,9 @@ DOCKER_BUILD = docker build -t $(REGISTRY)
 DOCKER_BUILDX = docker buildx build --platform linux/arm64,linux/amd64 --push -t $(REGISTRY)
 
 
-debian10-base:
+debian13-base:
 	docker buildx build --platform linux/arm64,linux/amd64 --push \
-		-t registry.cn-beijing.aliyuncs.com/yunionio/debian10-base:1.0 -f ./Dockerfile.debian-base .
+		-t registry.cn-beijing.aliyuncs.com/yunionio/debian13-base:1.0 -f ./Dockerfile.debian-base .
 
 ONECLOUD_BASE_VERSION = v0.3-3.13.5
 ONECLOUD_BASE_VERSION_3-15-4 = v3.15.4-0


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump base image of debian-base from debian:10 to debian:13, since tag 13
is not yet made available, we could still use trixie for now.
