### PR TITLE
Automated cherry pick of #23435: fix: disable password history unique check by default

### DIFF
--- a/pkg/keystone/options/options.go
+++ b/pkg/keystone/options/options.go
@@ -40,7 +40,7 @@ type SKeystoneOptions struct {
 
 	PasswordExpirationSeconds  int `help:"password expires after the duration in seconds"`
 	PasswordMinimalLength      int `help:"password minimal length" default:"6"`
-	PasswordUniqueHistoryCheck int `help:"password must be unique in last N passwords" default:"1"`
+	PasswordUniqueHistoryCheck int `help:"password must be unique in last N passwords, default is 0 means no check" default:"0"`
 	PasswordCharComplexity     int `help:"password complexity policy" default:"0"`
 
 	PasswordErrorLockCount int `help:"lock user account if given number of failed auth"`


### PR DESCRIPTION
Cherry pick of #23435 on release/4.0.0.

#23435: fix: disable password history unique check by default