### PR TITLE
Automated cherry pick of #23134: fix(region): avoid update guest disable_delete attribute error when host id is empty

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1470,15 +1470,19 @@ func (self *SGuest) ValidateUpdateData(ctx context.Context, userCred mcclient.To
 		}
 	}
 
-	drv, err := self.GetDriver()
-	if err != nil {
-		return input, err
-	}
-	input, err = drv.ValidateUpdateData(ctx, self, userCred, input)
-	if err != nil {
-		return input, errors.Wrap(err, "GetDriver().ValidateUpdateData")
+	// 避免调度失败的机器修改删除保护时报no rows in result set 错误，导致前端删不掉机器
+	if len(self.HostId) > 0 {
+		drv, err := self.GetDriver()
+		if err != nil {
+			return input, err
+		}
+		input, err = drv.ValidateUpdateData(ctx, self, userCred, input)
+		if err != nil {
+			return input, errors.Wrap(err, "GetDriver().ValidateUpdateData")
+		}
 	}
 
+	var err error
 	input.VirtualResourceBaseUpdateInput, err = self.SVirtualResourceBase.ValidateUpdateData(ctx, userCred, query, input.VirtualResourceBaseUpdateInput)
 	if err != nil {
 		return input, errors.Wrap(err, "SVirtualResourceBase.ValidateUpdateData")


### PR DESCRIPTION
Cherry pick of #23134 on release/4.0.

#23134: fix(region): avoid update guest disable_delete attribute error when host id is empty