### PR TITLE
Automated cherry pick of #24365: fix(host): check file exist before copy ovmf vars

### DIFF
--- a/pkg/hostman/guestman/qemu/qemu.go
+++ b/pkg/hostman/guestman/qemu/qemu.go
@@ -297,7 +297,7 @@ func (o baseOptions) BIOS(ovmfPath, ovmfVarsPath, homedir string) (string, error
 	guestOvmfVarsPath := path.Join(homedir, ovmfVarsName)
 	if !fileutils2.Exists(guestOvmfVarsPath) {
 		sourceOvmfVarsPath := ovmfPath
-		if ovmfVarsPath != "" {
+		if ovmfVarsPath != "" && fileutils2.Exists(ovmfVarsPath) {
 			sourceOvmfVarsPath = ovmfVarsPath
 		}
 		err := procutils.NewRemoteCommandAsFarAsPossible("cp", "-f", sourceOvmfVarsPath, guestOvmfVarsPath).Run()


### PR DESCRIPTION
Cherry pick of #24365 on master.

#24365: fix(host): check file exist before copy ovmf vars