### PR TITLE
Automated cherry pick of #25427: fix: allow empty host networks

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -381,7 +381,7 @@ func (h *SHostInfo) parseConfig() error {
 	if mem < 64 { // MB
 		return fmt.Errorf("Not enough memory!")
 	}
-	if len(options.HostOptions.Networks) == 0 {
+	if len(options.HostOptions.Networks) == 0 && len(options.HostOptions.ListenInterface) == 0 {
 		netConf, err := h.generateLocalNetworkConfig()
 		if err != nil {
 			return errors.Wrap(err, "generateLocalNetworkConfig")


### PR DESCRIPTION
Cherry pick of #25427 on master.

#25427: fix: allow empty host networks