### PR TITLE
fix: add version etc. aux handlers to mcp-server

### DIFF
--- a/cmd/climc/shell/misc/version.go
+++ b/cmd/climc/shell/misc/version.go
@@ -16,6 +16,8 @@ package misc
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"yunion.io/x/cloudmux/pkg/cloudprovider"
 	"yunion.io/x/jsonutils"
@@ -29,6 +31,20 @@ import (
 	modules "yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/modules/identity"
 )
+
+var (
+	noValidEndpointsForServiceInRegionRegex = regexp.MustCompile(`no valid \w+ endpoints`)
+)
+
+func isSkippableVersionErr(err error) bool {
+	cause := errors.Cause(err)
+	if cause == cloudprovider.ErrNotFound || cause == errors.ErrConnectRefused {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connect: connection refused") ||
+		strings.Contains(msg, "connection refused") || noValidEndpointsForServiceInRegionRegex.MatchString(msg)
+}
 
 func init() {
 	type VersionOptions struct {
@@ -104,7 +120,7 @@ func init() {
 			}
 			ver, err := modules.GetVersion(s, serviceType)
 			if err != nil {
-				if errors.Cause(err) == cloudprovider.ErrNotFound || errors.Cause(err) == errors.ErrConnectRefused {
+				if isSkippableVersionErr(err) {
 					continue
 				}
 				vers[serviceType] = err.Error()

--- a/pkg/mcclient/modulebase/misc.go
+++ b/pkg/mcclient/modulebase/misc.go
@@ -15,9 +15,11 @@
 package modulebase
 
 import (
+	"io"
 	"io/ioutil"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/printutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -27,12 +29,12 @@ func GetVersion(s *mcclient.ClientSession, serviceType string) (string, error) {
 	man := NewBaseManager(serviceType, "", "", nil, nil)
 	resp, err := man.rawBaseUrlRequest(s, "GET", "/version", nil, nil)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "man.rawBaseUrlRequest")
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "io.ReadAll")
 	}
 	return string(body), nil
 }

--- a/pkg/mcp-server/server/server.go
+++ b/pkg/mcp-server/server/server.go
@@ -27,6 +27,7 @@ import (
 	"yunion.io/x/pkg/appctx"
 
 	api "yunion.io/x/onecloud/pkg/apis/identity"
+	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/mcp-server/adapters"
 	"yunion.io/x/onecloud/pkg/mcp-server/options"
@@ -197,10 +198,30 @@ func (s *CloudpodsMCPServer) Start() error {
 		return ctx
 	}
 
+	mux := http.NewServeMux()
+
 	sseServer := server.NewSSEServer(
 		s.mcpServer,
 		server.WithSSEContextFunc(contextFunc),
+		server.WithHTTPServer(&http.Server{Handler: mux}),
 	)
+	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
+		appsrv.VersionHandler(context.Background(), w, r)
+	})
+	mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
+		appsrv.StatisticHandler(context.Background(), w, r)
+	})
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		appsrv.PingHandler(context.Background(), w, r)
+	})
+	mux.HandleFunc("/worker_stats", func(w http.ResponseWriter, r *http.Request) {
+		appsrv.WorkerStatsHandler(context.Background(), w, r)
+	})
+	mux.HandleFunc("/process_stats", func(w http.ResponseWriter, r *http.Request) {
+		appsrv.ProcessStatsHandler(context.Background(), w, r)
+	})
+	mux.Handle(sseServer.CompleteSsePath(), sseServer.SSEHandler())
+	mux.Handle(sseServer.CompleteMessagePath(), sseServer.MessageHandler())
 
 	if err := sseServer.Start(fmt.Sprintf("%s:%d", options.Options.Address, options.Options.Port)); err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add version etc. aux handlers to mcp-server

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/4.0

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @ioito 