### PR TITLE
fix(monitor): convert SNodeAlert to SCommonAlert in FetchCustomizeColumns

### DIFF
--- a/pkg/monitor/models/nodealert.go
+++ b/pkg/monitor/models/nodealert.go
@@ -570,7 +570,12 @@ func (man *SNodeAlertManager) FetchCustomizeColumns(
 ) []monitor.NodeAlertDetails {
 	rows := make([]monitor.NodeAlertDetails, len(objs))
 
-	v1Rows := man.SCommonAlertManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
+	cObjs := make([]interface{}, len(objs))
+	for i := range objs {
+		obj := objs[i].(*SNodeAlert)
+		cObjs[i] = &SCommonAlert{obj.SAlert}
+	}
+	v1Rows := man.SCommonAlertManager.FetchCustomizeColumns(ctx, userCred, query, cObjs, fields, isList)
 
 	for i := range rows {
 		rows[i] = monitor.NodeAlertDetails{


### PR DESCRIPTION
Pass cObjs of type *SCommonAlert to SCommonAlertManager.FetchCustomizeColumns instead of *SNodeAlert so the parent correctly fetches common alert columns.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0
/area monitor