### PR TITLE
Automated cherry pick of #25278: fix(llm): detach stale GPUs when effective devices are empty on restart

### DIFF
--- a/pkg/llm/drivers/llm_container/desktop_test.go
+++ b/pkg/llm/drivers/llm_container/desktop_test.go
@@ -28,15 +28,36 @@ func TestAppendContainerIsolatedDevicesFromSku(t *testing.T) {
 }
 
 func TestAppendContainerIsolatedDevicesById(t *testing.T) {
+	devices := api.Devices{{Model: "GeForce RTX 4090"}}
+	sku := &models.SLLMSku{}
+	sku.Devices = &devices
 	dev := computeapi.SIsolatedDevice{}
 	dev.Id = "gpu-1"
 	spec := computeapi.ContainerSpec{}
-	appendContainerIsolatedDevices(&spec, nil, nil, []computeapi.SIsolatedDevice{dev})
+	appendContainerIsolatedDevices(&spec, nil, sku, []computeapi.SIsolatedDevice{dev})
 	if len(spec.Devices) != 1 || spec.Devices[0].IsolatedDevice == nil || spec.Devices[0].IsolatedDevice.Id != "gpu-1" {
 		t.Fatalf("devices = %#v", spec.Devices)
 	}
 	if spec.Devices[0].IsolatedDevice.GuestIsolatedDeviceIndex != 0 {
 		t.Fatalf("guest_isolated_device_index = %d", spec.Devices[0].IsolatedDevice.GuestIsolatedDeviceIndex)
+	}
+}
+
+func TestAppendContainerIsolatedDevicesEmptySkuIgnoresBound(t *testing.T) {
+	dev := computeapi.SIsolatedDevice{}
+	dev.Id = "gpu-stale"
+	spec := computeapi.ContainerSpec{}
+	appendContainerIsolatedDevices(&spec, nil, nil, []computeapi.SIsolatedDevice{dev})
+	if len(spec.Devices) != 0 {
+		t.Fatalf("expected no devices when effective devices empty, got %#v", spec.Devices)
+	}
+	sku := &models.SLLMSku{}
+	empty := api.Devices{}
+	sku.Devices = &empty
+	spec2 := computeapi.ContainerSpec{}
+	appendContainerIsolatedDevices(&spec2, nil, sku, []computeapi.SIsolatedDevice{dev})
+	if len(spec2.Devices) != 0 {
+		t.Fatalf("expected no devices for empty sku devices, got %#v", spec2.Devices)
 	}
 }
 
