### PR TITLE
Automated cherry pick of #24904: fix: upgrade go 1.26

### DIFF
--- a/.github/workflows/ci-pr-build-test.yml
+++ b/.github/workflows/ci-pr-build-test.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
 
     - name: Install check tools
       shell: bash

--- a/.github/workflows/docker_apigateway.yml
+++ b/.github/workflows/docker_apigateway.yml
@@ -22,7 +22,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_climc.yml
+++ b/.github/workflows/docker_climc.yml
@@ -20,7 +20,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_cloudmon.yml
+++ b/.github/workflows/docker_cloudmon.yml
@@ -21,7 +21,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_esxi_agent.yml
+++ b/.github/workflows/docker_esxi_agent.yml
@@ -19,7 +19,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_glance.yml
+++ b/.github/workflows/docker_glance.yml
@@ -23,7 +23,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_host.yml
+++ b/.github/workflows/docker_host.yml
@@ -19,7 +19,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_keystone.yml
+++ b/.github/workflows/docker_keystone.yml
@@ -23,7 +23,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_logger.yml
+++ b/.github/workflows/docker_logger.yml
@@ -23,7 +23,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_notify.yml
+++ b/.github/workflows/docker_notify.yml
@@ -23,7 +23,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_region.yml
+++ b/.github/workflows/docker_region.yml
@@ -24,7 +24,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_scheduler.yml
+++ b/.github/workflows/docker_scheduler.yml
@@ -20,7 +20,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker_webconsole.yml
+++ b/.github/workflows/docker_webconsole.yml
@@ -23,7 +23,7 @@ jobs:
         
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/Makefile.common.mk
+++ b/Makefile.common.mk
@@ -8,7 +8,7 @@ endif
 ModBaseName:=$(notdir $(ModName))
 
 DockerImageRegistry?=registry.cn-beijing.aliyuncs.com
-DockerImageAlpineBuild?=$(DockerImageRegistry)/yunionio/alpine-build:3.22.2-go-1.24.9-0
+DockerImageAlpineBuild?=$(DockerImageRegistry)/yunionio/alpine-build:3.23-go-1.26.3-0
 
 EnvIf=$(if $($(1)),$(1)=$($(1)))
 


### PR DESCRIPTION
Cherry pick of #24904 on release/4.0.

#24904: fix: upgrade go 1.26