### PR TITLE
fix(host): aggregate same-type container devices for env config

### DIFF
--- a/pkg/hostman/guestman/pod.go
+++ b/pkg/hostman/guestman/pod.go
@@ -2389,13 +2389,23 @@ func (s *sPodGuestInstance) getIsolatedDeviceExtraConfig(spec *hostapi.Container
 	if len(fDevs.EnvDevs) != 0 {
 		ctrCfg.Envs = append(ctrCfg.Envs, getEnvsFromDevices(fDevs.EnvDevs)...)
 	}
+	restDevsByType := map[string][]*hostapi.ContainerDevice{}
+	restDevTypeOrder := []string{}
 	for i := range fDevs.RestDevs {
 		dev := fDevs.RestDevs[i]
-		devMan, err := isolated_device.GetContainerDeviceManager(isolated_device.ContainerDeviceType(dev.IsolatedDevice.DeviceType))
-		if err != nil {
-			return errors.Wrapf(err, "GetContainerDeviceManager by type %q", dev.IsolatedDevice.DeviceType)
+		devType := dev.IsolatedDevice.DeviceType
+		if _, ok := restDevsByType[devType]; !ok {
+			restDevTypeOrder = append(restDevTypeOrder, devType)
 		}
-		envs, mounts := devMan.GetContainerExtraConfigures([]*hostapi.ContainerDevice{dev})
+		restDevsByType[devType] = append(restDevsByType[devType], dev)
+	}
+	for _, devType := range restDevTypeOrder {
+		devs := restDevsByType[devType]
+		devMan, err := isolated_device.GetContainerDeviceManager(isolated_device.ContainerDeviceType(devType))
+		if err != nil {
+			return errors.Wrapf(err, "GetContainerDeviceManager by type %q", devType)
+		}
+		envs, mounts := devMan.GetContainerExtraConfigures(devs)
 		if len(envs) > 0 {
 			ctrCfg.Envs = append(ctrCfg.Envs, envs...)
 		}


### PR DESCRIPTION
When multiple NVIDIA GPUs were attached to a container, each device was passed individually to GetContainerExtraConfigures, producing one NVIDIA_VISIBLE_DEVICES env per GPU. Duplicate env keys are collapsed by the runtime to the last value, so the container only saw one GPU even though the spec listed all of them.

Group RestDevs by DeviceType and invoke GetContainerExtraConfigures once per type so all GPU UUIDs are joined into a single NVIDIA_VISIBLE_DEVICES value.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area host
- 4.0.3