### PR TITLE
fix: force NetworkManager unmanged physical netinterface

### DIFF
--- a/pkg/hostman/hostinfo/hostbridge/hostbridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/hostbridge.go
@@ -403,6 +403,16 @@ func (d *SBaseBridgeDriver) SetupAddresses(mask net.IPMask) error {
 	}
 	if d.inter != nil {
 		ifname := d.inter.String()
+		{
+			// if the interface is managed by NetworkManager, we need to unmanage it
+			// ignore error if nmcli is not present or NetworkManger is not running
+			args := []string{"nmcli", "device", "set", ifname, "managed", "no"}
+			nmcli := procutils.NewRemoteCommandAsFarAsPossible("nmcli", args...)
+			output, err := nmcli.Output()
+			if err != nil {
+				log.Warningf("try to unmanage interface %s failed: %s(%s)", ifname, err, output)
+			}
+		}
 		if err := iproute2.NewAddress(ifname).Exact().Err(); err != nil {
 			return errors.Wrapf(err, "remove addresses on slave ifname: %s", ifname)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: force NetworkManager unmanged physical netinterface

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11
- release/4.0
- release/4.0.0

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi @ioito 