### PR TITLE
Automated cherry pick of #23235: fix(region): sync prepaid disk expired time

### DIFF
--- a/pkg/compute/tasks/guest/guest_create_disk_task.go
+++ b/pkg/compute/tasks/guest/guest_create_disk_task.go
@@ -259,8 +259,15 @@ func (self *ManagedGuestCreateDiskTask) OnManagedDiskPrepared(ctx context.Contex
 				continue
 			}
 
+			idisk.Refresh()
+
 			db.Update(disk, func() error {
 				disk.BillingType = guest.BillingType
+				disk.AutoRenew = guest.AutoRenew
+				disk.ExpiredAt = guest.ExpiredAt
+				if expiredAt := idisk.GetExpiredAt(); !expiredAt.IsZero() {
+					disk.ExpiredAt = expiredAt
+				}
 				return nil
 			})
 		}


### PR DESCRIPTION
Cherry pick of #23235 on release/4.0.

#23235: fix(region): sync prepaid disk expired time