### PR TITLE
Automated cherry pick of #24850: fix(host): remove cgroup root path check quotation marks

### DIFF
--- a/pkg/util/cgrouputils/manager.go
+++ b/pkg/util/cgrouputils/manager.go
@@ -92,7 +92,7 @@ func Init(ioScheduler string) error {
 	cgroupPath := ""
 	if fileutils2.Exists(CGROUP_PATH_SYSFS) {
 		cgroupPath = CGROUP_PATH_SYSFS
-	} else if fileutils2.Exists("CGROUP_PATH_ROOT") {
+	} else if fileutils2.Exists(CGROUP_PATH_ROOT) {
 		cgroupPath = CGROUP_PATH_ROOT
 	}
 	if cgroupPath == "" {


### PR DESCRIPTION
Cherry pick of #24850 on release/4.0.

#24850: fix(host): remove cgroup root path check quotation marks