### PR TITLE
fix: allow create-server without disk args

### DIFF
--- a/pkg/mcclient/options/compute/servers.go
+++ b/pkg/mcclient/options/compute/servers.go
@@ -304,7 +304,7 @@ type ServerCreateCommonConfig struct {
 		--disk 'size=40g,image=<id>,backend=cloud_essd'
 		--disk 'size=500M'
 		--disk 'snapshot_id=1ceb8c6d-6571-451d-8957-4bd3a871af85'
-	" nargs:"+" mcp:"true"`
+	" mcp:"true"`
 	DiskSchedtag []string `help:"Disk schedtag description, e.g. '0:<tag>:<strategy>'"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allow create-server without disk args

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/4.0

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @ioito 