### PR TITLE
feat(climc): add generic feature-config command

### DIFF
--- a/cmd/climc/shell/misc/feature.go
+++ b/cmd/climc/shell/misc/feature.go
@@ -95,6 +95,7 @@ func init() {
 		"default",
 		"k8s",
 		"pod",
+		"ai",
 		"monitor",
 		"bingocloud",
 		"ksyun",
@@ -120,77 +121,89 @@ func init() {
 		Switch string `help:"Config feature on or off" choices:"on|off"`
 	}
 
+	configFeature := func(s *mcclient.ClientSession, name string, enable bool) error {
+		items, err := yunionconf.Parameters.List(s, jsonutils.Marshal(map[string]string{
+			"name":  GlobalSettings,
+			"scope": "system"}))
+		if err != nil {
+			return errors.Wrapf(err, "get %s from yunionconf", GlobalSettings)
+		}
+
+		if len(items.Data) == 0 {
+			// create it if enabled
+			if enable {
+				value := []string{name}
+				if utils.IsInStringArray(name, storageFeatures) {
+					value = append(value, "storage")
+				}
+				input := map[string]interface{}{
+					"name":       GlobalSettings,
+					"service_id": YunionAgent,
+					"value":      NewGlobalSettingsValue(value, true),
+				}
+				params := jsonutils.Marshal(input)
+				if _, err := yunionconf.Parameters.Create(s, params); err != nil {
+					return errors.Errorf("create %s for feature %q", GlobalSettings, name)
+				}
+				return nil
+			} else {
+				return errors.Errorf("not found %s", GlobalSettings)
+			}
+		}
+
+		if len(items.Data) != 1 {
+			return errors.Errorf("found %d %q from yunionconf", len(items.Data), GlobalSettings)
+		}
+
+		// update it
+		ss := items.Data[0]
+		value, err := ss.Get("value")
+		if err != nil {
+			return errors.Wrap(err, "get value")
+		}
+		curConf := new(GlobalSettingsValue)
+		if err := value.Unmarshal(curConf); err != nil {
+			return errors.Wrapf(err, "unmarshal to GlobalSettingsValue: %s", value)
+		}
+		if !enable {
+			curConf.Switch(name, false)
+		} else {
+			curConf.Switch(name, true)
+			if utils.IsInStringArray(name, storageFeatures) {
+				curConf.Switch("storage", true)
+			}
+		}
+		id, err := ss.GetString("id")
+		if err != nil {
+			return errors.Errorf("get id from %s", ss)
+		}
+		ss.(*jsonutils.JSONDict).Set("value", jsonutils.Marshal(curConf))
+		obj, err := yunionconf.Parameters.Update(s, id, ss)
+		if err != nil {
+			return errors.Wrapf(err, "update %s(%s)", GlobalSettings, id)
+		}
+		printObject(obj)
+		return nil
+	}
+
 	featureR := func(name string) {
 		R(&FeatureCfgOpts{}, fmt.Sprintf("feature-config-%s", name), fmt.Sprintf("Set feature %s on or off", name), func(s *mcclient.ClientSession, args *FeatureCfgOpts) error {
-			enable := true
-			if args.Switch == "off" {
-				enable = false
-			}
-			items, err := yunionconf.Parameters.List(s, jsonutils.Marshal(map[string]string{
-				"name":  GlobalSettings,
-				"scope": "system"}))
-			if err != nil {
-				return errors.Wrapf(err, "get %s from yunionconf", GlobalSettings)
-			}
-
-			if len(items.Data) == 0 {
-				// create it if enabled
-				if enable {
-					value := []string{name}
-					if utils.IsInStringArray(name, storageFeatures) {
-						value = append(value, "storage")
-					}
-					input := map[string]interface{}{
-						"name":       GlobalSettings,
-						"service_id": YunionAgent,
-						"value":      NewGlobalSettingsValue(value, true),
-					}
-					params := jsonutils.Marshal(input)
-					if _, err := yunionconf.Parameters.Create(s, params); err != nil {
-						return errors.Errorf("create %s for feature %q", GlobalSettings, name)
-					}
-					return nil
-				} else {
-					return errors.Errorf("not found %s", GlobalSettings)
-				}
-			}
-
-			if len(items.Data) != 1 {
-				return errors.Errorf("found %d %q from yunionconf", len(items.Data), GlobalSettings)
-			}
-
-			// update it
-			ss := items.Data[0]
-			value, err := ss.Get("value")
-			if err != nil {
-				return errors.Wrap(err, "get value")
-			}
-			curConf := new(GlobalSettingsValue)
-			if err := value.Unmarshal(curConf); err != nil {
-				return errors.Wrapf(err, "unmarshal to GlobalSettingsValue: %s", value)
-			}
-			if !enable {
-				curConf.Switch(name, false)
-			} else {
-				curConf.Switch(name, true)
-				if utils.IsInStringArray(name, storageFeatures) {
-					curConf.Switch("storage", true)
-				}
-			}
-			id, err := ss.GetString("id")
-			if err != nil {
-				return errors.Errorf("get id from %s", ss)
-			}
-			ss.(*jsonutils.JSONDict).Set("value", jsonutils.Marshal(curConf))
-			obj, err := yunionconf.Parameters.Update(s, id, ss)
-			if err != nil {
-				return errors.Wrapf(err, "update %s(%s)", GlobalSettings, id)
-			}
-			printObject(obj)
-			return nil
+			return configFeature(s, name, args.Switch != "off")
 		})
 	}
 	for _, name := range features {
 		featureR(name)
 	}
+
+	type FeatureConfigOpts struct {
+		FEATURE string `help:"Feature name to config"`
+		SWITCH  string `help:"Config feature on or off" choices:"on|off"`
+		Force   bool   `help:"Skip checking whether feature is in the known list"`
+	}
+	R(&FeatureConfigOpts{}, "feature-config", "Set a feature on or off", func(s *mcclient.ClientSession, args *FeatureConfigOpts) error {
+		if !args.Force && !utils.IsInStringArray(args.FEATURE, features) {
+			return errors.Errorf("unknown feature %q, supported: %v (use --force to skip this check)", args.FEATURE, features)
+		}
+		return configFeature(s, args.FEATURE, args.SWITCH != "off")
+	})
 }


### PR DESCRIPTION
Add a generic `feature-config <feature> <on|off>` command alongside the existing per-feature `feature-config-<name>` commands. A `--force` flag skips the known-features validation so new features can be toggled without a code change. Also adds "ai" to the known feature list.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0.3
/area climc