### PR TITLE
fix(region): support login info for ed25519 keypairs

### DIFF
--- a/pkg/util/seclib2/crypto.go
+++ b/pkg/util/seclib2/crypto.go
@@ -18,6 +18,7 @@ import (
 	"crypto"
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -72,6 +73,8 @@ func Encrypt(publicKey, origData []byte) ([]byte, error) {
 			pubInf = ssh2dsaPublicKey(pub)
 		case ssh.KeyAlgoECDSA256, ssh.KeyAlgoECDSA384, ssh.KeyAlgoECDSA521:
 			pubInf = ssh2ecdsaPublicKey(pub)
+		case ssh.KeyAlgoED25519:
+			pubInf = ssh2CryptoPublicKey(pub)
 		default:
 			return nil, fmt.Errorf("unsupported key type %s", pub.Type())
 		}
@@ -106,6 +109,12 @@ func Decrypt(privateKey, secret []byte) ([]byte, error) {
 			return nil, err
 		}
 		return decryptAES(ecdsaPub, secret)
+	case ed25519.PrivateKey, *ed25519.PrivateKey:
+		ed25519Pub, err := exportSshPublicKey(priv.(crypto.Signer).Public())
+		if err != nil {
+			return nil, err
+		}
+		return decryptAES(ed25519Pub, secret)
 	}
 	return nil, fmt.Errorf("unsupported")
 }

--- a/pkg/util/seclib2/ssh_test.go
+++ b/pkg/util/seclib2/ssh_test.go
@@ -15,6 +15,8 @@
 package seclib2
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -175,5 +177,54 @@ func TestDsaDecryptEncrypt(t *testing.T) {
 	if secret != secret2 {
 		t.Errorf("rsa decrypt/encrypt error! %s != %s", secret2, secret)
 		return
+	}
+}
+
+func TestEd25519DecryptEncrypt(t *testing.T) {
+	privateKey, publicKey, err := GenerateED25519SSHKeypair()
+	if err != nil {
+		t.Fatalf("fail to generate keypair %s", err)
+	}
+
+	secret := "this is a secret string!!!"
+	code, err := EncryptBase64(publicKey, secret)
+	if err != nil {
+		t.Fatalf("ed25519 encrypt error %s", err)
+	}
+	decrypted, err := DecryptBase64(privateKey, code)
+	if err != nil {
+		t.Fatalf("ed25519 decrypt error %s", err)
+	}
+	if secret != decrypted {
+		t.Fatalf("ed25519 decrypt/encrypt error! %s != %s", decrypted, secret)
+	}
+}
+
+func TestEd25519PKCS8DecryptEncrypt(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("fail to generate keypair %s", err)
+	}
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("fail to marshal private key %s", err)
+	}
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
+	publicKeySSH, err := exportSshPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("fail to export public key %s", err)
+	}
+
+	secret := "this is a secret string!!!"
+	code, err := EncryptBase64(string(publicKeySSH), secret)
+	if err != nil {
+		t.Fatalf("ed25519 encrypt error %s", err)
+	}
+	decrypted, err := DecryptBase64(string(privateKeyPEM), code)
+	if err != nil {
+		t.Fatalf("ed25519 decrypt error %s", err)
+	}
+	if secret != decrypted {
+		t.Fatalf("ed25519 decrypt/encrypt error! %s != %s", decrypted, secret)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

添加 ed25519 类型密钥提示下列错误：
```
[info 2026-07-17 09:02:58 workmanager.(*workerTask).Run(manager.go:96)] DelayTask failed: Deploy guest fs: request deploy guest fs: rpc error: code = Unknown desc = ChangeUserPasswd: Encryption: unsupported key type ssh-ed25519
```
- [x] Unit test written

**Does this PR need to be backport to the previous release branch?**:

NONE

相关关联：
https://github.com/yunionio/cloudpods/pull/23195/changes

https://github.com/yunionio/cloudpods/issues/23071