### PR TITLE
Automated cherry pick of #25316: fix(cloudmon): cloudpods metric pull delay time

### DIFF
--- a/pkg/cloudmon/options/options.go
+++ b/pkg/cloudmon/options/options.go
@@ -26,6 +26,8 @@ type CloudMonOptions struct {
 	CollectMetricInterval   int64  `help:"Increment Sync Interval unit:minute" default:"6"`
 	SkipMetricPullProviders string `help:"Skip indicate provider metric pull" default:""`
 
+	CloudpodsCollectDelayMinutes int64 `help:"Cloudpods Collect Delay Duration unit:minute" default:"0"`
+
 	InfluxDatabase string `help:"influxdb database name, default telegraf" default:"telegraf"`
 
 	DisableServiceMetric               bool  `help:"disable service metric collect"`

--- a/pkg/cloudmon/providerdriver/cloudpods.go
+++ b/pkg/cloudmon/providerdriver/cloudpods.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudmon/options"
 )
 
 type CloudpodsCollect struct {
@@ -37,5 +38,5 @@ func init() {
 }
 
 func (self *CloudpodsCollect) GetDelayDuration() time.Duration {
-	return time.Minute * 9
+	return time.Minute * time.Duration(options.Options.CloudpodsCollectDelayMinutes)
 }


### PR DESCRIPTION
Cherry pick of #25316 on release/4.0.4.

#25316: fix(cloudmon): cloudpods metric pull delay time