### PR TITLE
fix: disable s3 direct download default

### DIFF
--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -56,7 +56,7 @@ type SImageOptions struct {
 	S3UploadPartSizeMb int64  `help:"s3 upload part size in MB, default to 50MB" default:"50"`
 	S3UploadParallel   int    `help:"s3 upload parallel count" default:"4"`
 
-	S3DirectDownload bool `help:"enable s3 direct download" default:"true"`
+	S3DirectDownload bool `help:"enable s3 direct download" default:"false"`
 
 	ImageStreamWorkerCount int `help:"Image stream worker count" default:"10"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: disable s3 direct download default

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/4.0

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 