### PR TITLE
Automated cherry pick of #24035: fix(region): support order by snapshot

### DIFF
--- a/pkg/apis/compute/input.go
+++ b/pkg/apis/compute/input.go
@@ -147,6 +147,7 @@ type SnapshotPolicyListInput struct {
 	// 按绑定的磁盘数量排序
 	// pattern:asc|desc
 	OrderByBindDiskCount string `json:"order_by_bind_disk_count"`
+	OrderBySnapshotCount string `json:"order_by_snapshot_count"`
 	// 按类型过滤
 	Type string `json:"type"`
 }

--- a/pkg/mcclient/options/compute/snapshotpolicy.go
+++ b/pkg/mcclient/options/compute/snapshotpolicy.go
@@ -27,6 +27,7 @@ type SnapshotPolicyListOptions struct {
 	options.BaseListOptions
 
 	OrderByBindDiskCount string
+	OrderBySnapshotCount string
 }
 
 func (opts *SnapshotPolicyListOptions) Params() (jsonutils.JSONObject, error) {


### PR DESCRIPTION
Cherry pick of #24035 on release/4.0.

#24035: fix(region): support order by snapshot