### PR TITLE
Automated cherry pick of #23544: fix(host): host probe isoalted device return jsonarray

### DIFF
--- a/pkg/hostman/hosthandler/handler.go
+++ b/pkg/hostman/hosthandler/handler.go
@@ -103,6 +103,5 @@ func hostRestart(ctx context.Context, hostId string, body jsonutils.JSONObject) 
 }
 
 func hostProbeIsolatedDevices(ctx context.Context, hostId string, body jsonutils.JSONObject) (interface{}, error) {
-	_, err := hostinfo.Instance().ProbeSyncIsolatedDevices(hostId, body)
-	return nil, err
+	return hostinfo.Instance().ProbeSyncIsolatedDevices(hostId, body)
 }


### PR DESCRIPTION
Cherry pick of #23544 on release/4.0.1.

#23544: fix(host): host probe isoalted device return jsonarray