### PR TITLE
Automated cherry pick of #23513: fix(region,host,scheduler): add check kvm cpu max on cpu predicate

### DIFF
--- a/pkg/apis/compute/host.go
+++ b/pkg/apis/compute/host.go
@@ -467,6 +467,8 @@ type HostSizeAttributes struct {
 	CpuMicrocode string `json:"cpu_microcode"`
 	// CPU架构
 	CpuArchitecture string `json:"cpu_architecture"`
+	// KVM 允许单台虚机最大 vcpu 个数
+	KvmCapMaxVcpu *int `json:"kvm_cap_max_vcpu"`
 
 	// 内存大小(单位MB)
 	MemSize string `json:"mem_size"`

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -146,6 +146,8 @@ type SHost struct {
 	CpuMicrocode string `width:"64" charset:"ascii" nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 	// CPU架构
 	CpuArchitecture string `width:"16" charset:"ascii" nullable:"true" get:"domain" list:"domain" update:"domain" create:"domain_optional"`
+	// KVM CAP VCPU MAX
+	KvmCapMaxVcpu int `nullable:"true" get:"domain" list:"domain" update:"domain" create:"domain_optional"`
 
 	// 内存大小,单位Mb
 	MemSize int `nullable:"true" list:"domain" update:"domain" create:"domain_optional"`

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1617,6 +1617,8 @@ func (h *SHostInfo) updateOrCreateHost(hostId string) (*api.HostDetails, error) 
 	input.CpuDesc = h.Cpu.cpuInfoProc.Model
 	input.CpuMicrocode = h.Cpu.cpuInfoProc.Microcode
 	input.CpuArchitecture = h.Cpu.CpuArchitecture
+	maxVcpu := int(h.GetKVMMaxCpus())
+	input.KvmCapMaxVcpu = &maxVcpu
 
 	if h.Cpu.cpuInfoProc.Freq > 0 {
 		input.CpuMhz = &h.Cpu.cpuInfoProc.Freq

--- a/pkg/scheduler/algorithm/predicates/error.go
+++ b/pkg/scheduler/algorithm/predicates/error.go
@@ -45,6 +45,7 @@ const (
 	ErrBaremetalHasAlreadyBeenOccupied        = `baremetal has already been occupied`
 	ErrPrepaidHostOccupied                    = `prepaid host occupied`
 	ErrHostCpuArchitectureNotMatch            = `host cpu architecture not match`
+	ErrHostKvmVcpuMaxNotEnough                = `host kvm vcpu max not enough`
 
 	ErrUnknown = `unknown error`
 )

--- a/pkg/scheduler/algorithm/predicates/guest/cpu_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/guest/cpu_predicate.go
@@ -80,8 +80,13 @@ func (f *CPUPredicate) Execute(ctx context.Context, u *core.Unit, c core.Candida
 		return h.GetResult()
 	}
 
-	freeCPUCount := getter.FreeCPUCount(useRsvd)
 	reqCPUCount := int64(d.Ncpu + d.ExtraCpuCount)
+	if getter.KvmCapMaxVcpuCount() > 0 && reqCPUCount > getter.KvmCapMaxVcpuCount() {
+		h.Exclude2(predicates.ErrHostKvmVcpuMaxNotEnough, getter.KvmCapMaxVcpuCount(), reqCPUCount)
+		return h.GetResult()
+	}
+
+	freeCPUCount := getter.FreeCPUCount(useRsvd)
 	if freeCPUCount < reqCPUCount {
 		totalCPUCount := getter.TotalCPUCount(useRsvd)
 		h.AppendInsufficientResourceError(reqCPUCount, totalCPUCount, freeCPUCount)

--- a/pkg/scheduler/cache/candidate/base.go
+++ b/pkg/scheduler/cache/candidate/base.go
@@ -96,6 +96,10 @@ func (b baseHostGetter) CPUArch() string {
 	return b.h.CpuArchitecture
 }
 
+func (b baseHostGetter) KvmCapMaxVcpuCount() int64 {
+	return int64(b.h.KvmCapMaxVcpu)
+}
+
 func (b baseHostGetter) Cloudprovider() *computemodels.SCloudprovider {
 	return b.h.Cloudprovider
 }

--- a/pkg/scheduler/core/types.go
+++ b/pkg/scheduler/core/types.go
@@ -93,6 +93,7 @@ type CandidatePropertyGetter interface {
 	RunningCPUCount() int64
 	TotalCPUCount(useRsvd bool) int64
 	FreeCPUCount(useRsvd bool) int64
+	KvmCapMaxVcpuCount() int64
 
 	RunningMemorySize() int64
 	TotalMemorySize(useRsvd bool) int64

--- a/pkg/scheduler/test/mock/core.go
+++ b/pkg/scheduler/test/mock/core.go
@@ -318,6 +318,10 @@ func (m *MockCandidatePropertyGetter) CPUArch() string {
 	return ""
 }
 
+func (m *MockCandidatePropertyGetter) KvmCapMaxVcpuCount() int64 {
+	return -1
+}
+
 // Host indicates an expected call of Host
 func (mr *MockCandidatePropertyGetterMockRecorder) Host() *gomock.Call {
 	mr.mock.ctrl.T.Helper()


### PR DESCRIPTION
Cherry pick of #23513 on release/4.0.

#23513: fix(region,host,scheduler): add check kvm cpu max on cpu predicate