### PR TITLE
Automated cherry pick of #24202: fix(monitor): comparator string

### DIFF
--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -914,11 +914,11 @@ func getCommonAlertMetricDetailsFromCondition(
 	cmp := ""
 	switch cond.Evaluator.Type {
 	case "gt":
-		cmp = ">="
+		cmp = ">"
 	case "eq":
 		cmp = "=="
 	case "lt":
-		cmp = "<="
+		cmp = "<"
 	case "within_range":
 		cmp = "within_range"
 	case "outside_range":


### PR DESCRIPTION
Cherry pick of #24202 on release/4.0.2.

#24202: fix(monitor): comparator string