### PR TITLE
Automated cherry pick of #24745: fix: init ifb kernel module

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -534,6 +534,11 @@ func (h *SHostInfo) prepareEnv() error {
 		}
 	}
 
+	_, err = procutils.NewRemoteCommandAsFarAsPossible("modprobe", "ifb", "numifbs=0").Output()
+	if err != nil {
+		return errors.Wrap(err, "Failed to activate ifb device")
+	}
+
 	output, err := procutils.NewRemoteCommandAsFarAsPossible("modprobe", "vhost_net").Output()
 	if err != nil {
 		log.Warningf("modprobe vhost_net error: %s", output)


### PR DESCRIPTION
Cherry pick of #24745 on master.

#24745: fix: init ifb kernel module