### PR TITLE
fix(scheduler): correct mem_free = (mem_total - mem_reserved) * mem_cmtbound

### DIFF
--- a/pkg/scheduler/cache/candidate/hosts.go
+++ b/pkg/scheduler/cache/candidate/hosts.go
@@ -902,7 +902,7 @@ func (b *HostBuilder) fillGuestsResourceInfo(desc *HostDesc, host *computemodels
 	desc.CreatingCPUCount = creatingCPUCount
 	desc.FakeDeletedCPUCount = cpuFakeDeletedCount
 
-	desc.TotalMemSize = int64(float32(desc.MemSize) * desc.MemCmtbound)
+	desc.TotalMemSize = int64(float32(desc.MemSize-desc.MemReserved) * desc.MemCmtbound)
 	desc.TotalCPUCount = int64(float32(desc.CpuCount) * desc.CPUCmtbound)
 
 	var memFreeSize int64
@@ -919,9 +919,6 @@ func (b *HostBuilder) fillGuestsResourceInfo(desc *HostDesc, host *computemodels
 		}
 	}
 
-	// free memory size calculate
-	rsvdUseMem := desc.GuestReservedResourceUsed.MemorySize
-	memFreeSize = memFreeSize + rsvdUseMem - desc.GetReservedMemSize()
 	memSub := desc.GuestReservedResource.MemorySize - desc.GuestReservedResourceUsed.MemorySize
 	if memSub < 0 {
 		memFreeSize += memSub


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.8
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
