### PR TITLE
Automated cherry pick of #24344: fix(monitor): convert SNodeAlert to SCommonAlert in FetchCustomizeColumns

### DIFF
--- a/pkg/monitor/models/nodealert.go
+++ b/pkg/monitor/models/nodealert.go
@@ -573,7 +573,12 @@ func (man *SNodeAlertManager) FetchCustomizeColumns(
 ) []monitor.NodeAlertDetails {
 	rows := make([]monitor.NodeAlertDetails, len(objs))
 
-	v1Rows := man.SCommonAlertManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
+	cObjs := make([]interface{}, len(objs))
+	for i := range objs {
+		obj := objs[i].(*SNodeAlert)
+		cObjs[i] = &SCommonAlert{obj.SAlert}
+	}
+	v1Rows := man.SCommonAlertManager.FetchCustomizeColumns(ctx, userCred, query, cObjs, fields, isList)
 
 	for i := range rows {
 		rows[i] = monitor.NodeAlertDetails{


### PR DESCRIPTION
Cherry pick of #24344 on release/3.11.

#24344: fix(monitor): convert SNodeAlert to SCommonAlert in FetchCustomizeColumns