### PR TITLE
feat(monitor): add ResourceMetricsDefaultInterval option

### DIFF
--- a/pkg/monitor/models/unifiedmonitor.go
+++ b/pkg/monitor/models/unifiedmonitor.go
@@ -571,7 +571,7 @@ func (self *SUnifiedMonitorManager) GetPropertySimpleQuery(ctx context.Context, 
 		where.Equal(k, v)
 	}
 	if len(input.Interval) == 0 {
-		input.Interval = "5m"
+		input.Interval = options.Options.ResourceMetricsDefaultInterval
 	}
 	_, err := time.ParseDuration(input.Interval)
 	if err != nil {
@@ -733,7 +733,7 @@ func (self *SUnifiedMonitorManager) getResourceMetrics(
 		input.StartTime = input.EndTime.Add(-1 * time.Hour)
 	}
 	if len(input.Interval) == 0 {
-		input.Interval = "5m"
+		input.Interval = options.Options.ResourceMetricsDefaultInterval
 	}
 
 	tagKey := drv.GetTagKey()

--- a/pkg/monitor/options/options.go
+++ b/pkg/monitor/options/options.go
@@ -37,6 +37,8 @@ type AlerterOptions struct {
 
 	WorkerCheckInterval int `default:"180"`
 
+	ResourceMetricsDefaultInterval string `default:"5m" help:"default interval for resource metrics query"`
+
 	AutoMigrationMustPair      bool `default:"false" help:"result of auto migration source guests and target hosts must be paired"`
 	DisableQuerySignatureCheck bool `default:"true" help:"disable query signature check"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area monitor
- 4.0.3