### PR TITLE
Automated cherry pick of #24893: fix(region): skip useless addition network wire create

### DIFF
--- a/pkg/compute/models/network_additional_wires.go
+++ b/pkg/compute/models/network_additional_wires.go
@@ -191,9 +191,11 @@ func (net *SNetwork) syncAdditionalWires(ctx context.Context, wireIds []string) 
 			}
 			markedPtr = &marked
 		}
-		err := NetworkAdditionalWireManager.newRecord(ctx, net.Id, w.Id, &connected, markedPtr)
-		if err != nil {
-			return errors.Wrap(err, "NetworkAdditionalWireManager.newRecord")
+		if connected || (markedPtr != nil && *markedPtr) {
+			err := NetworkAdditionalWireManager.newRecord(ctx, net.Id, w.Id, &connected, markedPtr)
+			if err != nil {
+				return errors.Wrap(err, "NetworkAdditionalWireManager.newRecord")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Cherry pick of #24893 on release/4.0.

#24893: fix(region): skip useless addition network wire create