### PR TITLE
fix(monitor): update silent_period when channel is empty

### DIFF
--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -1322,6 +1322,10 @@ func (alert *SCommonAlert) PostUpdate(
 			log.Errorf("update notification error: %v", err)
 		}
 		alert.SetChannel(ctx, updateInput.Channel)
+	} else if len(updateInput.SilentPeriod) != 0 {
+		if err := alert.updateNotificationSilentPeriod(updateInput.SilentPeriod); err != nil {
+			log.Errorf("update notification silent_period error: %v", err)
+		}
 	}
 	if _, err := data.GetString("scope"); err == nil {
 		_, err = alert.PerformSetScope(ctx, userCred, query, data)
@@ -1713,6 +1717,27 @@ func (alert *SCommonAlert) GetSilentPeriod() (int64, error) {
 		}
 	}
 	return 0, nil
+}
+
+func (alert *SCommonAlert) updateNotificationSilentPeriod(silentPeriod string) error {
+	duration, _ := time.ParseDuration(silentPeriod)
+	frequency := int64(duration / time.Second)
+	notis, err := alert.GetNotifications()
+	if err != nil {
+		return errors.Wrap(err, "GetNotifications")
+	}
+	for _, n := range notis {
+		noti, _ := n.GetNotification()
+		if noti != nil {
+			if _, err := db.Update(noti, func() error {
+				noti.Frequency = frequency
+				return nil
+			}); err != nil {
+				return errors.Wrapf(err, "update notification %s frequency", noti.GetId())
+			}
+		}
+	}
+	return nil
 }
 
 func (alert *SCommonAlert) GetAlertRules(silentPeriod int64) ([]*monitor.AlertRecordRule, error) {


### PR DESCRIPTION
silent_period is stored as Frequency on the notification, not on the alert itself. PostUpdate only called UpdateNotification (which recreates notifications with the new silent_period) when Channel was non-empty. When channel was an empty array, the silent_period update was silently skipped. Add an else-if branch to directly update the existing notifications' Frequency when silent_period changes but channel is empty.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0
/area monitor