### PR TITLE
Automated cherry pick of #23346: fix: host backup task worker limit

### DIFF
--- a/pkg/hostman/hostutils/hostutils.go
+++ b/pkg/hostman/hostutils/hostutils.go
@@ -312,7 +312,7 @@ func initImageCacheWorkerManager() {
 }
 
 func initBackupWorkerManager() {
-	backupW = workmanager.NewWorkManger("BackupDelayTaskWorkers", TaskFailed, TaskComplete, options.HostOptions.DefaultRequestWorkerCount)
+	backupW = workmanager.NewWorkManger("BackupDelayTaskWorkers", TaskFailed, TaskComplete, options.HostOptions.BackupTaskWorkerCount)
 }
 
 func InitWorkerManagerWithCount(count int) {

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -171,6 +171,7 @@ type SHostOptions struct {
 
 	MaxReservedMemory int `default:"10240" help:"host reserved memory"`
 
+	BackupTaskWorkerCount     int `default:"2" help:"backup task worker count"`
 	DefaultRequestWorkerCount int `default:"8" help:"default request worker count"`
 	ImageCacheWorkerCount     int `default:"8" help:"default request worker count"`
 	ContainerStartWorkerCount int `default:"1" help:"container start worker count"`


### PR DESCRIPTION
Cherry pick of #23346 on release/4.0.1.

#23346: fix: host backup task worker limit