### PR TITLE
Automated cherry pick of #24898: fix: throttle image cache progress callback to avoid S3 download bottleneck

### DIFF
--- a/pkg/hostman/storageman/imagecachemanager_local.go
+++ b/pkg/hostman/storageman/imagecachemanager_local.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"sync"
+	"time"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -113,9 +114,11 @@ func (c *SLocalImageCacheManager) AcquireImage(ctx context.Context, input api.Ca
 		c.cachedImages.Store(input.ImageId, imgObj)
 	}
 	if callback == nil && len(input.ServerId) > 0 {
+		var lastReport time.Time
 		callback = func(progress, progressMbps float64, totalSizeMb int64) {
-			if len(input.ServerId) > 0 {
-				hostutils.UpdateServerProgress(ctx, input.ServerId, progress, progressMbps)
+			if len(input.ServerId) > 0 && time.Since(lastReport) > 5*time.Second {
+				lastReport = time.Now()
+				go hostutils.UpdateServerProgress(ctx, input.ServerId, progress, progressMbps)
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick of #24898 on release/4.0.0.

#24898: fix: throttle image cache progress callback to avoid S3 download bottleneck