### PR TITLE
Automated cherry pick of #23973: fix(climc): host set memory commit bound incorrect params

### DIFF
--- a/pkg/mcclient/options/compute/host.go
+++ b/pkg/mcclient/options/compute/host.go
@@ -143,7 +143,7 @@ func (o *HostAutoMigrateOnHostDownOptions) Params() (jsonutils.JSONObject, error
 type HostSetCommitBoundOptions struct {
 	options.BaseIdsOptions
 	CpuCmtbound *float32 `help:"Cpu commit bound"`
-	MemCmtBound *float32 `help:"Mem commit bound"`
+	MemCmtbound *float32 `help:"Mem commit bound"`
 }
 
 func (o *HostSetCommitBoundOptions) Params() (jsonutils.JSONObject, error) {


### PR DESCRIPTION
Cherry pick of #23973 on master.

#23973: fix(climc): host set memory commit bound incorrect params