### PR TITLE
fix: add customer usable filters that filter noaddr networks

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -4097,3 +4097,33 @@ func (net SNetwork) HasIPv4Addr() bool {
 func (net SNetwork) HasIPv6Addr() bool {
 	return len(net.GuestIp6Start) > 0 && len(net.GuestIp6End) > 0
 }
+
+func (manager *SNetworkManager) CustomizeFilterList(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*db.CustomizeListFilters, error) {
+	filters := db.NewCustomizeListFilters()
+
+	if query.Contains("usable") {
+		isUsable := jsonutils.QueryBoolean(query, "usable", false)
+		addrCountFilter := func(obj jsonutils.JSONObject) (bool, error) {
+			portsStats := struct {
+				PortsUsed  int
+				Ports6Used int
+				Ports      int
+				Ports6     int
+			}{}
+			err := obj.Unmarshal(&portsStats)
+			if err != nil {
+				return false, err
+			}
+			if portsStats.PortsUsed < portsStats.Ports || portsStats.Ports6Used < portsStats.Ports6 {
+				return true, nil
+			}
+			return false, nil
+		}
+
+		if isUsable {
+			filters.Append(addrCountFilter)
+		}
+	}
+
+	return filters, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add customer usable filters that filter noaddr networks

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/4.0

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 