### PR TITLE
Automated cherry pick of #24339: fix: keep climc network-create backward compatibility

### DIFF
--- a/cmd/climc/shell/compute/networks.go
+++ b/cmd/climc/shell/compute/networks.go
@@ -98,6 +98,22 @@ func init() {
 		return nil
 	})
 
+	type NetworkCreate3Options struct {
+		compute_options.NetworkCreateOptions `start_ip->positional:"false" end_ip->positional:"false" net_mask->positional:"false"`
+	}
+	R(&NetworkCreate3Options{}, "network-create3", "Create a dual-stack virtual network", func(s *mcclient.ClientSession, args *NetworkCreate3Options) error {
+		params, err := args.Params()
+		if err != nil {
+			return err
+		}
+		net, err := modules.Networks.Create(s, params)
+		if err != nil {
+			return err
+		}
+		printObject(net)
+		return nil
+	})
+
 	type NetworkSplitOptions struct {
 		NETWORK string `help:"ID or name of network to split"`
 		IP      string `help:"Start ip of the split network"`

--- a/pkg/mcclient/options/compute/network.go
+++ b/pkg/mcclient/options/compute/network.go
@@ -67,9 +67,9 @@ func (opts *NetworkListOptions) Params() (jsonutils.JSONObject, error) {
 type NetworkCreateOptions struct {
 	WIRE    string `help:"ID or Name of wire in which the network is created"`
 	NETWORK string `help:"Name of new network"`
-	StartIp string `help:"Start of IPv4 address range"`
-	EndIp   string `help:"End of IPv4 address rnage"`
-	NetMask int64  `help:"Length of network mask"`
+	StartIp string `help:"Start of IPv4 address range" positional:"true" json:"start_ip"`
+	EndIp   string `help:"End of IPv4 address rnage" positional:"true" json:"end_ip"`
+	NetMask int64  `help:"Length of network mask" positional:"true" json:"net_mask"`
 	Gateway string `help:"Default gateway"`
 
 	StartIp6 string `help:"IPv6 start ip"`


### PR DESCRIPTION
Cherry pick of #24339 on release/4.0.

#24339: fix: keep climc network-create backward compatibility