### PR TITLE
Automated cherry pick of #24580: fix(host): get pod status by primary container status

### DIFF
--- a/pkg/hostman/guestman/pod_helper.go
+++ b/pkg/hostman/guestman/pod_helper.go
@@ -238,11 +238,11 @@ func (t *localPodRestartTask) Dump() string {
 }
 
 func GetPodStatusByContainerStatus(status string, cStatus string, isPrimary bool) string {
-	if cStatus == computeapi.CONTAINER_STATUS_CRASH_LOOP_BACK_OFF {
+	if cStatus == computeapi.CONTAINER_STATUS_CRASH_LOOP_BACK_OFF && isPrimary {
 		status = computeapi.POD_STATUS_CRASH_LOOP_BACK_OFF
 	}
 	if cStatus == computeapi.CONTAINER_STATUS_EXITED && status != computeapi.VM_READY {
-		status = computeapi.POD_STATUS_CONTAINER_EXITED
+		// status = computeapi.POD_STATUS_CONTAINER_EXITED
 		if isPrimary {
 			status = computeapi.VM_READY
 		}


### PR DESCRIPTION
Cherry pick of #24580 on release/4.0.2.

#24580: fix(host): get pod status by primary container status