### PR TITLE
feat(llm): add community images catalog API

### DIFF
--- a/pkg/apis/llm/llm_images_catalog.go
+++ b/pkg/apis/llm/llm_images_catalog.go
@@ -1,0 +1,59 @@
+package llm
+
+// LLMImagesCatalogItem is one entry in llmimages.yaml — either a single
+// community image or a bundle (e.g. dify with import_kind: bundle).
+type LLMImagesCatalogItem struct {
+	// Resource id for mcclient list/show. Populated at load time.
+	Id string `json:"id" yaml:"-"`
+
+	// Single-image fields
+	Image       string                 `json:"image,omitempty" yaml:"image"`
+	LLMType     string                 `json:"llm_type" yaml:"llm_type"`
+	Description string                 `json:"description,omitempty" yaml:"description"`
+	AppName     string                 `json:"app_name,omitempty" yaml:"app_name"`
+	Desktop     *LLMImageDesktopConfig `json:"desktop,omitempty" yaml:"desktop"`
+
+	// Bundle fields
+	Name       string                        `json:"name,omitempty" yaml:"name"`
+	ImportKind string                        `json:"import_kind,omitempty" yaml:"import_kind"`
+	Images     []LLMImagesCatalogBundleImage `json:"images,omitempty" yaml:"images"`
+	Sku        *LLMImagesCatalogSku          `json:"sku,omitempty" yaml:"sku"`
+}
+
+// LLMImagesCatalogBundleImage is one component image inside a bundle entry.
+type LLMImagesCatalogBundleImage struct {
+	Role         string `json:"role" yaml:"role"`
+	GenerateName string `json:"generate_name" yaml:"generate_name"`
+	Image        string `json:"image" yaml:"image"`
+}
+
+// LLMImagesCatalogSku holds optional default SKU spec embedded in yaml.
+type LLMImagesCatalogSku struct {
+	GenerateName string       `json:"generate_name,omitempty" yaml:"generate_name"`
+	CPU          int          `json:"cpu,omitempty" yaml:"cpu"`
+	Memory       int          `json:"memory,omitempty" yaml:"memory"`
+	VolumeSizeMb int          `json:"volume_size_mb,omitempty" yaml:"volume_size_mb"`
+	Bandwidth    int          `json:"bandwidth,omitempty" yaml:"bandwidth"`
+	PortMappings PortMappings `json:"port_mappings,omitempty" yaml:"port_mappings"`
+}
+
+// LLMImagesCatalogListInput is the query filter for GET /llm_images_catalogs.
+type LLMImagesCatalogListInput struct {
+	LLMType string `json:"llm_type"`
+	Search  string `json:"search"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+}
+
+// LLMImagesCatalogListOutput mirrors the standard list-response envelope.
+type LLMImagesCatalogListOutput struct {
+	LLMImagesCatalogs []LLMImagesCatalogItem `json:"llm_images_catalogs"`
+	Total             int                    `json:"total"`
+	Limit             int                    `json:"limit"`
+	Offset            int                    `json:"offset"`
+}
+
+// LLMImagesCatalogShowOutput is the single-item response wrapper.
+type LLMImagesCatalogShowOutput struct {
+	LLMImagesCatalog LLMImagesCatalogItem `json:"llm_images_catalog"`
+}

--- a/pkg/apis/llm/sku.go
+++ b/pkg/apis/llm/sku.go
@@ -60,11 +60,11 @@ func (pm PortMappingEnvs) IsZero() bool {
 }
 
 type PortMapping struct {
-	Protocol        string                           `json:"protocol"`
-	ContainerPort   int                              `json:"container_port"`
-	RemoteIps       []string                         `json:"remote_ips"`
-	FirstPortOffset *int                             `json:"first_port_offset"`
-	Envs            []computeapi.GuestPortMappingEnv `json:"envs"`
+	Protocol        string                           `json:"protocol" yaml:"protocol"`
+	ContainerPort   int                              `json:"container_port" yaml:"container_port"`
+	RemoteIps       []string                         `json:"remote_ips" yaml:"remote_ips,omitempty"`
+	FirstPortOffset *int                             `json:"first_port_offset" yaml:"first_port_offset,omitempty"`
+	Envs            []computeapi.GuestPortMappingEnv `json:"envs" yaml:"envs,omitempty"`
 }
 
 type PortMappings []PortMapping

--- a/pkg/llm/models/llm_images_catalog.go
+++ b/pkg/llm/models/llm_images_catalog.go
@@ -1,0 +1,252 @@
+package models
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v2"
+
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+
+	api "yunion.io/x/onecloud/pkg/apis/llm"
+)
+
+const (
+	DefaultLLMImagesCatalogURL = "https://www.cloudpods.org/llmimages.yaml"
+	imagesCatalogFetchTimeout  = 30 * time.Second
+	bundleImportKind           = "bundle"
+)
+
+// SLLMImagesCatalogManager caches community image catalog entries loaded from
+// a configurable YAML source (http(s) URL or local file path).
+type SLLMImagesCatalogManager struct {
+	mu          sync.RWMutex
+	items       []api.LLMImagesCatalogItem
+	itemsById   map[string]*api.LLMImagesCatalogItem
+	lastFetched time.Time
+	lastErr     error
+	source      string
+}
+
+var llmImagesCatalogManager *SLLMImagesCatalogManager
+var llmImagesCatalogManagerOnce sync.Once
+
+// GetLLMImagesCatalogManager returns the singleton catalog manager.
+func GetLLMImagesCatalogManager() *SLLMImagesCatalogManager {
+	llmImagesCatalogManagerOnce.Do(func() {
+		llmImagesCatalogManager = &SLLMImagesCatalogManager{
+			itemsById: map[string]*api.LLMImagesCatalogItem{},
+		}
+	})
+	return llmImagesCatalogManager
+}
+
+// Start kicks off the initial load and optional periodic refresh.
+func (m *SLLMImagesCatalogManager) Start(ctx context.Context, source string, interval time.Duration) {
+	if source == "" {
+		source = DefaultLLMImagesCatalogURL
+	}
+	m.mu.Lock()
+	m.source = source
+	m.mu.Unlock()
+
+	go func() {
+		if err := m.Refresh(ctx); err != nil {
+			log.Warningf("LLMImagesCatalog: initial load from %s failed: %s", source, err)
+		}
+	}()
+
+	if interval <= 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := m.Refresh(ctx); err != nil {
+					log.Warningf("LLMImagesCatalog: periodic refresh failed: %s", err)
+				}
+			}
+		}
+	}()
+}
+
+// Refresh re-loads the configured source and replaces the in-memory cache.
+// On error the previous cache is preserved.
+func (m *SLLMImagesCatalogManager) Refresh(ctx context.Context) error {
+	m.mu.RLock()
+	source := m.source
+	m.mu.RUnlock()
+	if source == "" {
+		source = DefaultLLMImagesCatalogURL
+	}
+
+	body, err := m.loadSource(ctx, source)
+	if err != nil {
+		m.recordErr(err)
+		return err
+	}
+
+	var rawItems []api.LLMImagesCatalogItem
+	if err := yaml.Unmarshal(body, &rawItems); err != nil {
+		m.recordErr(err)
+		return errors.Wrap(err, "parse llmimages yaml")
+	}
+
+	items := make([]api.LLMImagesCatalogItem, 0, len(rawItems))
+	itemsById := make(map[string]*api.LLMImagesCatalogItem, len(rawItems))
+	for i := range rawItems {
+		item := rawItems[i]
+		if item.LLMType == "" {
+			continue
+		}
+		item.Id = catalogItemId(&item, i)
+		if item.Id == "" {
+			continue
+		}
+		items = append(items, item)
+		itemsById[item.Id] = &items[len(items)-1]
+	}
+
+	m.mu.Lock()
+	m.items = items
+	m.itemsById = itemsById
+	m.lastFetched = time.Now()
+	m.lastErr = nil
+	m.mu.Unlock()
+
+	log.Infof("LLMImagesCatalog: refreshed %d items from %s", len(items), source)
+	return nil
+}
+
+func catalogItemId(item *api.LLMImagesCatalogItem, index int) string {
+	if item.ImportKind == bundleImportKind && item.Name != "" {
+		return item.Name
+	}
+	if item.Image != "" {
+		imageName, imageLabel := parseCatalogImageRef(item.Image)
+		return item.LLMType + ":" + imageName + ":" + imageLabel
+	}
+	return fmt.Sprintf("%s-%d", item.LLMType, index)
+}
+
+func parseCatalogImageRef(imageStr string) (string, string) {
+	idx := strings.LastIndex(imageStr, ":")
+	if idx > 0 {
+		return imageStr[:idx], imageStr[idx+1:]
+	}
+	return imageStr, "latest"
+}
+
+func (m *SLLMImagesCatalogManager) loadSource(ctx context.Context, source string) ([]byte, error) {
+	lower := strings.ToLower(source)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return m.fetchHTTP(ctx, source)
+	}
+	if strings.HasPrefix(lower, "file://") {
+		source = strings.TrimPrefix(source, "file://")
+	}
+	data, err := os.ReadFile(source)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read catalog file %s", source)
+	}
+	return data, nil
+}
+
+func (m *SLLMImagesCatalogManager) fetchHTTP(ctx context.Context, url string) ([]byte, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, imagesCatalogFetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "build catalog request")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetch catalog")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, errors.Errorf("upstream returned %s", resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func (m *SLLMImagesCatalogManager) recordErr(err error) {
+	m.mu.Lock()
+	m.lastErr = err
+	m.mu.Unlock()
+}
+
+// ListItems returns items matching the filter. limit <= 0 returns all items
+// from offset (community catalog is small).
+func (m *SLLMImagesCatalogManager) ListItems(input api.LLMImagesCatalogListInput) ([]api.LLMImagesCatalogItem, int) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	filtered := make([]api.LLMImagesCatalogItem, 0, len(m.items))
+	for _, item := range m.items {
+		if !catalogItemMatches(&item, input) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	total := len(filtered)
+
+	offset := input.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > total {
+		offset = total
+	}
+	limit := input.Limit
+	if limit <= 0 {
+		return filtered[offset:], total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	return filtered[offset:end], total
+}
+
+// GetItem returns one catalog entry by id.
+func (m *SLLMImagesCatalogManager) GetItem(id string) (*api.LLMImagesCatalogItem, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	item, ok := m.itemsById[id]
+	if !ok {
+		return nil, false
+	}
+	cp := *item
+	return &cp, true
+}
+
+func catalogItemMatches(item *api.LLMImagesCatalogItem, input api.LLMImagesCatalogListInput) bool {
+	if input.LLMType != "" && !strings.EqualFold(item.LLMType, input.LLMType) {
+		return false
+	}
+	if input.Search == "" {
+		return true
+	}
+	needle := strings.ToLower(input.Search)
+	haystack := strings.ToLower(strings.Join([]string{
+		item.Image,
+		item.LLMType,
+		item.Description,
+		item.AppName,
+		item.Name,
+	}, " "))
+	return strings.Contains(haystack, needle)
+}

--- a/pkg/llm/options/option.go
+++ b/pkg/llm/options/option.go
@@ -40,6 +40,7 @@ type LLMOptions struct {
 	// http(s) URL or a local file path; sources without an http:// or https://
 	// prefix are treated as local files.
 	ModelCatalogURL                  string `help:"URL of the LLM model catalog YAML; values without http(s):// prefix are treated as local file paths" default:"https://www.cloudpods.org/model-catalog.yaml"`
+	LLMImagesCatalogURL              string `help:"URL of the LLM community images YAML; values without http(s):// prefix are treated as local file paths" default:"https://www.cloudpods.org/llmimages.yaml"`
 	LLMCatalogRefreshIntervalMinutes int    `help:"Catalog refresh interval in minutes; 0 disables periodic refresh" default:"60"`
 
 	// Server-side proxy for outbound HuggingFace / ModelScope calls (used by

--- a/pkg/llm/service/handler.go
+++ b/pkg/llm/service/handler.go
@@ -133,6 +133,65 @@ func handleLLMModelSetRefresh(ctx context.Context, w http.ResponseWriter, r *htt
 	appsrv.SendJSON(w, resp)
 }
 
+// handleLLMImagesCatalogList: GET /llm_images_catalogs
+func handleLLMImagesCatalogList(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	query, err := jsonutils.ParseQueryString(r.URL.RawQuery)
+	if err != nil {
+		httperrors.InvalidInputError(ctx, w, "Parse query string %q: %v", r.URL.RawQuery, err)
+		return
+	}
+	input := api.LLMImagesCatalogListInput{}
+	if query != nil {
+		_ = query.Unmarshal(&input)
+	}
+	items, total := models.GetLLMImagesCatalogManager().ListItems(input)
+	if items == nil {
+		items = []api.LLMImagesCatalogItem{}
+	}
+	resp := jsonutils.NewDict()
+	resp.Set("llm_images_catalogs", jsonutils.Marshal(items))
+	resp.Set("total", jsonutils.NewInt(int64(total)))
+	resp.Set("limit", jsonutils.NewInt(int64(input.Limit)))
+	resp.Set("offset", jsonutils.NewInt(int64(input.Offset)))
+	appsrv.SendJSON(w, resp)
+}
+
+// handleLLMImagesCatalogShow: GET /llm_images_catalogs/<id>
+func handleLLMImagesCatalogShow(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	id := lastPathSegment(r.URL.Path)
+	item, ok := models.GetLLMImagesCatalogManager().GetItem(id)
+	if !ok {
+		httperrors.NotFoundError(ctx, w, "images catalog item %s not found", id)
+		return
+	}
+	appsrv.SendStruct(w, api.LLMImagesCatalogShowOutput{LLMImagesCatalog: *item})
+}
+
+// handleLLMImagesCatalogRefresh: POST /llm_images_catalogs/refresh — admin only.
+func handleLLMImagesCatalogRefresh(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	userCred := auth.FetchUserCredential(ctx, policy.FilterPolicyCredential)
+	if userCred == nil {
+		httperrors.UnauthorizedError(ctx, w, "Unauthorized")
+		return
+	}
+	if !userCred.HasSystemAdminPrivilege() {
+		httperrors.ForbiddenError(ctx, w, "system admin required")
+		return
+	}
+	if err := models.GetLLMImagesCatalogManager().Refresh(ctx); err != nil {
+		httperrors.GeneralServerError(ctx, w, err)
+		return
+	}
+	items, total := models.GetLLMImagesCatalogManager().ListItems(api.LLMImagesCatalogListInput{})
+	if items == nil {
+		items = []api.LLMImagesCatalogItem{}
+	}
+	resp := jsonutils.NewDict()
+	resp.Set("llm_images_catalogs", jsonutils.Marshal(items))
+	resp.Set("total", jsonutils.NewInt(int64(total)))
+	appsrv.SendJSON(w, resp)
+}
+
 func lastPathSegment(path string) string {
 	if i := strings.LastIndex(path, "/"); i >= 0 {
 		return path[i+1:]
@@ -263,6 +322,10 @@ func InitHandlers(app *appsrv.Application, isSlave bool) {
 	app.AddHandler2("GET", "/llm_model_sets/<id>/specs", auth.Authenticate(handleLLMModelSetSpecs), nil, "llm_model_set_specs", nil)
 	app.AddHandler2("GET", "/llm_model_sets/<id>", auth.Authenticate(handleLLMModelSetShow), nil, "llm_model_set_show", nil)
 	app.AddHandler2("GET", "/llm_model_specs/<id>", auth.Authenticate(handleLLMModelSpecShow), nil, "llm_model_spec_show", nil)
+
+	app.AddHandler2("GET", "/llm_images_catalogs", auth.Authenticate(handleLLMImagesCatalogList), nil, "llm_images_catalog_list", nil)
+	app.AddHandler2("POST", "/llm_images_catalogs/refresh", auth.Authenticate(handleLLMImagesCatalogRefresh), nil, "llm_images_catalog_refresh", nil)
+	app.AddHandler2("GET", "/llm_images_catalogs/<id>", auth.Authenticate(handleLLMImagesCatalogShow), nil, "llm_images_catalog_show", nil)
 
 	AddAvailableNetworkHandler(models.GetLLMManager().KeywordPlural(), app)
 

--- a/pkg/llm/service/service.go
+++ b/pkg/llm/service/service.go
@@ -52,6 +52,12 @@ func StartService() {
 		time.Duration(opts.LLMCatalogRefreshIntervalMinutes)*time.Minute,
 	)
 
+	models.GetLLMImagesCatalogManager().Start(
+		context.Background(),
+		opts.LLMImagesCatalogURL,
+		time.Duration(opts.LLMCatalogRefreshIntervalMinutes)*time.Minute,
+	)
+
 	// if !opts.IsSlaveNode {
 	// 	models.InitializeCronjobs(app.GetContext())
 	// }

--- a/pkg/mcclient/modules/llm/mod_llm_images_catalog.go
+++ b/pkg/mcclient/modules/llm/mod_llm_images_catalog.go
@@ -1,0 +1,23 @@
+package llm
+
+import (
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
+	"yunion.io/x/onecloud/pkg/mcclient/modules"
+)
+
+var (
+	LLMImagesCatalogs LLMImagesCatalogsManager
+)
+
+func init() {
+	LLMImagesCatalogs = LLMImagesCatalogsManager{
+		modules.NewLLMManager("llm_images_catalog", "llm_images_catalogs",
+			[]string{"id", "llm_type", "image", "name", "description"},
+			[]string{}),
+	}
+	modules.Register(&LLMImagesCatalogs)
+}
+
+type LLMImagesCatalogsManager struct {
+	modulebase.ResourceManager
+}


### PR DESCRIPTION
Expose llmimages.yaml as list/show/refresh endpoints with configurable source URL, periodic cache refresh, and mcclient module support.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0
/area llm