### PR TITLE
Automated cherry pick of #25413: fix: allow create-server without disk args

### DIFF
--- a/pkg/mcclient/options/compute/servers.go
+++ b/pkg/mcclient/options/compute/servers.go
@@ -303,7 +303,7 @@ type ServerCreateCommonConfig struct {
 		--disk 'size=40g,image=<id>,backend=cloud_essd'
 		--disk 'size=500M'
 		--disk 'snapshot_id=1ceb8c6d-6571-451d-8957-4bd3a871af85'
-	" nargs:"+" mcp:"true"`
+	" mcp:"true"`
 	DiskSchedtag []string `help:"Disk schedtag description, e.g. '0:<tag>:<strategy>'"`
 }
 


### PR DESCRIPTION
Cherry pick of #25413 on release/4.0.4.

#25413: fix: allow create-server without disk args