### PR TITLE
Automated cherry pick of #25420: fix(host-deployer): no noeed clean failed mountpoints

### DIFF
--- a/pkg/hostman/guestfs/kvmpart/kvmpart.go
+++ b/pkg/hostman/guestfs/kvmpart/kvmpart.go
@@ -56,7 +56,7 @@ func NewKVMGuestDiskPartition(devPath, sourceDev string, isLVM bool) *SKVMGuestD
 	res.fs = res.getFsFormat()
 	res.sourceDev = sourceDev
 	res.IsLVMPart = isLVM
-	fileutils2.CleanFailedMountpoints()
+	//fileutils2.CleanFailedMountpoints()
 	mountPath := fmt.Sprintf("/tmp/%s", strings.Replace(devPath, "/", "_", -1))
 	res.SLocalGuestFS = NewLocalGuestFS(mountPath)
 	return res


### PR DESCRIPTION
Cherry pick of #25420 on release/4.0.4.

#25420: fix(host-deployer): no noeed clean failed mountpoints