### PR TITLE
Automated cherry pick of #25177: fix(host-deployer): bond netplan add vlan subinterface config

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/netplan.go
+++ b/pkg/hostman/guestfs/fsdriver/netplan.go
@@ -86,17 +86,32 @@ func newNetplanNetwork(allNics []*types.SServerNic, bondNics []*types.SServerNic
 
 			network.AddEthernet(sn.Name, nicConf)
 		}
-
 		netConf := getNetplanEthernetConfig(bondNic, true, mainIp, mainIp6, nicCnt)
-
 		if netConf.Mtu == 0 {
 			netConf.Mtu = defaultMtu
 		}
+		if bondNic.VlanInterface {
+			ifname := fmt.Sprintf("%s.%d", bondNic.Name, bondNic.Vlan)
+			vlanConfig := &netplan.VlanConfig{
+				EthernetConfig: *netConf,
+				Link:           bondNic.Name,
+				Id:             bondNic.Vlan,
+			}
+			network.AddVlan(ifname, vlanConfig)
 
-		// TODO: implement kinds of bond mode config
-		bondConf := netplan.NewBondMode4(netConf, interfaces)
-
-		network.AddBond(bondNic.Name, bondConf)
+			bondNicConf := &netplan.EthernetConfig{
+				DHCP4:      false,
+				DHCP6:      false,
+				MacAddress: bondNic.Mac,
+				Match:      netplan.NewEthernetConfigMatchMac(bondNic.Mac),
+			}
+			bondConf := netplan.NewBondMode4(bondNicConf, interfaces)
+			network.AddBond(bondNic.Name, bondConf)
+		} else {
+			// TODO: implement kinds of bond mode config
+			bondConf := netplan.NewBondMode4(netConf, interfaces)
+			network.AddBond(bondNic.Name, bondConf)
+		}
 	}
 
 	return network


### PR DESCRIPTION
Cherry pick of #25177 on release/4.0.4.

#25177: fix(host-deployer): bond netplan add vlan subinterface config