### PR TITLE
Automated cherry pick of #25138: fix(host-deployer): windows disk extend separate partition and filesystem

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/winscripts.go
+++ b/pkg/hostman/guestfs/fsdriver/winscripts.go
@@ -473,12 +473,14 @@ function mtw_mount_disk() {
 }
 
 function mtw_extend_c() {
-    cmd_lines = [
+    mtw_execute_diskpart([
         'select volume c',
         'extend',
+    ]);
+    mtw_execute_diskpart([
+        'select volume c',
         'extend filesystem',
-    ];
-    mtw_execute_diskpart(cmd_lines);
+    ]);
     mtw_append_debug(["extend c"], ["success"]);
 }
 


### PR DESCRIPTION
Cherry pick of #25138 on release/4.0.

#25138: fix(host-deployer): windows disk extend separate partition and filesystem