### PR TITLE
Automated cherry pick of #23216: fix: fail to delete cas idp due to readonly domain

### DIFF
--- a/pkg/keystone/models/domains.go
+++ b/pkg/keystone/models/domains.go
@@ -320,8 +320,12 @@ func (domain *SDomain) GetIdpCount() (int, error) {
 }
 
 func (domain *SDomain) ValidateDeleteCondition(ctx context.Context, info *api.DomainDetails) error {
+	return domain.validateDeleteConditionInternal(ctx, info, false)
+}
+
+func (domain *SDomain) validateDeleteConditionInternal(ctx context.Context, info *api.DomainDetails, skipIdpCheck bool) error {
 	if gotypes.IsNil(info) {
-		info := &api.DomainDetails{}
+		info = &api.DomainDetails{}
 		if usage, _ := DomainManager.TotalResourceCount([]string{domain.Id}); usage != nil {
 			info.DomainUsage, _ = usage[domain.Id]
 		}
@@ -330,7 +334,7 @@ func (domain *SDomain) ValidateDeleteCondition(ctx context.Context, info *api.Do
 			info.IdpResourceInfo = idpInfo[0]
 		}
 	}
-	if len(info.IdpId) > 0 {
+	if !skipIdpCheck && len(info.IdpId) > 0 {
 		return httperrors.NewForbiddenError("readonly")
 	}
 	if domain.Id == api.DEFAULT_DOMAIN_ID {

--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -913,7 +913,7 @@ func (self *SIdentityProvider) Purge(ctx context.Context, userCred mcclient.Toke
 				return errors.Wrap(err, "domains[i].UnlinkIdp")
 			}
 		} else {
-			err = domains[i].ValidateDeleteCondition(ctx, nil)
+			err = domains[i].validateDeleteConditionInternal(ctx, nil, true)
 			if err != nil {
 				db.OpsLog.LogEvent(&domains[i], db.ACT_DELETE_FAIL, err, userCred)
 				return errors.Wrap(err, "domain.ValidateDeleteCondition")


### PR DESCRIPTION
Cherry pick of #23216 on release/4.0.

#23216: fix: fail to delete cas idp due to readonly domain