### PR TITLE
fix(host): support containerd kubelet image storage

### DIFF
--- a/pkg/hostman/hostutils/kubelet/docker.go
+++ b/pkg/hostman/hostutils/kubelet/docker.go
@@ -21,27 +21,58 @@ import (
 	"yunion.io/x/onecloud/pkg/util/procutils"
 )
 
-type DockerInfo struct {
+const containerdRootDir = "/var/lib/containerd"
+
+type RuntimeInfo struct {
+	RootDir string
+}
+
+type dockerInfo struct {
 	ID            string `json:"ID"`
 	Driver        string `json:"Driver"`
 	DockerRootDir string `json:"DockerRootDir"`
 }
 
-func GetDockerInfoByRemote() (*DockerInfo, error) {
+func getDockerRuntimeInfoByRemote() (*RuntimeInfo, error) {
 	content, err := procutils.NewRemoteCommandAsFarAsPossible("docker", "info", "--format", "{{json .}}").Output()
 	if err != nil {
 		return nil, errors.Wrap(err, "Run command 'docker info'")
 	}
+	return parseDockerRuntimeInfo(content)
+}
 
+func parseDockerRuntimeInfo(content []byte) (*RuntimeInfo, error) {
 	obj, err := jsonutils.Parse(content)
 	if err != nil {
 		return nil, errors.Wrap(err, "Parse docker info to json")
 	}
 
-	info := new(DockerInfo)
+	info := new(dockerInfo)
 	if err := obj.Unmarshal(info); err != nil {
 		return nil, errors.Wrap(err, "Unmarshal docker info")
 	}
+	if len(info.DockerRootDir) == 0 {
+		return nil, errors.Error("docker info returned an empty root directory")
+	}
 
-	return info, nil
+	return &RuntimeInfo{RootDir: info.DockerRootDir}, nil
+}
+
+func getContainerdRuntimeInfoByRemote() (*RuntimeInfo, error) {
+	if err := procutils.NewRemoteCommandAsFarAsPossible("test", "-d", containerdRootDir).Run(); err != nil {
+		return nil, errors.Wrap(err, "Find containerd root directory")
+	}
+	return &RuntimeInfo{RootDir: containerdRootDir}, nil
+}
+
+func GetContainerRuntimeInfoByRemote() (*RuntimeInfo, error) {
+	dockerInfo, dockerErr := getDockerRuntimeInfoByRemote()
+	if dockerErr == nil {
+		return dockerInfo, nil
+	}
+	containerdInfo, containerdErr := getContainerdRuntimeInfoByRemote()
+	if containerdErr == nil {
+		return containerdInfo, nil
+	}
+	return nil, errors.Wrapf(containerdErr, "Get container runtime info (docker: %v)", dockerErr)
 }

--- a/pkg/hostman/hostutils/kubelet/docker_test.go
+++ b/pkg/hostman/hostutils/kubelet/docker_test.go
@@ -1,0 +1,22 @@
+package kubelet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerdRuntimeInfo(t *testing.T) {
+	info := &RuntimeInfo{RootDir: containerdRootDir}
+	assert.Equal(t, "/var/lib/containerd", info.RootDir)
+}
+
+func TestParseDockerRuntimeInfo(t *testing.T) {
+	info, err := parseDockerRuntimeInfo([]byte(`{"DockerRootDir":"/var/lib/docker"}`))
+	if assert.NoError(t, err) {
+		assert.Equal(t, "/var/lib/docker", info.RootDir)
+	}
+
+	_, err = parseDockerRuntimeInfo([]byte(`{"DockerRootDir":""}`))
+	assert.Error(t, err)
+}

--- a/pkg/hostman/hostutils/kubelet/kubelet.go
+++ b/pkg/hostman/hostutils/kubelet/kubelet.go
@@ -41,7 +41,7 @@ type KubeletConfig interface {
 // kubeletConfig implements KubeletRunDirectory interface.
 type kubeletConfig struct {
 	config         jsonutils.JSONObject
-	dockerInfo     *DockerInfo
+	runtimeInfo    *RuntimeInfo
 	evictionConfig eviction.Config
 	nodeFsDevice   string
 	imageFsDevice  string
@@ -55,15 +55,15 @@ func NewKubeletConfigByDirectory(dir string) (KubeletConfig, error) {
 		return nil, errors.Wrapf(err, "Read config file %s", configFile)
 	}
 
-	dockerInfo, err := GetDockerInfoByRemote()
+	runtimeInfo, err := GetContainerRuntimeInfoByRemote()
 	if err != nil {
-		return nil, errors.Wrap(err, "Get docker info")
+		return nil, errors.Wrap(err, "Get container runtime info")
 	}
 
-	return newKubeletConfig(content, dockerInfo)
+	return newKubeletConfig(content, runtimeInfo)
 }
 
-func newKubeletConfig(yamlConfig []byte, dockerInfo *DockerInfo) (KubeletConfig, error) {
+func newKubeletConfig(yamlConfig []byte, runtimeInfo *RuntimeInfo) (KubeletConfig, error) {
 	obj, err := jsonutils.ParseYAML(string(yamlConfig))
 	if err != nil {
 		return nil, errors.Wrapf(err, "Parse yaml content %s", yamlConfig)
@@ -74,7 +74,7 @@ func newKubeletConfig(yamlConfig []byte, dockerInfo *DockerInfo) (KubeletConfig,
 		return nil, errors.Wrap(err, "New eviction config")
 	}
 
-	imageFsDev, err := GetDirectoryMountDevice(dockerInfo.DockerRootDir)
+	imageFsDev, err := GetDirectoryMountDevice(runtimeInfo.RootDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "Find docker root directory device")
 	}
@@ -86,7 +86,7 @@ func newKubeletConfig(yamlConfig []byte, dockerInfo *DockerInfo) (KubeletConfig,
 
 	k := &kubeletConfig{
 		config:         obj,
-		dockerInfo:     dockerInfo,
+		runtimeInfo:    runtimeInfo,
 		evictionConfig: evictionConfig,
 		nodeFsDevice:   nodeFsDev,
 		imageFsDevice:  imageFsDev,
@@ -116,7 +116,7 @@ func (k *kubeletConfig) HasDedicatedImageFs() bool {
 }
 
 func (k *kubeletConfig) GetImageFs() string {
-	return k.dockerInfo.DockerRootDir
+	return k.runtimeInfo.RootDir
 }
 
 func (k *kubeletConfig) GetEvictionConfig() eviction.Config {


### PR DESCRIPTION
## Summary

- discover the kubelet image filesystem from Docker when available
- fall back to `/var/lib/containerd` for native Kubernetes/containerd hosts
- keep Docker behavior unchanged and add parsing tests

## Why

Hostman currently exits during initialization when Kubernetes uses containerd and no Docker CLI is installed. Cloudpods only needs the runtime root directory here to calculate image filesystem capacity.

## Test

```text
go test ./pkg/hostman/hostutils/kubelet
ok  yunion.io/x/onecloud/pkg/hostman/hostutils/kubelet
```