### PR TITLE
fix(region): do not set guest to resuce status on guest running

### DIFF
--- a/pkg/compute/tasks/guest_rescue_task.go
+++ b/pkg/compute/tasks/guest_rescue_task.go
@@ -111,8 +111,6 @@ func (self *StartRescueTask) OnRescueStartServerComplete(ctx context.Context, gu
 	db.OpsLog.LogEvent(guest, db.ACT_START_RESCUE, guest.GetShortDesc(ctx), self.UserCred)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_START_RESCUE, guest.GetShortDesc(ctx), self.UserCred, true)
 
-	// Set guest status to rescue running
-	guest.SetStatus(ctx, self.UserCred, api.VM_RESCUE, "OnRescueStartServerComplete")
 	self.SetStageComplete(ctx, nil)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.10
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
