### PR TITLE
fix(glance): set glance s3 bucket name default onecloud-images

### DIFF
--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -169,7 +169,7 @@ type S3CommonOptions struct {
 	S3SecretKey              string `help:"s3 secret key"`
 	S3Endpoint               string `help:"s3 endpoint"`
 	S3UseSSL                 bool   `help:"s3 access use ssl"`
-	S3BucketName             string `help:"s3 bucket name" default:"onecloud-screendump"`
+	S3BucketName             string `help:"s3 bucket name"`
 	S3BucketLifecycleKeepDay int    `help:"s3 bucket lifecycle keep day" default:"180"`
 }
 

--- a/pkg/hostman/host_services.go
+++ b/pkg/hostman/host_services.go
@@ -166,6 +166,8 @@ func (host *SHostService) initHandlers(app *appsrv.Application) {
 	app_common.ExportOptionsHandler(app, &options.HostOptions)
 }
 
+const DEFAULT_SCREENDUMP_S3_BUCKET = "onecloud-screendump-new"
+
 func initS3() {
 	url := options.HostOptions.S3Endpoint
 	if len(url) == 0 {
@@ -179,6 +181,10 @@ func initS3() {
 		}
 		url = prefix + url
 	}
+	if options.HostOptions.S3BucketName == "" {
+		options.HostOptions.S3BucketName = DEFAULT_SCREENDUMP_S3_BUCKET
+	}
+
 	err := s3.Init(
 		url,
 		options.HostOptions.S3AccessKey,

--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -188,6 +188,8 @@ func hasVmwareAccount() (bool, error) {
 	return res.Total > 0, nil
 }
 
+const DEFAULT_IMAGE_S3_BUCKET = "onecloud-images"
+
 func initS3() {
 	url := options.Options.S3Endpoint
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
@@ -197,6 +199,10 @@ func initS3() {
 		}
 		url = prefix + url
 	}
+	if options.Options.S3BucketName == "" {
+		options.Options.S3BucketName = DEFAULT_IMAGE_S3_BUCKET
+	}
+
 	err := s3.Init(
 		url,
 		options.Options.S3AccessKey,
@@ -207,6 +213,12 @@ func initS3() {
 	if err != nil {
 		log.Fatalf("failed init s3 client %s", err)
 	}
+	if options.Options.S3BucketName == "onecloud-screendump" {
+		if err = s3.SetBucketLifecycle(""); err != nil {
+			log.Warningf("remove onecloud-screendump lifecycle %s", err)
+		}
+	}
+
 	func() {
 		fd, err := os.OpenFile("/tmp/s3-pass", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.11
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
