### PR TITLE
Automated cherry pick of #24256: fix(region,host): rename screen dump info structure

### DIFF
--- a/pkg/apis/compute/guest_image.go
+++ b/pkg/apis/compute/guest_image.go
@@ -28,7 +28,7 @@ type SImagesInGuest struct {
 	DataImages []SSubImage
 }
 
-type SGuestScreenDump struct {
+type SGuestScreenDumpInfo struct {
 	S3AccessKey  string
 	S3SecretKey  string
 	S3Endpoint   string

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -150,7 +150,7 @@ func (self *SGuest) PerformEvent(ctx context.Context, userCred mcclient.TokenCre
 		kwargs := jsonutils.NewDict()
 		kwargs.Set("reason", jsonutils.NewString(event))
 		if data.Contains("screen_dump_info") {
-			screenDumpInfo := api.SGuestScreenDump{}
+			screenDumpInfo := api.SGuestScreenDumpInfo{}
 			if err := data.Unmarshal(&screenDumpInfo, "screen_dump_info"); err != nil {
 				log.Errorf("failed unmarshal screen_dump_info %s", err)
 			} else {

--- a/pkg/compute/models/guestscreendump.go
+++ b/pkg/compute/models/guestscreendump.go
@@ -77,7 +77,7 @@ func (self *SGuestScreenDump) Delete(ctx context.Context, userCred mcclient.Toke
 	return db.DeleteModel(ctx, userCred, self)
 }
 
-func (self *SGuest) SaveGuestScreenDump(ctx context.Context, userCred mcclient.TokenCredential, screenDumpInfo *api.SGuestScreenDump) (*SGuestScreenDump, error) {
+func (self *SGuest) SaveGuestScreenDump(ctx context.Context, userCred mcclient.TokenCredential, screenDumpInfo *api.SGuestScreenDumpInfo) (*SGuestScreenDump, error) {
 	sd := new(SGuestScreenDump)
 	sd.SetModelManager(GuestScreenDumpManager, sd)
 	sd.GuestId = self.GetId()

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -1148,7 +1148,7 @@ func (s *SKVMGuestInstance) eventGuestPaniced(event *monitor.Event) {
 			if err != nil {
 				log.Errorf("faild put screenDumpPath %s to s3 %s", screenDumpPath, err)
 			} else {
-				screenDumpInfo := api.SGuestScreenDump{
+				screenDumpInfo := api.SGuestScreenDumpInfo{
 					S3AccessKey:  options.HostOptions.S3AccessKey,
 					S3SecretKey:  options.HostOptions.S3SecretKey,
 					S3Endpoint:   options.HostOptions.S3Endpoint,


### PR DESCRIPTION
Cherry pick of #24256 on release/4.0.2.

#24256: fix(region,host): rename screen dump info structure