### PR TITLE
fix(host): move the hostInstance.Init() step after InitAuth

### DIFF
--- a/pkg/hostman/host_services.go
+++ b/pkg/hostman/host_services.go
@@ -85,15 +85,15 @@ func (host *SHostService) RunService() {
 		log.Fatalf("failed set qemuimg preallocation to %s: %s", options.HostOptions.Qcow2Preallocation, err)
 	}
 
-	hostInstance := hostinfo.Instance()
-	if err := hostInstance.Init(); err != nil {
-		log.Fatalf("Host instance init error: %v", err)
-	}
-
 	app_common.InitAuth(&options.HostOptions.CommonOptions, func() {
 		log.Infof("Auth complete!!")
 	})
 	common_options.StartOptionManager(&options.HostOptions.CommonOptions, options.HostOptions.ConfigSyncPeriodSeconds, "", "", common_options.OnCommonOptionsChange)
+
+	hostInstance := hostinfo.Instance()
+	if err := hostInstance.Init(); err != nil {
+		log.Fatalf("Host instance init error: %v", err)
+	}
 
 	deployclient.Init(options.HostOptions.DeployServerSocketPath)
 	if err := storageman.Init(hostInstance); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

修复设置了 customized_private_prifixes ，但 dhcp_relay 功能没有读取到这个配置的问题。

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area host
- 3.11
/cc @swordqiu @wanyaoqi 