### PR TITLE
fix: throttle image cache progress callback to avoid S3 download bottleneck

### DIFF
--- a/pkg/hostman/storageman/imagecachemanager_local.go
+++ b/pkg/hostman/storageman/imagecachemanager_local.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"sync"
+	"time"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -113,9 +114,11 @@ func (c *SLocalImageCacheManager) AcquireImage(ctx context.Context, input api.Ca
 		c.cachedImages.Store(input.ImageId, imgObj)
 	}
 	if callback == nil && len(input.ServerId) > 0 {
+		var lastReport time.Time
 		callback = func(progress, progressMbps float64, totalSizeMb int64) {
-			if len(input.ServerId) > 0 {
-				hostutils.UpdateServerProgress(ctx, input.ServerId, progress, progressMbps)
+			if len(input.ServerId) > 0 && time.Since(lastReport) > 5*time.Second {
+				lastReport = time.Now()
+				go hostutils.UpdateServerProgress(ctx, input.ServerId, progress, progressMbps)
 			}
 		}
 	}


### PR DESCRIPTION
## 问题

使用 S3/MinIO 后端时，从 MinIO 缓存镜像的速度被限制在约 0.65 Mbps，而实际网络带宽可达 50+ MB/s。

关联 issue：#24897

## 根本原因

`AcquireImage` 中设置的 progress callback 会被 `StreamPipe2`（4KB 读缓冲）在**每次读取 4KB 数据后同步调用一次**。callback 内部调用 `UpdateServerProgress`，这是一个**阻塞的 HTTP PUT 请求**，每次耗时约 50ms。

```
imagecachemanager_local.go → s3remotefile.go
  → DownloadObjectParallelWithProgress
    → StreamPipe2 (4KB buffer, calls callback every chunk)
      → UpdateServerProgress (blocking HTTP PUT, ~50ms)
```

吞吐量被限制为：`4096 bytes ÷ 50ms ≈ 80 KB/s ≈ 0.65 Mbps`

## 修复方案

对 callback 加节流（最多每 5 秒触发一次）并改为异步调用，与 v3.11.x 中 `pb.NewProxyReader` 的 1 秒 ticker + goroutine 行为保持一致：

```go
var lastReport time.Time
callback = func(progress, progressMbps float64, totalSizeMb int64) {
    if len(input.ServerId) > 0 && time.Since(lastReport) > 5*time.Second {
        lastReport = time.Now()
        go hostutils.UpdateServerProgress(ctx, input.ServerId, progress, progressMbps)
    }
}
```

## 影响范围

所有使用 MinIO S3 后端 + local 存储的计算节点，在创建 VM 触发镜像缓存时均受影响（v4.0.x 全系列）。