### PR TITLE
Automated cherry pick of #23896: fix(host): ensure a single file dir when mounting

### DIFF
--- a/pkg/hostman/container/volume_mount/disk/post_overlay_hostpath.go
+++ b/pkg/hostman/container/volume_mount/disk/post_overlay_hostpath.go
@@ -134,8 +134,17 @@ func (p postOverlayHostPath) mountSingleFile(singleFilePath string, d diskPostOv
 		return errors.Wrapf(err, "change file %s owner", singleFilePath)
 	}
 	if !fileutils.Exists(mergedDst) {
+		if err := volume_mount.EnsureDir(filepath.Dir(mergedDst)); err != nil {
+			return errors.Wrapf(err, "ensure dir %s", filepath.Dir(mergedDst))
+		}
+		if err := volume_mount.ChangeDirOwnerDirectly(filepath.Dir(mergedDst), ov.FsUser, ov.FsGroup); err != nil {
+			return errors.Wrapf(err, "change dir %s owner", filepath.Dir(mergedDst))
+		}
 		if err := volume_mount.TouchFile(mergedDst); err != nil {
 			return errors.Wrapf(err, "touch file %s", mergedDst)
+		}
+		if err := volume_mount.ChangeDirOwnerDirectly(mergedDst, ov.FsUser, ov.FsGroup); err != nil {
+			return errors.Wrapf(err, "change file %s owner", mergedDst)
 		}
 	}
 	if err := mountutils.MountBind(singleFileMergedFilePath, mergedDst); err != nil {


### PR DESCRIPTION
Cherry pick of #23896 on master.

#23896: fix(host): ensure a single file dir when mounting