### PR TITLE
fix(monitor): normalize resource-metrics alert_state

### DIFF
--- a/pkg/monitor/models/unifiedmonitor.go
+++ b/pkg/monitor/models/unifiedmonitor.go
@@ -801,7 +801,11 @@ func (self *SUnifiedMonitorManager) PerformResourceMetrics(
 	} else {
 		for _, mr := range monResources {
 			if rv, ok := result[mr.ResId]; ok {
-				rv.AlertState = mr.AlertState
+				state := mr.AlertState
+				if state == monitor.MONITOR_RESOURCE_ALERT_STATUS_ATTACH || state == monitor.MONITOR_RESOURCE_ALERT_STATUS_INIT {
+					state = monitor.MONITOR_RESOURCE_ALERT_STATUS_INIT
+				}
+				rv.AlertState = state
 			}
 		}
 	}


### PR DESCRIPTION
Treat attach and init as init in PerformResourceMetrics output.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0
/area monitor