### PR TITLE
feat(region): fix ISO size display

### DIFF
--- a/pkg/compute/models/guestcdrom.go
+++ b/pkg/compute/models/guestcdrom.go
@@ -136,7 +136,9 @@ func (self *SGuestcdrom) GetImage() (*SCachedimage, error) {
 func (self *SGuestcdrom) GetDetails() string {
 	if len(self.ImageId) > 0 {
 		if self.Size > 0 {
-			return fmt.Sprintf("%s(%s/%dMB)", self.Name, self.ImageId, self.Size)
+			// Size is stored in bytes, convert to MB for display
+			sizeMB := self.Size / 1024 / 1024
+			return fmt.Sprintf("%s(%s/%dMB)", self.Name, self.ImageId, sizeMB)
 		} else {
 			return fmt.Sprintf("%s(inserting)", self.ImageId)
 		}


### PR DESCRIPTION
SGuestcdrom.Size is Byte, not MB

**What this PR does / why we need it**:
During virtual machine creation, the iso_attach displays an incorrect ISO size. The original image is 12 GB, but it mistakenly treats Bytes as MB here.

Before:
<img width="1291" height="594" alt="图片" src="https://github.com/user-attachments/assets/e9605c5b-7e27-4e0d-9c30-a338a6edec14" />

After:
<img width="1399" height="601" alt="图片" src="https://github.com/user-attachments/assets/829985fd-2f2d-493b-97de-0dd8cd2c00d9" />

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
UNKNOWN
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
