### PR TITLE
Automated cherry pick of #24307: fix(host): set dmesg parse failed log level to debug

### DIFF
--- a/pkg/hostman/hostmetrics/host_dmesg.go
+++ b/pkg/hostman/hostmetrics/host_dmesg.go
@@ -104,7 +104,7 @@ func (c *SHostDmesgCollector) Start() {
 
 		entry, err := c.parseKmsgLine(line, bootTime)
 		if err != nil {
-			log.Errorf("failed parse kmsg line %s: %s", line, err)
+			log.Debugf("failed parse kmsg line %s: %s", line, err)
 			continue
 		}
 		if entry.Seq <= lastSeq {


### PR DESCRIPTION
Cherry pick of #24307 on release/4.0.

#24307: fix(host): set dmesg parse failed log level to debug