### PR TITLE
fix(host): skip unmanage interface when bridge slave has no address

### DIFF
--- a/pkg/hostman/hostinfo/hostbridge/hostbridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/hostbridge.go
@@ -477,7 +477,9 @@ func (d *SBaseBridgeDriver) SetupAddresses() error {
 	if d.inter != nil {
 		// first shutdown the origin interface
 		ifname := d.inter.String()
-		tryUnmanageInterface(ifname)
+		if len(d.inter.Addr) > 0 || len(d.inter.Addr6) > 0 {
+			tryUnmanageInterface(ifname)
+		}
 		if err := d.inter.FlushAddrs(); err != nil {
 			return errors.Wrapf(err, "bridge %s slave ifname: %s flush addrs fail", br, ifname)
 		}


### PR DESCRIPTION
Only call tryUnmanageInterface when the slave interface has IPv4 or IPv6 addresses configured, avoiding unnecessary NetworkManager unmanage on address-less interfaces during bridge setup.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/area host
- 4.0.4