### PR TITLE
feat(host): support openRuyi guest initialization

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/drivers.go
+++ b/pkg/hostman/guestfs/fsdriver/drivers.go
@@ -37,7 +37,7 @@ func GetRootfsDrivers() []newRootFsDriverFunc {
 
 func Init(cloudrootDir string) error {
 	linuxFsDrivers := []newRootFsDriverFunc{
-		NewFangdeRootFs, NewUnionOSRootFs,
+		NewOpenRuyiRootFs, NewFangdeRootFs, NewUnionOSRootFs,
 		NewAnolisRootFs, NewRockyRootFs, NewOpenCloudOsRootFs, NewAlmaLinuxRootFs,
 		NewOpenKylinRootfs, NewUOSDesktopRootfs,
 		NewGalaxyKylinRootFs, NewNeoKylinRootFs,

--- a/pkg/hostman/guestfs/fsdriver/openruyi.go
+++ b/pkg/hostman/guestfs/fsdriver/openruyi.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsdriver
+
+import (
+	"strings"
+
+	"yunion.io/x/jsonutils"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/types"
+	deployapi "yunion.io/x/onecloud/pkg/hostman/hostdeployer/apis"
+)
+
+type SOpenRuyiRootFs struct {
+	*sRedhatLikeRootFs
+}
+
+func NewOpenRuyiRootFs(part IDiskPartition) IRootFsDriver {
+	return &SOpenRuyiRootFs{sRedhatLikeRootFs: newRedhatLikeRootFs(part)}
+}
+
+func (d *SOpenRuyiRootFs) GetName() string {
+	return "openRuyi"
+}
+
+func (d *SOpenRuyiRootFs) String() string {
+	return "OpenRuyiRootFs"
+}
+
+func (d *SOpenRuyiRootFs) RootSignatures() []string {
+	sig := d.sLinuxRootFs.RootSignatures()
+	return append([]string{"/etc/os-release", "/usr/lib/rpm/openruyi"}, sig...)
+}
+
+func parseOpenRuyiVersion(osRelease string) string {
+	for _, line := range strings.Split(osRelease, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "VERSION_ID=") {
+			return strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "VERSION_ID=")), `"'`)
+		}
+	}
+	return ""
+}
+
+func (d *SOpenRuyiRootFs) GetReleaseInfo(rootFs IDiskPartition) *deployapi.ReleaseInfo {
+	rel, _ := rootFs.FileGetContents("/etc/os-release", false)
+	return deployapi.NewReleaseInfo(d.GetName(), parseOpenRuyiVersion(string(rel)), d.GetArch(rootFs))
+}
+
+func (d *SOpenRuyiRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics []*types.SServerNic) error {
+	return d.sRedhatLikeRootFs.deployNetworkingScripts(rootFs, nics, d.GetReleaseInfo(rootFs))
+}
+
+func (d *SOpenRuyiRootFs) EnableSerialConsole(rootFs IDiskPartition, sysInfo *jsonutils.JSONDict) error {
+	return d.enableSerialConsoleSystemd(rootFs)
+}
+
+func (d *SOpenRuyiRootFs) DisableSerialConsole(rootFs IDiskPartition) error {
+	d.disableSerialConsoleSystemd(rootFs)
+	return nil
+}

--- a/pkg/hostman/guestfs/fsdriver/openruyi_test.go
+++ b/pkg/hostman/guestfs/fsdriver/openruyi_test.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsdriver
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOpenRuyiRootSignatures(t *testing.T) {
+	driver := NewOpenRuyiRootFs(nil)
+	want := []string{
+		"/etc/os-release",
+		"/usr/lib/rpm/openruyi",
+		"/bin",
+		"/etc",
+		"/boot",
+		"/lib",
+		"/usr",
+	}
+	if got := driver.RootSignatures(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("RootSignatures() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseOpenRuyiVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		osRelease string
+		want      string
+	}{
+		{name: "double quoted", osRelease: "NAME=\"openRuyi\"\nVERSION_ID=\"Creek\"\n", want: "Creek"},
+		{name: "single quoted", osRelease: "VERSION_ID='River'\n", want: "River"},
+		{name: "unquoted", osRelease: "VERSION_ID=Lake\n", want: "Lake"},
+		{name: "missing", osRelease: "NAME=\"openRuyi\"\n", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseOpenRuyiVersion(tt.osRelease); got != tt.want {
+				t.Fatalf("parseOpenRuyiVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an openRuyi root filesystem driver so Cloudpods can detect openRuyi images, report the Creek release metadata, deploy Red Hat-style networking, and manage the systemd serial console. This is required for openRuyi riscv64 guests managed by Cloudpods.

- [x] Smoke testing completed on openRuyi Creek 2026.07 riscv64
- [x] Unit test written

Validation:

```text
go test ./pkg/hostman/guestfs/fsdriver
ok  yunion.io/x/onecloud/pkg/hostman/guestfs/fsdriver
```

**Does this PR need to be backport to the previous release branch?**:

NONE