### PR TITLE
fix(monitor): diffTagKeys are empty when only one series in results

### DIFF
--- a/pkg/monitor/tsdb/driver/victoriametrics/vm.go
+++ b/pkg/monitor/tsdb/driver/victoriametrics/vm.go
@@ -164,6 +164,10 @@ func translateResponse(resp *Response, query *tsdb.Query) (*tsdb.QueryResult, er
 				}
 			}
 		}
+	} else if len(results) == 1 {
+		for tagKey := range results[0].Metric {
+			diffTagKeys.Insert(tagKey)
+		}
 	}
 
 	if !isUnionResult {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area monitor
- 3.11