### PR TITLE
Automated cherry pick of #23314: fix(cloudmon): alert metric with tenant id

### DIFF
--- a/pkg/apis/monitor/alertrecord.go
+++ b/pkg/apis/monitor/alertrecord.go
@@ -97,11 +97,11 @@ type AlertRecordHistoryAlertData struct {
 
 func (self AlertRecordHistoryAlertData) GetMetricTags() map[string]string {
 	return map[string]string{
-		"project_id": self.ProjectId,
-		"domain_id":  self.DomainId,
-		"domain":     self.Domain,
-		"project":    self.Project,
-		"res_type":   self.ResType,
+		"tenant_id": self.ProjectId,
+		"domain_id": self.DomainId,
+		"domain":    self.Domain,
+		"tenant":    self.Project,
+		"res_type":  self.ResType,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #23314 on release/3.11.

#23314: fix(cloudmon): alert metric with tenant id