### PR TITLE
fix(glance): set s3 bucket name before s3 init check

### DIFF
--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -140,6 +140,11 @@ func StartService() {
 	}
 
 	go func() {
+		if options.Options.S3BucketName == "" {
+			options.Options.S3BucketName = DEFAULT_IMAGE_S3_BUCKET
+			log.Infof("Set s3 bucket name to %s", options.Options.S3BucketName)
+		}
+
 		if options.Options.HasValidS3Options() {
 			initS3()
 		}
@@ -198,9 +203,6 @@ func initS3() {
 			prefix = "https://"
 		}
 		url = prefix + url
-	}
-	if options.Options.S3BucketName == "" {
-		options.Options.S3BucketName = DEFAULT_IMAGE_S3_BUCKET
 	}
 
 	err := s3.Init(


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
release/3.11
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
