### PR TITLE
feat(host): support QEMU 11.1 on riscv64

### DIFF
--- a/pkg/hostman/guestman/qemu/qemu.go
+++ b/pkg/hostman/guestman/qemu/qemu.go
@@ -38,6 +38,7 @@ const (
 	Version_9_0_1  Version = "9.0.1"
 	Version_10_0_3 Version = "10.0.3"
 	Version_10_0_7 Version = "10.0.7"
+	Version_11_1_0 Version = "11.1.0"
 )
 
 type Arch string

--- a/pkg/hostman/guestman/qemu/qemu_test.go
+++ b/pkg/hostman/guestman/qemu/qemu_test.go
@@ -44,3 +44,11 @@ func Test_baseOptions(t *testing.T) {
 	assert.Equal("-vnc :5900,password", opt.VNC(5900, true))
 	assert.Equal("-vnc :5900", opt.VNC(5900, false))
 }
+
+func TestQemu1110Riscv64Registered(t *testing.T) {
+	cmd, ok := GetCommand(Version_11_1_0, Arch_riscv64)
+	if assert.True(t, ok) {
+		assert.Equal(t, Version_11_1_0, cmd.GetVersion())
+		assert.Equal(t, Arch_riscv64, cmd.GetArch())
+	}
+}

--- a/pkg/hostman/guestman/qemu/v11_1_0.go
+++ b/pkg/hostman/guestman/qemu/v11_1_0.go
@@ -1,0 +1,25 @@
+package qemu
+
+func init() {
+	RegisterCmd(newCmd_11_1_0_riscv64())
+}
+
+type opt_1110_riscv64 struct {
+	*baseOptions_riscv64
+	*baseOptions_ge_310
+}
+
+func newCmd_11_1_0_riscv64() QemuCommand {
+	return newBaseCommand(
+		Version_11_1_0,
+		Arch_riscv64,
+		newOpt_11_1_0_riscv64(),
+	)
+}
+
+func newOpt_11_1_0_riscv64() QemuOptions {
+	return &opt_1110_riscv64{
+		baseOptions_riscv64: newBaseOptions_riscv64(),
+		baseOptions_ge_310:  newBaseOptionsGE310(),
+	}
+}


### PR DESCRIPTION
## Summary

- register the QEMU 11.1.0 command driver for riscv64 hosts
- reuse the existing RISC-V and post-3.1 option implementations
- add a registry test for the new version/architecture pair

## Why

openRuyi Creek 2026.07 RVA23 validation uses QEMU 11.1.0. Hostman detects the installed version correctly, but VM startup currently fails with `Qemu comand driver 11.1.0 riscv64 not registered`.

## Test

```text
go test ./pkg/hostman/guestman/qemu
ok  yunion.io/x/onecloud/pkg/hostman/guestman/qemu
```