### PR TITLE
Automated cherry pick of #25376: fix(region): skip sync cloudpods kvm secgroup

### DIFF
--- a/pkg/compute/models/secgroups.go
+++ b/pkg/compute/models/secgroups.go
@@ -831,6 +831,10 @@ func (manager *SSecurityGroupManager) DelaySync(ctx context.Context, userCred mc
 			return errors.Wrapf(err, "GetKvmGuests")
 		}
 		for _, guest := range guests {
+			// skip sync if guest has external id(cloudpods guest)
+			if len(guest.ExternalId) > 0 {
+				continue
+			}
 			guest.StartSyncTask(ctx, userCred, true, "")
 		}
 	}


### PR DESCRIPTION
Cherry pick of #25376 on release/4.0.

#25376: fix(region): skip sync cloudpods kvm secgroup