### PR TITLE
Automated cherry pick of #25380: fix(host): skip unmanage interface when bridge slave has no address

### DIFF
--- a/pkg/hostman/hostinfo/hostbridge/hostbridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/hostbridge.go
@@ -477,7 +477,9 @@ func (d *SBaseBridgeDriver) SetupAddresses() error {
 	if d.inter != nil {
 		// first shutdown the origin interface
 		ifname := d.inter.String()
-		tryUnmanageInterface(ifname)
+		if len(d.inter.Addr) > 0 || len(d.inter.Addr6) > 0 {
+			tryUnmanageInterface(ifname)
+		}
 		if err := d.inter.FlushAddrs(); err != nil {
 			return errors.Wrapf(err, "bridge %s slave ifname: %s flush addrs fail", br, ifname)
 		}


### PR DESCRIPTION
Cherry pick of #25380 on release/4.0.4.

#25380: fix(host): skip unmanage interface when bridge slave has no address