### PR TITLE
Automated cherry pick of #24567: fix(region): order containers by created_at time

### DIFF
--- a/pkg/compute/models/containers.go
+++ b/pkg/compute/models/containers.go
@@ -140,7 +140,7 @@ func (m *SContainerManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQue
 }
 
 func (m *SContainerManager) GetContainersByPod(guestId string) ([]SContainer, error) {
-	q := m.Query().Equals("guest_id", guestId)
+	q := m.Query().Equals("guest_id", guestId).Asc("created_at")
 	ctrs := make([]SContainer, 0)
 	if err := db.FetchModelObjects(m, q, &ctrs); err != nil {
 		return nil, errors.Wrap(err, "db.FetchModelObjects")

--- a/pkg/compute/models/guest_queries.go
+++ b/pkg/compute/models/guest_queries.go
@@ -807,7 +807,7 @@ func fetchGuestBackupInfo(hostIds []string) (map[string]api.BackupInfo, error) {
 func fetchContainers(guestIds []string) (map[string][]*api.PodContainerDesc, error) {
 	ret := map[string][]*api.PodContainerDesc{}
 	containers := []SContainer{}
-	err := GetContainerManager().Query().In("guest_id", guestIds).All(&containers)
+	err := GetContainerManager().Query().In("guest_id", guestIds).Asc("created_at").All(&containers)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry pick of #24567 on release/4.0.0.

#24567: fix(region): order containers by created_at time