### PR TITLE
fix(monitor): nodata 告警补充 ResIdKey 与 AlertDetails

### DIFF
--- a/pkg/apis/monitor/commalert.go
+++ b/pkg/apis/monitor/commalert.go
@@ -174,15 +174,17 @@ type CommonAlertMetricDetails struct {
 	ConditionType  string    `json:"condition_type"`
 	ThresholdStr   string    `json:"threshold_str"`
 	// metric points'value的运算方式
-	Reduce                 string           `json:"reduce"`
-	DB                     string           `json:"db"`
-	Measurement            string           `json:"measurement"`
-	MeasurementDisplayName string           `json:"measurement_display_name"`
-	ResType                string           `json:"res_type"`
-	Field                  string           `json:"field"`
-	Groupby                string           `json:"groupby"`
-	Filters                []MetricQueryTag `json:"filters"`
-	FieldDescription       MetricFieldDetail
-	FieldOpt               string `json:"field_opt"`
-	GetPointStr            bool   `json:"get_point_str"`
+	Reduce                 string `json:"reduce"`
+	DB                     string `json:"db"`
+	Measurement            string `json:"measurement"`
+	MeasurementDisplayName string `json:"measurement_display_name"`
+	ResType                string `json:"res_type"`
+	// ResIdKey 为该资源类型在 TSDB 中的资源 ID tag，如 host_id / vm_id
+	ResIdKey         string           `json:"res_id_key"`
+	Field            string           `json:"field"`
+	Groupby          string           `json:"groupby"`
+	Filters          []MetricQueryTag `json:"filters"`
+	FieldDescription MetricFieldDetail
+	FieldOpt         string `json:"field_opt"`
+	GetPointStr      bool   `json:"get_point_str"`
 }

--- a/pkg/monitor/alerting/conditions/nodataquery.go
+++ b/pkg/monitor/alerting/conditions/nodataquery.go
@@ -162,6 +162,7 @@ func (c *NoDataQueryCondition) NewNoDataEvalMatch(context *alerting.EvalContext,
 
 	//evalMatch.Condition = c.GenerateFormatCond(meta, queryKeyInfo).String()
 	evalMatch.ValueStr = NO_DATA
+	evalMatch.AlertDetails = jsonutils.Marshal(alertDetails)
 	return evalMatch, nil
 }
 

--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -908,6 +908,9 @@ func getMetricDescriptionDetails(metricDetails *monitor.CommonAlertMetricDetails
 	if len(influxdbMeasurements[0].ResType) != 0 {
 		metricDetails.ResType = influxdbMeasurements[0].ResType
 	}
+	if metricDetails.ResType != "" {
+		metricDetails.ResIdKey = monitor.GetMeasurementTagIdKeyByResTypeWithDefault(metricDetails.ResType)
+	}
 	fields := make([]string, 0)
 	if len(metricDetails.FieldOpt) != 0 {
 		fields = append(fields, strings.Split(metricDetails.Field, metricDetails.FieldOpt)...)


### PR DESCRIPTION
为 CommonAlertMetricDetails 填充资源 ID tag，并在无数据评估匹配中序列化 AlertDetails，便于下游定位资源。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area monitor