### PR TITLE
Automated cherry pick of #25229: fix(host): qmp device add convert string to boolean

### DIFF
--- a/pkg/hostman/monitor/qmp.go
+++ b/pkg/hostman/monitor/qmp.go
@@ -538,7 +538,14 @@ func (m *QmpMonitor) DeviceAdd(dev string, params map[string]string, callback St
 	}
 
 	for k, v := range params {
-		args[k] = v
+		var iv interface{}
+		iv = v
+		if v == "on" || v == "true" {
+			iv = true
+		} else if v == "off" || v == "false" {
+			iv = false
+		}
+		args[k] = iv
 	}
 
 	cmd := &Command{


### PR DESCRIPTION
Cherry pick of #25229 on release/4.0.4.

#25229: fix(host): qmp device add convert string to boolean