### PR TITLE
Automated cherry pick of #23265: fix(climc): monitor-alertrecords-total-alert command

### DIFF
--- a/cmd/climc/shell/monitor/alertrecord.go
+++ b/cmd/climc/shell/monitor/alertrecord.go
@@ -23,5 +23,5 @@ func init() {
 	cmd := NewResourceCmd(modules.AlertRecordManager)
 	cmd.List(new(options.AlertRecordListOptions))
 	cmd.Show(new(options.AlertRecordShowOptions))
-	cmd.Get("", new(options.AlertRecordTotalOptions))
+	cmd.GetProperty(new(options.AlertRecordTotalOptions))
 }

--- a/pkg/mcclient/options/monitor/alertrecord.go
+++ b/pkg/mcclient/options/monitor/alertrecord.go
@@ -53,7 +53,6 @@ func (o *AlertRecordShowOptions) GetId() string {
 }
 
 type AlertRecordTotalOptions struct {
-	ID string `help:"total-alert" json:"-"`
 	options.BaseListOptions
 }
 
@@ -61,8 +60,8 @@ func (o *AlertRecordTotalOptions) Params() (jsonutils.JSONObject, error) {
 	return options.ListStructToParams(o)
 }
 
-func (o *AlertRecordTotalOptions) GetId() string {
-	return o.ID
+func (o *AlertRecordTotalOptions) Property() string {
+	return "total-alert"
 }
 
 type AlertRecordShieldListOptions struct {


### PR DESCRIPTION
Cherry pick of #23265 on release/4.0.

#23265: fix(climc): monitor-alertrecords-total-alert command