### PR TITLE
Automated cherry pick of #23091: fix: webconsole skip refererer check by default

### DIFF
--- a/pkg/webconsole/options/options.go
+++ b/pkg/webconsole/options/options.go
@@ -40,7 +40,7 @@ type WebConsoleOptions struct {
 
 	KeepWebsocketSession bool `help:"keep websocket session" default:"false"`
 
-	RefererWhitelist []string `help:"referer whitelist"`
+	RefererWhitelist []string `help:"referer whitelist" default:"skip_check"`
 }
 
 func OnOptionsChange(oldO, newO interface{}) bool {


### PR DESCRIPTION
Cherry pick of #23091 on release/4.0.

#23091: fix: webconsole skip refererer check by default