### PR TITLE
fix(ansibleserver): allow CreatorMark to be nullable

### DIFF
--- a/pkg/ansibleserver/models/ansibleplaybooks_v2.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks_v2.go
@@ -49,7 +49,7 @@ type SAnsiblePlaybookV2 struct {
 	StartTime    time.Time `list:"user"`
 	EndTime      time.Time `list:"user"`
 
-	CreatorMark string `length:"32" nullable:"false" create:"optional" get:"user"`
+	CreatorMark string `length:"32" nullable:"true" create:"optional" get:"user"`
 }
 
 type SAnsiblePlaybookV2Manager struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0
/area ansibleserver