### PR TITLE
Automated cherry pick of #22925: fix(region): host order

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -804,7 +804,7 @@ func (manager *SHostManager) OrderByExtraFields(
 			guestSQ.Field("mem_commit"),
 			sqlchemy.NewFunction(
 				sqlchemy.NewCase().When(
-					sqlchemy.GE(host.Field("mem_cmtbound"), 0),
+					sqlchemy.GT(host.Field("mem_cmtbound"), 0),
 					host.Field("mem_cmtbound"),
 				).Else(sqlchemy.NewConstField(1)),
 				"mem_cmtbound",
@@ -844,7 +844,7 @@ func (manager *SHostManager) OrderByExtraFields(
 			guestSQ.Field("cpu_commit"),
 			sqlchemy.NewFunction(
 				sqlchemy.NewCase().When(
-					sqlchemy.GE(host.Field("cpu_cmtbound"), 0),
+					sqlchemy.GT(host.Field("cpu_cmtbound"), 0),
 					host.Field("cpu_cmtbound"),
 				).Else(sqlchemy.NewConstField(1)),
 				"cpu_cmtbound",
@@ -879,7 +879,7 @@ func (manager *SHostManager) OrderByExtraFields(
 			hoststorages.Field("host_id"),
 			sqlchemy.NewFunction(
 				sqlchemy.NewCase().When(
-					sqlchemy.GE(storageQ.Field("cmtbound"), 0),
+					sqlchemy.GT(storageQ.Field("cmtbound"), 0),
 					storageQ.Field("cmtbound"),
 				).Else(sqlchemy.NewConstField(1)),
 				"cmtbound",


### PR DESCRIPTION
Cherry pick of #22925 on release/4.0.0.

#22925: fix(region): host order