### PR TITLE
Automated cherry pick of #24282: fix: remove parent task info from task context

### DIFF
--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -688,6 +688,9 @@ func (task *STask) GetRequestContext() appctx.AppContextData {
 			ctxJson.Unmarshal(&ctxData)
 		}
 	}
+	// clear parentTaskId
+	ctxData.TaskId = ""
+	ctxData.TaskNotifyUrl = ""
 	return ctxData
 }
 


### PR DESCRIPTION
Cherry pick of #24282 on release/4.0.1.

#24282: fix: remove parent task info from task context