### PR TITLE
Automated cherry pick of #22872: fix(region): allow stopping the container in probe_failed status

### DIFF
--- a/pkg/compute/models/containers.go
+++ b/pkg/compute/models/containers.go
@@ -630,6 +630,7 @@ func (c *SContainer) PerformStop(ctx context.Context, userCred mcclient.TokenCre
 		if !sets.NewString(
 			api.CONTAINER_STATUS_RUNNING,
 			api.CONTAINER_STATUS_PROBING,
+			api.CONTAINER_STATUS_PROBE_FAILED,
 			api.CONTAINER_STATUS_STOP_FAILED).Has(c.Status) {
 			return nil, httperrors.NewInvalidStatusError("Can't stop container in status %s", c.Status)
 		}


### PR DESCRIPTION
Cherry pick of #22872 on release/4.0.0.

#22872: fix(region): allow stopping the container in probe_failed status