### PR TITLE
Automated cherry pick of #23096: fix(vpcagent): dhcp enable default gateway on default network

### DIFF
--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -476,7 +476,7 @@ func generateDhcpOptions(ctx context.Context, guestnetwork *agentmodels.Guestnet
 		Options: map[string]string{
 			"server_id":  network.GuestGateway,
 			"server_mac": dhcpMac,
-			"router":     network.GuestGateway,
+			//"router":     network.GuestGateway,
 			"mtu":        fmt.Sprintf("%d", mtu),
 			"lease_time": fmt.Sprintf("%d", leaseTime),
 			"T1":         fmt.Sprintf("%d", renewTime),
@@ -489,6 +489,7 @@ func generateDhcpOptions(ctx context.Context, guestnetwork *agentmodels.Guestnet
 	{
 		routes := []string{}
 		if guestnetwork.IsDefault {
+			dhcpopts.Options["router"] = network.GuestGateway
 			routes = append(routes,
 				mdIp, "0.0.0.0",
 				"0.0.0.0/0", network.GuestGateway,


### PR DESCRIPTION
Cherry pick of #23096 on release/4.0.0.

#23096: fix(vpcagent): dhcp enable default gateway on default network