### PR TITLE
Automated cherry pick of #23487: fix: ignore e2fsck errors if retcode < 4

### DIFF
--- a/pkg/hostman/diskutils/fsutils/fsutils.go
+++ b/pkg/hostman/diskutils/fsutils/fsutils.go
@@ -360,8 +360,10 @@ func (d *SFsutilDriver) FsckExtFs(fpath string) bool {
 	log.Debugf("Exec command: %v", []string{"e2fsck", "-f", "-p", fpath})
 	retCode, stdout, stderr, err := d.ExecInputWait("e2fsck", []string{"-f", "-p", fpath}, nil)
 	if err != nil {
-		log.Errorf("exec e2fsck failed %s", err)
-		return false
+		log.Errorf("exec e2fsck error %s retcode %d stdout %s stderr %s", err, retCode, stdout, stderr)
+		if retCode >= 4 {
+			return false
+		}
 	}
 	if retCode < 4 {
 		return true


### PR DESCRIPTION
Cherry pick of #23487 on master.

#23487: fix: ignore e2fsck errors if retcode < 4