### PR TITLE
fix: deploy gai.conf if both v4 and v6 present

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -458,6 +458,26 @@ func (l *sLinuxRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics []*ty
 			log.Errorf("rootFs.GenerateSshHostKeys fail %s", err)
 		}
 	}
+	{
+		// deploy /etc/gai.conf if both IPv4 and IPv6 are enabled
+		v4Enabled := false
+		v6Enabled := false
+		for _, nic := range nics {
+			if nic.Ip != "" {
+				v4Enabled = true
+			}
+			if nic.Ip6 != "" {
+				v6Enabled = true
+			}
+			if v4Enabled && v6Enabled {
+				// prefer IPv4 over IPv6 by default of /etc/gai.conf not present
+				if !rootFs.Exists("/etc/gai.conf", false) {
+					rootFs.FilePutContents("/etc/gai.conf", "precedence ::ffff:0:0/96 100\n", false, false)
+				}
+				break
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: deploy gai.conf if both v4 and v6 present

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/4.0
- release/4.0.1
- release/4.0.0
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @wanyaoqi @zexi 