### PR TITLE
fix(llm): 更新 model catalog 默认 URL 与 webtop 镜像同步

### DIFF
--- a/pkg/llm/options/option.go
+++ b/pkg/llm/options/option.go
@@ -39,7 +39,7 @@ type LLMOptions struct {
 	// LLM model catalog (browsable curated entries). Value can be either an
 	// http(s) URL or a local file path; sources without an http:// or https://
 	// prefix are treated as local files.
-	ModelCatalogURL                  string `help:"URL of the LLM model catalog YAML; values without http(s):// prefix are treated as local file paths" default:"https://www.cloudpods.org/llm-catalog.yaml"`
+	ModelCatalogURL                  string `help:"URL of the LLM model catalog YAML; values without http(s):// prefix are treated as local file paths" default:"https://www.cloudpods.org/model-catalog.yaml"`
 	LLMCatalogRefreshIntervalMinutes int    `help:"Catalog refresh interval in minutes; 0 disables periodic refresh" default:"60"`
 
 	// Server-side proxy for outbound HuggingFace / ModelScope calls (used by

--- a/scripts/sync_llm_images.sh
+++ b/scripts/sync_llm_images.sh
@@ -35,8 +35,18 @@ IMAGES=(
   # "coollabsio/openclaw:latest"
   # "coollabsio/openclaw-browser:latest"
   # ghcr.io/coollabsio/openclaw-base:latest
-  # lscr.io/linuxserver/webtop:ubuntu-xfce
-  registry.cn-beijing.aliyuncs.com/zexi/openclaw:v2026.3.12-20260326.2
+  # registry.cn-beijing.aliyuncs.com/zexi/openclaw:v2026.3.12-20260326.2
+  # lscr.io/linuxserver/bambustudio:02.07.00
+  # lscr.io/linuxserver/weixin:180e26d4-ls27
+  # lscr.io/linuxserver/wps-office:11.1.0.11723-2-ls171
+  # lscr.io/linuxserver/vscode:1.122.1-ls9
+  # lscr.io/linuxserver/chrome:149.0.7827.53-1-ls97
+  # lscr.io/linuxserver/rustdesk:1.4.7-ls111
+  # lscr.io/linuxserver/steam:b6afafe3-ls25
+  # lscr.io/linuxserver/webtop:ubuntu-xfce-version-be8fdec1
+  # lscr.io/linuxserver/webtop:ubuntu-kde-version-386ae438
+  # lscr.io/linuxserver/webtop:fedora-kde-version-06d34634
+  lscr.io/linuxserver/webtop:fedora-xfce-version-a3d1e044
 )
 
 for image in "${IMAGES[@]}"; do


### PR DESCRIPTION
将 ModelCatalogURL 默认路径改为 model-catalog.yaml；
sync_llm_images 改为同步 fedora-xfce webtop 并注释其它候选镜像。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0