### PR TITLE
Automated cherry pick of #24395: fix(monitor): 仅在 From/To/Interval 为空时设置默认值

### DIFF
--- a/pkg/monitor/models/unifiedmonitor.go
+++ b/pkg/monitor/models/unifiedmonitor.go
@@ -397,9 +397,15 @@ func setDefaultValue(
 	inputQuery *monitor.MetricQueryInput,
 	scope string, ownerId mcclient.IIdentityProvider,
 	isAlert bool) {
-	query.From = inputQuery.From
-	query.To = inputQuery.To
-	query.Model.Interval = inputQuery.Interval
+	if query.From == "" {
+		query.From = inputQuery.From
+	}
+	if query.To == "" {
+		query.To = inputQuery.To
+	}
+	if query.Model.Interval == "" {
+		query.Model.Interval = inputQuery.Interval
+	}
 
 	metricMeasurement, _ := MetricMeasurementManager.GetCache().Get(query.Model.Measurement)
 


### PR DESCRIPTION
Cherry pick of #24395 on release/4.0.2.

#24395: fix(monitor): 仅在 From/To/Interval 为空时设置默认值