### PR TITLE
Automated cherry pick of #24212: fix(region,climc): persist netinterface vlan_id to hostnetwork

### DIFF
--- a/cmd/climc/shell/compute/hosts.go
+++ b/cmd/climc/shell/compute/hosts.go
@@ -333,6 +333,7 @@ func init() {
 		IpAddr    string `help:"IP address"`
 		Bridge    string `help:"Bridge of hostwire"`
 		Interface string `help:"Interface name, eg:eth0, en0"`
+		VlanId    int    `help:"Vlan ID"`
 	}
 	R(&HostAddNetIfOptions{}, "host-add-netif", "Host add a NIC", func(s *mcclient.ClientSession, args *HostAddNetIfOptions) error {
 		params := jsonutils.NewDict()
@@ -352,6 +353,7 @@ func init() {
 		if len(args.Interface) > 0 {
 			params.Add(jsonutils.NewString(args.Interface), "interface")
 		}
+		addVlanIdToParams(params, args.VlanId)
 		result, err := modules.Hosts.PerformAction(s, args.ID, "add-netif", params)
 		if err != nil {
 			return err
@@ -361,12 +363,14 @@ func init() {
 	})
 
 	type HostRemoveNetIfOptions struct {
-		ID  string `help:"ID or Name of host"`
-		MAC string `help:"MAC of NIC to remove"`
+		ID     string `help:"ID or Name of host"`
+		MAC    string `help:"MAC of NIC to remove"`
+		VlanId int    `help:"Vlan Id"`
 	}
 	R(&HostRemoveNetIfOptions{}, "host-remove-netif", "Remove NIC from host", func(s *mcclient.ClientSession, args *HostRemoveNetIfOptions) error {
 		params := jsonutils.NewDict()
 		params.Add(jsonutils.NewString(args.MAC), "mac")
+		addVlanIdToParams(params, args.VlanId)
 		result, err := modules.Hosts.PerformAction(s, args.ID, "remove-netif", params)
 		if err != nil {
 			return err
@@ -381,6 +385,7 @@ func init() {
 		Ip       string `help:"IP address"`
 		Network  string `help:"network to connect"`
 		Reserved bool   `help:"fetch IP from reserved pool"`
+		VlanId   int    `help:"Vlan ID"`
 	}
 	R(&HostEnableNetIfOptions{}, "host-enable-netif", "Enable a network interface for a host", func(s *mcclient.ClientSession, args *HostEnableNetIfOptions) error {
 		params := jsonutils.NewDict()
@@ -394,6 +399,7 @@ func init() {
 		if len(args.Network) > 0 {
 			params.Add(jsonutils.NewString(args.Network), "network")
 		}
+		addVlanIdToParams(params, args.VlanId)
 		result, err := modules.Hosts.PerformAction(s, args.ID, "enable-netif", params)
 		if err != nil {
 			return err
@@ -406,6 +412,7 @@ func init() {
 		ID      string `help:"ID or Name of host"`
 		MAC     string `help:"MAC of NIC to disable"`
 		Reserve bool   `help:"Reserve the IP address"`
+		VlanId  int    `help:"Vlan Id"`
 	}
 	R(&HostDisableNetIfOptions{}, "host-disable-netif", "Disable a network interface", func(s *mcclient.ClientSession, args *HostDisableNetIfOptions) error {
 		params := jsonutils.NewDict()
@@ -413,6 +420,7 @@ func init() {
 		if args.Reserve {
 			params.Add(jsonutils.JSONTrue, "reserve")
 		}
+		addVlanIdToParams(params, args.VlanId)
 		result, err := modules.Hosts.PerformAction(s, args.ID, "disable-netif", params)
 		if err != nil {
 			return err
@@ -753,4 +761,10 @@ func init() {
 			return nil
 		},
 	)
+}
+
+func addVlanIdToParams(params *jsonutils.JSONDict, vlanId int) {
+	if vlanId > 1 {
+		params.Add(jsonutils.NewInt(int64(vlanId)), "vlan_id")
+	}
 }

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -5876,6 +5876,7 @@ func (hh *SHost) Attach2Network(
 	bn.NetworkId = net.Id
 	bn.IpAddr = freeIp
 	bn.MacAddr = netif.Mac
+	bn.VlanId = netif.VlanId
 	err = HostnetworkManager.TableSpec().Insert(ctx, bn)
 	if err != nil {
 		return nil, errors.Wrap(err, "HostnetworkManager.TableSpec().Insert")

--- a/pkg/mcclient/modules/compute/mod_baremetalnetworks.go
+++ b/pkg/mcclient/modules/compute/mod_baremetalnetworks.go
@@ -29,7 +29,7 @@ func init() {
 		"baremetalnetworks",
 		[]string{"Baremetal_ID", "Host",
 			"Network_ID", "Network", "IP_addr", "Mac_addr",
-			"Nic_Type"},
+			"Nic_Type", "Vlan_ID"},
 		[]string{},
 		&Hosts,
 		&Networks)


### PR DESCRIPTION
Cherry pick of #24212 on release/3.11.13.

#24212: fix(region,climc): persist netinterface vlan_id to hostnetwork