### PR TITLE
Automated cherry pick of #24579: fix(host): use findmnt instead of df to detect local mount point

### DIFF
--- a/pkg/hostman/storageman/storagehandler/storagehandler.go
+++ b/pkg/hostman/storageman/storagehandler/storagehandler.go
@@ -98,8 +98,7 @@ func storageIsLocalMountPoint(ctx context.Context, w http.ResponseWriter, r *htt
 		return
 	}
 	fs, err := procutils.NewRemoteCommandAsFarAsPossible(
-		"sh", "-c",
-		fmt.Sprintf("df -T %s | awk 'NR==2{print $2}'", mountPoint),
+		"findmnt", "-n", "-o", "FSTYPE", "--target", mountPoint,
 	).Output()
 	if err != nil {
 		log.Errorf("failed get source of mountpoint %s: %s", mountPoint, err)


### PR DESCRIPTION
Cherry pick of #24579 on release/3.11.

#24579: fix(host): use findmnt instead of df to detect local mount point