### PR TITLE
Automated cherry pick of #23704: fix(host): clear previous usage metrics when any container stopped of pod

### DIFF
--- a/pkg/hostman/hostmetrics/container_metrics.go
+++ b/pkg/hostman/hostmetrics/container_metrics.go
@@ -697,6 +697,23 @@ func (m *SGuestMonitor) getCadvisorDiskIoMetrics(cur stats.DiskIoStats, prev map
 	return ret
 }
 
+func isPodContainerStopped(prevUsage *GuestMetrics, stat *stats.PodStats) bool {
+	hasPrevUsage := prevUsage != nil && prevUsage.PodMetrics != nil
+	if !hasPrevUsage {
+		return false
+	}
+	curTime := stat.CPU.Time.Time
+	podCpu := &PodCpuMetric{
+		PodMetricMeta:        NewPodMetricMeta(curTime),
+		CpuUsageSecondsTotal: float64(*stat.CPU.UsageCoreNanoSeconds) / float64(time.Second),
+	}
+	pmPodCpu := prevUsage.PodMetrics.PodCpu
+	if podCpu.CpuUsageSecondsTotal < pmPodCpu.CpuUsageSecondsTotal {
+		return true
+	}
+	return false
+}
+
 func (m *SGuestMonitor) PodMetrics(prevUsage *GuestMetrics) *PodMetrics {
 	stat := m.podStat
 	curTime := stat.CPU.Time.Time

--- a/pkg/hostman/hostmetrics/hostmetrics.go
+++ b/pkg/hostman/hostmetrics/hostmetrics.go
@@ -498,6 +498,10 @@ func (s *SGuestMonitorCollector) collectGmReport(
 	if !gm.HasPodMetrics() {
 		return s.collectGuestMetrics(gm, prevUsage)
 	} else {
+		if isPodContainerStopped(prevUsage, gm.podStat) {
+			log.Infof("pod %s(%s) has container(s) stopped, clear previous usage", gm.Name, gm.Id)
+			prevUsage = new(GuestMetrics)
+		}
 		return s.collectPodMetrics(gm, prevUsage)
 	}
 }


### PR DESCRIPTION
Cherry pick of #23704 on release/4.0.0.

#23704: fix(host): clear previous usage metrics when any container stopped of pod