### PR TITLE
Automated cherry pick of #24925: fix(host): check cluster is valid before do qemuimg convert

### DIFF
--- a/pkg/util/qemuimg/qemuimg.go
+++ b/pkg/util/qemuimg/qemuimg.go
@@ -507,12 +507,22 @@ func convertEncrypt(srcInfo, destInfo SImageInfo, compact bool, workerOpions []s
 	return nil
 }
 
+func isValidClusterSize(size int) bool {
+	if size < 512 || size > 2*1024*1024 {
+		return false
+	}
+	return true
+}
+
 func (img *SQemuImage) doConvert(targetPath string, format qemuimgfmt.TImageFormat, compact bool, password string, encryptFormat TEncryptFormat, encryptAlg seclib2.TSymEncAlg) error {
 	if !img.IsValid() {
 		return fmt.Errorf("self is not valid")
 	}
 	destClusterSize := img.ClusterSize
 	if compact {
+		destClusterSize = DefaultQcow2ClusterSize
+	}
+	if format == qemuimgfmt.QCOW2 && !isValidClusterSize(destClusterSize) {
 		destClusterSize = DefaultQcow2ClusterSize
 	}
 	return Convert(SImageInfo{


### PR DESCRIPTION
Cherry pick of #24925 on release/4.0.

#24925: fix(host): check cluster is valid before do qemuimg convert