### PR TITLE
Automated cherry pick of #24788: fix(host): remove -no-kvm args, -no-kvm argument was a synonym for se…

### DIFF
--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -34,7 +34,6 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/utils"
 
-	"yunion.io/x/onecloud/pkg/apis"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/hostman/guestman/desc"
 	"yunion.io/x/onecloud/pkg/hostman/guestman/qemu"
@@ -485,10 +484,6 @@ func (s *SKVMGuestInstance) generateStartScript(data *jsonutils.JSONDict) (strin
 	cmd += "QEMU_CMD=$DEFAULT_QEMU_CMD\n"
 	if s.IsKvmSupport() && !options.HostOptions.DisableKVM {
 		cmd += "QEMU_CMD_KVM_ARG=-enable-kvm\n"
-	} else if utils.IsInStringArray(s.manager.host.GetCpuArchitecture(), apis.ARCH_X86) {
-		// -no-kvm仅x86适用，且将在qemu 5.2之后移除
-		// https://gitlab.com/qemu-project/qemu/-/blob/master/docs/about/removed-features.rst
-		cmd += "QEMU_CMD_KVM_ARG=-no-kvm\n"
 	} else {
 		cmd += "QEMU_CMD_KVM_ARG=\n"
 	}


### PR DESCRIPTION
Cherry pick of #24788 on release/4.0.3.

#24788: fix(host): remove -no-kvm args, -no-kvm argument was a synonym for se…