### PR TITLE
Automated cherry pick of #24368: fix(region): snapshot size opslog

### DIFF
--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -439,7 +439,8 @@ func (manager *SSnapshotManager) FetchCustomizeColumns(
 
 func (self *SSnapshot) GetShortDesc(ctx context.Context) *jsonutils.JSONDict {
 	res := self.SVirtualResourceBase.GetShortDesc(ctx)
-	res.Add(jsonutils.NewInt(int64(self.VirtualSize)), "size")
+	res.Add(jsonutils.NewInt(int64(self.VirtualSize)), "virtual_size")
+	res.Add(jsonutils.NewInt(int64(self.Size)), "size")
 	res.Add(jsonutils.NewString(self.DiskId), "disk_id")
 	disk, _ := self.GetDisk()
 	if disk != nil {


### PR DESCRIPTION
Cherry pick of #24368 on release/4.0.2.

#24368: fix(region): snapshot size opslog