### PR TITLE
Automated cherry pick of #23310: fix(monitor): diffTagKeys are empty when only one series in results

### DIFF
--- a/pkg/monitor/tsdb/driver/victoriametrics/vm.go
+++ b/pkg/monitor/tsdb/driver/victoriametrics/vm.go
@@ -164,6 +164,10 @@ func translateResponse(resp *Response, query *tsdb.Query) (*tsdb.QueryResult, er
 				}
 			}
 		}
+	} else if len(results) == 1 {
+		for tagKey := range results[0].Metric {
+			diffTagKeys.Insert(tagKey)
+		}
 	}
 
 	if !isUnionResult {


### PR DESCRIPTION
Cherry pick of #23310 on release/4.0.

#23310: fix(monitor): diffTagKeys are empty when only one series in results