### PR TITLE
fix: glance converts all queued subimages, regardless of format

### DIFF
--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -1085,8 +1085,10 @@ func (self *SImage) migrateSubImage(ctx context.Context) error {
 	}
 	if self.GetImageType() != api.ImageTypeISO && imgInst.IsSparse() && utils.IsInStringArray(self.DiskFormat, options.Options.TargetImageFormats) {
 		// need to convert again
+		log.Debugf("migrateImage: image is not iso but sparse, need to convert the image")
 		return self.newSubformat(ctx, qemuimgfmt.String2ImageFormat(self.DiskFormat), false)
 	} else {
+		log.Debugf("migrateImage: no need to convert the image")
 		localPath := self.GetLocalLocation()
 		if !strings.HasSuffix(localPath, fmt.Sprintf(".%s", self.DiskFormat)) {
 			newLocalpath := fmt.Sprintf("%s.%s", localPath, self.DiskFormat)
@@ -1146,9 +1148,6 @@ func (self *SImage) doConvertAllSubformats() error {
 		}
 		if !utils.IsInStringArray(subimgs[i].Format, options.Options.TargetImageFormats) {
 			// cleanup
-			continue
-		}
-		if self.DiskFormat == subimgs[i].Format {
 			continue
 		}
 		err := subimgs[i].doConvert(self)


### PR DESCRIPTION
**What this PR does / why we need it**:
Hotfix/qj glance convert all queued subimage

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/4.0
- release/4.0.0
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @ioito @zexi 