### PR TITLE
Automated cherry pick of #24169: fix(glance): set glance s3 bucket name default onecloud-images

### DIFF
--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -182,7 +182,7 @@ type S3CommonOptions struct {
 	S3SecretKey              string `help:"s3 secret key"`
 	S3Endpoint               string `help:"s3 endpoint"`
 	S3UseSSL                 bool   `help:"s3 access use ssl"`
-	S3BucketName             string `help:"s3 bucket name" default:"onecloud-screendump"`
+	S3BucketName             string `help:"s3 bucket name"`
 	S3BucketLifecycleKeepDay int    `help:"s3 bucket lifecycle keep day" default:"180"`
 }
 

--- a/pkg/hostman/host_services.go
+++ b/pkg/hostman/host_services.go
@@ -172,6 +172,8 @@ func (host *SHostService) initHandlers(app *appsrv.Application) {
 	app_common.ExportOptionsHandler(app, &options.HostOptions)
 }
 
+const DEFAULT_SCREENDUMP_S3_BUCKET = "onecloud-screendump-new"
+
 func initS3() {
 	url := options.HostOptions.S3Endpoint
 	if len(url) == 0 {
@@ -185,6 +187,10 @@ func initS3() {
 		}
 		url = prefix + url
 	}
+	if options.HostOptions.S3BucketName == "" {
+		options.HostOptions.S3BucketName = DEFAULT_SCREENDUMP_S3_BUCKET
+	}
+
 	err := s3.Init(
 		url,
 		options.HostOptions.S3AccessKey,

--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -204,7 +204,13 @@ func hasVmwareAccount() (bool, error) {
 	return res.Total > 0, nil
 }
 
+const DEFAULT_IMAGE_S3_BUCKET = "onecloud-images"
+
 func initS3() {
+	if options.Options.S3BucketName == "" {
+		options.Options.S3BucketName = DEFAULT_IMAGE_S3_BUCKET
+	}
+
 	err := s3.Init(
 		options.Options.S3Endpoint,
 		options.Options.S3AccessKey,
@@ -216,6 +222,12 @@ func initS3() {
 	if err != nil {
 		log.Fatalf("failed init s3 client %s", err)
 	}
+	if options.Options.S3BucketName == "onecloud-screendump" {
+		if err = s3.SetBucketLifecycle(""); err != nil {
+			log.Warningf("remove onecloud-screendump lifecycle %s", err)
+		}
+	}
+
 	func() {
 		fd, err := os.OpenFile("/tmp/s3-pass", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #24169 on release/4.0.

#24169: fix(glance): set glance s3 bucket name default onecloud-images