### PR TITLE
Automated cherry pick of #24886: fix: disable s3 direct download default

### DIFF
--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -56,7 +56,7 @@ type SImageOptions struct {
 	S3UploadPartSizeMb int64  `help:"s3 upload part size in MB, default to 50MB" default:"50"`
 	S3UploadParallel   int    `help:"s3 upload parallel count" default:"4"`
 
-	S3DirectDownload bool `help:"enable s3 direct download" default:"true"`
+	S3DirectDownload bool `help:"enable s3 direct download" default:"false"`
 
 	ImageStreamWorkerCount int `help:"Image stream worker count" default:"10"`
 


### PR DESCRIPTION
Cherry pick of #24886 on release/4.0.3.

#24886: fix: disable s3 direct download default