### PR TITLE
Automated cherry pick of #23484: fix: network manager supports ipv4 static routes for 3.11

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -1440,7 +1440,7 @@ func (r *sRedhatLikeRootFs) deployNetworkManagerConfigurations(rootFs IDiskParti
 			return errors.Wrap(err, "enableBondingModule")
 		}
 	}
-	// nicCnt := len(allNics) - len(bondNics)
+	nicCnt := len(allNics) - len(bondNics)
 
 	mainNic := getMainNic(allNics)
 	var mainIp, mainIp6 string
@@ -1450,7 +1450,7 @@ func (r *sRedhatLikeRootFs) deployNetworkManagerConfigurations(rootFs IDiskParti
 	}
 	for i := range allNics {
 		nicDesc := allNics[i]
-		profile := nicDescToNetworkManager(nicDesc, mainIp, mainIp6)
+		profile := nicDescToNetworkManager(nicDesc, mainIp, mainIp6, nicCnt)
 		var fn = fmt.Sprintf("%s/%s.nmconnection", scriptPath, nicDesc.Name)
 		if err := rootFs.FilePutContents(fn, profile, false, false); err != nil {
 			return err

--- a/pkg/hostman/guestfs/fsdriver/networkmaanger.go
+++ b/pkg/hostman/guestfs/fsdriver/networkmaanger.go
@@ -24,7 +24,7 @@ import (
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
-func nicDescToNetworkManager(nicDesc *types.SServerNic, mainIp string, mainIp6 string) string {
+func nicDescToNetworkManager(nicDesc *types.SServerNic, mainIp string, mainIp6 string, nicCnt int) string {
 	var profile strings.Builder
 
 	profile.WriteString("[connection]\n")
@@ -94,6 +94,15 @@ func nicDescToNetworkManager(nicDesc *types.SServerNic, mainIp string, mainIp6 s
 			dnslist, _ := netutils2.GetNicDns(nicDesc)
 			if len(dnslist) > 0 {
 				profile.WriteString(fmt.Sprintf("dns=%s\n", strings.Join(dnslist, ",")))
+			}
+			var routes = make([][]string, 0)
+			routes = netutils2.AddNicRoutes(routes, nicDesc, mainIp, nicCnt)
+			for i := range routes {
+				if len(routes[i]) >= 2 && routes[i][1] == "0.0.0.0" {
+					profile.WriteString(fmt.Sprintf("route%d=%s\n", i+1, routes[i][0]))
+				} else {
+					profile.WriteString(fmt.Sprintf("route%d=%s\n", i+1, strings.Join(routes[i], ",")))
+				}
 			}
 			profile.WriteString("\n")
 		}

--- a/pkg/hostman/guestfs/fsdriver/networkmanager_test.go
+++ b/pkg/hostman/guestfs/fsdriver/networkmanager_test.go
@@ -89,6 +89,7 @@ mac-address=00:22:0a:0b:0c:0d
 method=manual
 address1=192.168.1.100/24
 gateway=192.168.1.1
+route1=169.254.169.254/32
 
 [ipv6]
 method=manual
@@ -220,7 +221,7 @@ method=disabled
 	}
 
 	for _, c := range cases {
-		got := nicDescToNetworkManager(c.nicDesc, c.mainIp, c.mainIp6)
+		got := nicDescToNetworkManager(c.nicDesc, c.mainIp, c.mainIp6, 1)
 		if got != c.want {
 			t.Errorf("[[got]]\n%s\n[[want]]\n%s\n[[end]]", got, c.want)
 		}


### PR DESCRIPTION
Cherry pick of #23484 on release/3.11.12.

#23484: fix: network manager supports ipv4 static routes for 3.11