### PR TITLE
Add LLM service configuration sample

### DIFF
--- a/build/llm/root/etc/yunion/llm.conf.sample
+++ b/build/llm/root/etc/yunion/llm.conf.sample
@@ -1,0 +1,12 @@
+region = 'LocalTest'
+port = 9300
+auth_uri = 'http://10.16.22.51:35357/v3'
+admin_user = 'llmadmin'
+admin_password = 'password0'
+admin_tenant_name = 'system'
+sql_connection = 'mysql+pymysql://yunionllm:password0@10.16.22.51:3306/yunionllm?charset=utf8'
+
+auto_sync_table = True
+
+llm_working_directory = '/opt/cloud/workspace/llm/'
+mcp_server_url = 'http://default-mcp-server:30876'

--- a/build/llm/vars
+++ b/build/llm/vars
@@ -1,0 +1,1 @@
+DESCRIPTION="Yunion LLM Service"


### PR DESCRIPTION
## What does this PR do?

Was missing the llm.conf.sample file for the LLM service. Added it with all the necessary config options for auth, database, and MCP server setup. Also added a vars file with the service description.

## How was this PR tested?
- [x] Smoke testing
- [ ] Unit test

Confirmed the config file syntax is valid and all the necessary parameters are documented.

## Which issue(s) does this PR fix?

Fixes #24656

## Backport branch (if needed):

N/A