### PR TITLE
Automated cherry pick of #25199: fix: allow empty ip on link-local nic

### DIFF
--- a/pkg/hostman/hostinfo/hostbridge/hostbridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/hostbridge.go
@@ -405,7 +405,7 @@ func (d *SBaseBridgeDriver) ConfirmToConfig() (bool, string, error) {
 				return false, "", fmt.Errorf("bridge %s (%s) should have no ipv4 address", d.bridge, d.bridge.Addr)
 			}
 			if !d.bridge.IsSecretInterface() {
-				return false, "", fmt.Errorf("%s should have address in 169.254.0.0/16", d.bridge)
+				return false, fmt.Sprintf("bridge %s no ip and should have address in 169.254.0.0/16", d.bridge), nil
 			}
 		}
 		if len(d.ip6) > 0 {


### PR DESCRIPTION
Cherry pick of #25199 on release/4.0.

#25199: fix: allow empty ip on link-local nic