### PR TITLE
Automated cherry pick of #23947: fix: host flush addrs instead of reset interface

### DIFF
--- a/pkg/util/kmsg/doc.go
+++ b/pkg/util/kmsg/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kmsg // import "yunion.io/x/onecloud/pkg/util/kmsg"

--- a/pkg/util/kmsg/kmsg.go
+++ b/pkg/util/kmsg/kmsg.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kmsg
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+func Log(msg string) {
+	f, err := os.OpenFile("/dev/kmsg", os.O_WRONLY, 0)
+	if err != nil {
+		// This will likely fail without root privileges
+		log.Fatalf("failed to open /dev/kmsg: %v", err)
+	}
+	defer f.Close()
+
+	if !strings.HasSuffix(msg, "\n") {
+		msg = msg + "\n"
+	}
+
+	f.WriteString(msg)
+}

--- a/pkg/util/netutils2/netutils_linux.go
+++ b/pkg/util/netutils2/netutils_linux.go
@@ -115,6 +115,15 @@ func (n *SNetInterface) setStatus(status string) error {
 	return nil
 }
 
+func (n *SNetInterface) FlushAddrs() error {
+	cmd := procutils.NewCommand("ip", "addr", "flush", "dev", n.name)
+	msg, err := cmd.Output()
+	if err != nil {
+		return errors.Wrap(err, strings.TrimSpace(string(msg)))
+	}
+	return nil
+}
+
 func getRouteSpecs(listFunc func() ([]iproute2.RouteSpec, error)) []iproute2.RouteSpec {
 	routespecs, err := listFunc()
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #23947 on release/4.0.1.

#23947: fix: host flush addrs instead of reset interface