### PR TITLE
fix: check os_arch when server rebuilding root

### DIFF
--- a/pkg/apis/const.go
+++ b/pkg/apis/const.go
@@ -149,9 +149,26 @@ func IsARM(osArch string) bool {
 	return utils.IsInStringArray(osArch, ARCH_ARM)
 }
 
+func IsX86(osArch string) bool {
+	return utils.IsInStringArray(osArch, ARCH_X86)
+}
+
 func IsIllegalSearchDomain(domain string) bool {
 	switch domain {
 	case "cloud.onecloud.io":
+		return true
+	}
+	return false
+}
+
+func IsSameArch(arch1, arch2 string) bool {
+	if arch1 == arch2 {
+		return true
+	}
+	if IsARM(arch1) && IsARM(arch2) {
+		return true
+	}
+	if IsX86(arch1) && IsX86(arch2) {
 		return true
 	}
 	return false

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -1660,10 +1660,12 @@ func (self *SGuest) PerformRebuildRoot(
 		}
 
 		// compare os arch
-		if len(self.InstanceType) > 0 {
+		if len(img.Properties["os_arch"]) > 0 && len(self.OsArch) > 0 && !apis.IsSameArch(self.OsArch, img.Properties["os_arch"]) {
+			return nil, httperrors.NewConflictError("root disk image(%s) and guest(%s) OsArch mismatch", img.Properties["os_arch"], self.OsArch)
+		} else if len(self.InstanceType) > 0 {
 			provider := GetDriver(self.Hypervisor).GetProvider()
 			sku, _ := ServerSkuManager.FetchSkuByNameAndProvider(self.InstanceType, provider, true)
-			if sku != nil && len(sku.CpuArch) > 0 && len(img.Properties["os_arch"]) > 0 && !strings.Contains(img.Properties["os_arch"], sku.CpuArch) {
+			if sku != nil && len(sku.CpuArch) > 0 && len(img.Properties["os_arch"]) > 0 && !apis.IsSameArch(img.Properties["os_arch"], sku.CpuArch) {
 				return nil, httperrors.NewConflictError("root disk image(%s) and sku(%s) architecture mismatch", img.Properties["os_arch"], sku.CpuArch)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: check os_arch when server rebuilding root

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11
- release/4.0

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi @wanyaoqi @ioito 