### PR TITLE
fix(keystone): allow blob update for image credentials

### DIFF
--- a/pkg/keystone/models/credentials.go
+++ b/pkg/keystone/models/credentials.go
@@ -25,6 +25,7 @@ import (
 	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/rbacscope"
+	"yunion.io/x/pkg/util/sets"
 	"yunion.io/x/sqlchemy"
 
 	api "yunion.io/x/onecloud/pkg/apis/identity"
@@ -175,8 +176,8 @@ func (cred *SCredential) ValidateUpdateData(ctx context.Context, userCred mcclie
 	}
 
 	if len(input.Blob) > 0 {
-		if cred.Type != api.CONTAINER_SECRET_TYPE {
-			return input, httperrors.NewNotSupportedError("blob update only supported for credential type %s", api.CONTAINER_SECRET_TYPE)
+		if !sets.NewString(api.CONTAINER_SECRET_TYPE, api.CONTAINER_IMAGE_TYPE).Has(cred.Type) {
+			return input, httperrors.NewNotSupportedError("blob update only supported for credential type %v", sets.NewString(api.CONTAINER_SECRET_TYPE, api.CONTAINER_IMAGE_TYPE).List())
 		}
 		blobEnc, err := keys.CredentialKeyManager.Encrypt([]byte(input.Blob))
 		if err != nil {


### PR DESCRIPTION
Also fix type check to allow secret/image only.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area keystone