### PR TITLE
Automated cherry pick of #24917: fix(ansibleserver): allow CreatorMark to be nullable

### DIFF
--- a/pkg/ansibleserver/models/ansibleplaybooks_v2.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks_v2.go
@@ -49,7 +49,7 @@ type SAnsiblePlaybookV2 struct {
 	StartTime    time.Time `list:"user"`
 	EndTime      time.Time `list:"user"`
 
-	CreatorMark string `length:"32" nullable:"false" create:"optional" get:"user"`
+	CreatorMark string `length:"32" nullable:"true" create:"optional" get:"user"`
 }
 
 type SAnsiblePlaybookV2Manager struct {


### PR DESCRIPTION
Cherry pick of #24917 on master.

#24917: fix(ansibleserver): allow CreatorMark to be nullable