### PR TITLE
Automated cherry pick of #23684: fix(scheduler): sku predicate with empty zone id

### DIFF
--- a/pkg/scheduler/algorithm/predicates/sku_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/sku_predicate.go
@@ -68,7 +68,7 @@ func (p *InstanceTypePredicate) Execute(ctx context.Context, u *core.Unit, c cor
 			zoneMatch := false
 			for idx := range skus {
 				sku := skus[idx]
-				if sku.ZoneId == zoneId {
+				if len(sku.ZoneId) == 0 || sku.ZoneId == zoneId {
 					zoneMatch = true
 					break
 				}


### PR DESCRIPTION
Cherry pick of #23684 on release/4.0.

#23684: fix(scheduler): sku predicate with empty zone id