@@ -52,6 +73,11 @@ func TestDesktopUiTitle(t *testing.T) {
 func TestDesktopHasIsolatedGPU(t *testing.T) {
 	if desktopHasIsolatedGPU(nil, nil, nil) {
 		t.Fatal("expected false without devices")
+	}
+	bound := computeapi.SIsolatedDevice{}
+	bound.Id = "gpu-stale"
+	if desktopHasIsolatedGPU(nil, nil, []computeapi.SIsolatedDevice{bound}) {
+		t.Fatal("expected false when only stale bound devices and empty effective devices")
 	}
 	devices := api.Devices{{Model: "GeForce RTX 4090"}}
 	sku := &models.SLLMSku{}

--- a/pkg/llm/drivers/llm_container/desktop_webtop_common.go
+++ b/pkg/llm/drivers/llm_container/desktop_webtop_common.go
@@ -105,9 +105,6 @@ func desktopContainerRootFs(diskIndex *int) *commonapi.ContainerRootfs {
 const desktopDefaultDRINode = "/dev/dri/renderD128"
 
 func desktopHasIsolatedGPU(llm *models.SLLM, sku *models.SLLMSku, devices []computeapi.SIsolatedDevice) bool {
-	if len(devices) > 0 {
-		return true
-	}
 	effDevs := models.GetEffectiveDevices(llm, sku)
 	return effDevs != nil && len(*effDevs) > 0
 }
@@ -122,7 +119,10 @@ func desktopGPUWaylandEnvs() []*commonapi.ContainerKeyValue {
 
 func appendContainerIsolatedDevices(spec *computeapi.ContainerSpec, llm *models.SLLM, sku *models.SLLMSku, devices []computeapi.SIsolatedDevice) {
 	effDevs := models.GetEffectiveDevices(llm, sku)
-	if len(devices) == 0 && effDevs != nil && len(*effDevs) > 0 {
+	if effDevs == nil || len(*effDevs) == 0 {
+		return
+	}
+	if len(devices) == 0 {
 		for i := range *effDevs {
 			index := i
 			spec.Devices = append(spec.Devices, &computeapi.ContainerDevice{

--- a/pkg/llm/models/llm_base.go
+++ b/pkg/llm/models/llm_base.go
@@ -98,6 +98,64 @@ func getEffectiveDevices(llmBase *SLLMBase, skuBase *SLLMSkuBase) *api.Devices {
 	return nil
 }
 
+// SyncDetachIsolatedDevicesIfEmpty detaches all guest isolated devices when
+// effective devices (llm override or sku) are empty. Used on restart so stale
+// GPU bindings do not survive after SKU devices are cleared.
+func (llm *SLLM) SyncDetachIsolatedDevicesIfEmpty(ctx context.Context, userCred mcclient.TokenCredential, sku *SLLMSku) error {
+	eff := GetEffectiveDevices(llm, sku)
+	if eff != nil && !eff.IsZero() {
+		return nil
+	}
+	server, err := llm.GetServer(ctx)
+	if err != nil {
+		return errors.Wrap(err, "GetServer")
+	}
+	if len(server.IsolatedDevices) == 0 {
+		return nil
+	}
+	s := auth.GetSession(ctx, userCred, options.Options.Region)
+	params := jsonutils.NewDict()
+	params.Set("detach_all", jsonutils.JSONTrue)
+	_, err = compute.Servers.PerformAction(s, llm.CmpId, "detach-isolated-device", params)
+	if err != nil {
+		return errors.Wrap(err, "detach-isolated-device")
+	}
+	// detach-isolated-device schedules GuestIsolatedDeviceSyncTask asynchronously;
+	// status stays ready briefly then becomes sync_config. Waiting for ready
+	// immediately races and lets start run while still syncing.
+	if err := llm.waitServerLeaveReadyStatus(ctx, 120); err != nil {
+		return errors.Wrap(err, "waitServerLeaveReadyStatus after detach-isolated-device")
+	}
+	server, err = llm.WaitServerStatus(ctx, userCred, []string{computeapi.VM_READY}, 1800)
+	if err != nil {
+		return errors.Wrap(err, "WaitServerStatus after detach-isolated-device")
+	}
+	if len(server.IsolatedDevices) > 0 {
+		return errors.Wrapf(errors.ErrInvalidStatus, "isolated devices still present after detach: %d", len(server.IsolatedDevices))
+	}
+	return nil
+}
+
+// waitServerLeaveReadyStatus polls until guest status is no longer ready
+// (e.g. sync_config), or until timeoutSecs elapses while still ready.
+func (llm *SLLM) waitServerLeaveReadyStatus(ctx context.Context, timeoutSecs int) error {
+	expire := time.Now().Add(time.Second * time.Duration(timeoutSecs))
+	for time.Now().Before(expire) {
+		server, err := llm.GetServer(ctx)
+		if err != nil {
+			return errors.Wrap(err, "GetServer")
+		}
+		if server.Status != computeapi.VM_READY {
+			if strings.Contains(server.Status, "fail") {
+				return errors.Wrapf(errors.ErrInvalidStatus, "server status %s", server.Status)
+			}
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	return nil
+}
+
 // HasHygonDevices reports whether effective devices include Hygon DCU (exclusive or HAMI).
 func HasHygonDevices(llm *SLLM, sku *SLLMSku) bool {
 	devs := GetEffectiveDevices(llm, sku)

--- a/pkg/llm/tasks/llm/llm_restart_task.go
+++ b/pkg/llm/tasks/llm/llm_restart_task.go
@@ -376,6 +376,11 @@ func (task *LLMRestartTask) OnResetDiskComplete(ctx context.Context, obj db.ISta
 		return
 	}
 
+	if err := llm.SyncDetachIsolatedDevicesIfEmpty(ctx, task.UserCred, sku); err != nil {
+		task.taskFailed(ctx, llm, errors.Wrap(err, "SyncDetachIsolatedDevicesIfEmpty").Error())
+		return
+	}
+
 	volume, err := llm.GetVolume()
 	if err != nil {
 		task.taskFailed(ctx, llm, errors.Wrap(err, "GetVolume").Error())


### PR DESCRIPTION
Cherry pick of #25278 on master.

#25278: fix(llm): detach stale GPUs when effective devices are empty on restart