### PR TITLE
Automated cherry pick of #24324: fix(host): do not set cached image status to active for TGZ on host

### DIFF
--- a/pkg/hostman/container/volume_mount/disk/post_overlay_image.go
+++ b/pkg/hostman/container/volume_mount/disk/post_overlay_image.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/onecloud/pkg/apis"
 	hostapi "yunion.io/x/onecloud/pkg/apis/host"
 	"yunion.io/x/onecloud/pkg/hostman/container/volume_mount"
+	fileutils "yunion.io/x/onecloud/pkg/util/fileutils2"
 )
 
 func init() {
@@ -121,6 +122,11 @@ func (i postOverlayImage) withAction(
 			return errors.Wrap(err, "get host disk root path")
 		}
 		hostUpperDir = filepath.Join(hostPath, vm.Disk.SubDirectory, config.Disk.SubPath)
+		if !fileutils.Exists(hostUpperDir) {
+			if err := volume_mount.EnsureDir(hostUpperDir); err != nil {
+				return errors.Wrapf(err, "ensure dir %s", hostUpperDir)
+			}
+		}
 	}
 	for hostPath, ctrPath := range paths {
 		hostLowerPath := hostLowerPaths[hostPath]

--- a/pkg/hostman/storageman/imagecache_local.go
+++ b/pkg/hostman/storageman/imagecache_local.go
@@ -224,10 +224,14 @@ func (l *SLocalImageCache) fetch(ctx context.Context, input api.CacheImageInput,
 	}()
 	var _fetch = func() error {
 		if len(l.Manager.GetId()) > 0 {
-			_, err := hostutils.RemoteStoragecacheCacheImage(ctx,
-				l.Manager.GetId(), l.imageId, "active", l.GetPath())
-			if err != nil {
-				log.Errorf("Fail to update host cached image: %s", err)
+			// TGZ images are unpacked after fetch; do not set status to active here.
+			// TODO: status should be updated by the region task; this logic may be removable?
+			if l.remoteFile.GetFormat() != imageapi.IMAGE_DISK_FORMAT_TGZ {
+				_, err := hostutils.RemoteStoragecacheCacheImage(ctx,
+					l.Manager.GetId(), l.imageId, "active", l.GetPath())
+				if err != nil {
+					log.Errorf("Fail to update host cached image: %s", err)
+				}
 			}
 		}
 		l.cond.L.Lock()

--- a/pkg/hostman/storageman/remotefile/remotefile.go
+++ b/pkg/hostman/storageman/remotefile/remotefile.go
@@ -90,6 +90,10 @@ func NewRemoteFile(
 	}
 }
 
+func (r *SRemoteFile) GetFormat() string {
+	return r.format
+}
+
 func (r *SRemoteFile) Fetch(callback func(progress, progressMbps float64, totalSizeMb int64)) error {
 	if len(r.preChksum) > 0 {
 		log.Infof("Fetch remote file with precheck sum: %s", r.preChksum)


### PR DESCRIPTION
Cherry pick of #24324 on release/4.0.2.

#24324: fix(host): do not set cached image status to active for TGZ on host