### PR TITLE
fix(host,llm): fix pod shm mount path return and llm restart memory config

### DIFF
--- a/pkg/hostman/guestman/pod.go
+++ b/pkg/hostman/guestman/pod.go
@@ -2924,7 +2924,7 @@ func (s *sPodGuestInstance) mountDevShm(input *hostapi.ContainerCreateInput, mb 
 	}
 	if err := procutils.NewRemoteCommandAsFarAsPossible("mountpoint", shmPath).Run(); err == nil {
 		log.Warningf("mountpoint %s is already mounted", shmPath)
-		return "", nil
+		return shmPath, nil
 	}
 	out, err := procutils.NewRemoteCommandAsFarAsPossible("mount", "-t", "tmpfs", "-o", fmt.Sprintf("size=%dM", mb), "tmpfs", shmPath).Output()
 	if err != nil {

--- a/pkg/llm/tasks/llm/llm_restart_task.go
+++ b/pkg/llm/tasks/llm/llm_restart_task.go
@@ -164,12 +164,12 @@ func (task *LLMRestartTask) OnServerStopComplete(ctx context.Context, obj db.ISt
 		}
 	}
 
-	if sku.Cpu != server.VcpuCount || sku.Memory+1 != server.VmemSize {
+	if sku.Cpu != server.VcpuCount || sku.Memory != server.VmemSize {
 		// need to change config
 		s := auth.GetSession(ctx, task.UserCred, "")
 		params := computeapi.ServerChangeConfigInput{}
 		params.VcpuCount = &sku.Cpu
-		params.VmemSize = fmt.Sprintf("%dM", sku.Memory+1)
+		params.VmemSize = fmt.Sprintf("%dM", sku.Memory)
 		_, err := compute.Servers.PerformAction(s, llm.CmpId, "change-config", jsonutils.Marshal(params))
 		if err != nil {
 			task.taskFailed(ctx, llm, errors.Wrap(err, "change config").Error())


### PR DESCRIPTION
- Return shmPath instead of empty string when mountpoint is already mounted, so callers get the correct path
- Remove incorrect +1 offset in memory comparison and size formatting during LLM restart config change

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0