### PR TITLE
Automated cherry pick of #24304: fix(host-deployer): deploy single disk has no disk id

### DIFF
--- a/pkg/hostman/diskutils/fsutils/resizefs.go
+++ b/pkg/hostman/diskutils/fsutils/resizefs.go
@@ -31,6 +31,9 @@ func (d *SFsutilDriver) GetResizeDevBySerial(diskId string) (string, error) {
 	}
 	lines := strings.Split(string(out), "\n")
 	diskSerial := strings.ReplaceAll(diskId, "-", "")
+	if len(diskSerial) >= 20 {
+		diskSerial = diskSerial[:20]
+	}
 	resizeDev := ""
 	for i := range lines {
 		segs := strings.Fields(lines[i])

--- a/pkg/hostman/diskutils/qemu_kvm/driver.go
+++ b/pkg/hostman/diskutils/qemu_kvm/driver.go
@@ -698,7 +698,10 @@ func (d *QemuBaseDriver) startCmds(
 
 		cmd += diskDrive
 		serialId := strings.ReplaceAll(diskIds[i], "-", "")
-		deviceId := serialId[:20]
+		if len(serialId) >= 20 {
+			serialId = serialId[:20]
+		}
+		deviceId := serialId
 		cmd += __("-device scsi-hd,drive=drive_%d,bus=scsi.0,id=drive_%d,serial=%s,device_id=%s", i, i, serialId, deviceId)
 	}
 	cmd += __("-drive id=cd0,if=none,media=cdrom,file=%s", DEPLOY_ISO)


### PR DESCRIPTION
Cherry pick of #24304 on release/4.0.2.

#24304: fix(host-deployer): deploy single disk has no disk id