### PR TITLE
Automated cherry pick of #23768: fix: support build rpm/deb of riscv64

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -185,6 +185,9 @@ case "$GOARCH" in
     "amd64" | "x86" | "i686" | "i386" | "x86_64")
         TARGET="--target x86_64-redhat-linux"
         ;;
+    "riscv64")
+        TARGET="--target riscv64-linux"
+        ;;
 esac
 
 rpmbuild --define "_topdir $BUILDROOT" -bb $SPEC_FILE $TARGET

--- a/build/build_deb.sh
+++ b/build/build_deb.sh
@@ -42,15 +42,21 @@ case $(uname -m) in
     aarch64)
         CURRENT_ARCH=arm64
         ;;
+    riscv64)
+        CURRENT_ARCH=riscv64
+        ;;
 esac
 
 if [[ -n "$GOARCH" ]]; then
     case "$GOARCH" in
-		"arm64" | "arm" | "aarch64")
-	        CURRENT_ARCH="arm64"
+        "arm64" | "arm" | "aarch64")
+            CURRENT_ARCH="arm64"
             ;;
-		"x86" | "x86_64" | "i686" | "i386" | "amd64")
-			CURRENT_ARCH="amd64"
+        "x86" | "x86_64" | "i686" | "i386" | "amd64")
+            CURRENT_ARCH="amd64"
+            ;;
+        "riscv64")
+            CURRENT_ARCH="riscv64"
             ;;
 	esac
 fi
@@ -159,6 +165,9 @@ case "$CURRENT_ARCH" in
         ;;
     "arm64")
         DSTARCH="aarch64"
+        ;;
+    "riscv64")
+        DSTARCH="riscv64"
         ;;
 esac
 


### PR DESCRIPTION
Cherry pick of #23768 on release/4.0.

#23768: fix: support build rpm/deb of riscv64