### PR TITLE
feat(region,host): support riscv64 usage

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4691,7 +4691,7 @@ func usageTotalGuestResourceCount(
 	policyResult rbacutils.SPolicyResult,
 ) map[string]SGuestCountStat {
 	countStat := make(map[string]SGuestCountStat)
-	for _, arch := range []string{apis.OS_ARCH_ALL, apis.OS_ARCH_X86_64, apis.OS_ARCH_AARCH64} {
+	for _, arch := range []string{apis.OS_ARCH_ALL, apis.OS_ARCH_X86_64, apis.OS_ARCH_AARCH64, apis.OS_ARCH_RISCV64} {
 		allStat := usageTotalGuestResourceCountByArch(
 			ctx, scope, ownerId, rangeObjs, status,
 			hypervisors, includeSystem, pendingDelete,

--- a/pkg/hostman/guestfs/fsdriver/drivers.go
+++ b/pkg/hostman/guestfs/fsdriver/drivers.go
@@ -37,7 +37,7 @@ func GetRootfsDrivers() []newRootFsDriverFunc {
 
 func Init(cloudrootDir string) error {
 	linuxFsDrivers := []newRootFsDriverFunc{
-		NewFangdeRootFs, NewUnionOSRootFs,
+		NewOpenRuyiRootFs, NewFangdeRootFs, NewUnionOSRootFs,
 		NewAnolisRootFs, NewRockyRootFs, NewOpenCloudOsRootFs, NewAlmaLinuxRootFs,
 		NewOpenKylinRootfs, NewUOSDesktopRootfs,
 		NewGalaxyKylinRootFs, NewNeoKylinRootFs,

--- a/pkg/hostman/guestfs/fsdriver/openruyi.go
+++ b/pkg/hostman/guestfs/fsdriver/openruyi.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsdriver
+
+import (
+	"strings"
+
+	"yunion.io/x/jsonutils"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/types"
+	deployapi "yunion.io/x/onecloud/pkg/hostman/hostdeployer/apis"
+)
+
+type SOpenRuyiRootFs struct {
+	*sRedhatLikeRootFs
+}
+
+func NewOpenRuyiRootFs(part IDiskPartition) IRootFsDriver {
+	return &SOpenRuyiRootFs{sRedhatLikeRootFs: newRedhatLikeRootFs(part)}
+}
+
+func (d *SOpenRuyiRootFs) GetName() string {
+	return "openRuyi"
+}
+
+func (d *SOpenRuyiRootFs) String() string {
+	return "OpenRuyiRootFs"
+}
+
+func (d *SOpenRuyiRootFs) RootSignatures() []string {
+	sig := d.sLinuxRootFs.RootSignatures()
+	return append([]string{"/etc/os-release", "/usr/lib/rpm/openruyi"}, sig...)
+}
+
+func parseOpenRuyiVersion(osRelease string) string {
+	for _, line := range strings.Split(osRelease, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "VERSION_ID=") {
+			return strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "VERSION_ID=")), `"'`)
+		}
+	}
+	return ""
+}
+
+func (d *SOpenRuyiRootFs) GetReleaseInfo(rootFs IDiskPartition) *deployapi.ReleaseInfo {
+	rel, _ := rootFs.FileGetContents("/etc/os-release", false)
+	return deployapi.NewReleaseInfo(d.GetName(), parseOpenRuyiVersion(string(rel)), d.GetArch(rootFs))
+}
+
+func (d *SOpenRuyiRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics []*types.SServerNic) error {
+	return d.sRedhatLikeRootFs.deployNetworkingScripts(rootFs, nics, d.GetReleaseInfo(rootFs))
+}
+
+func (d *SOpenRuyiRootFs) EnableSerialConsole(rootFs IDiskPartition, sysInfo *jsonutils.JSONDict) error {
+	return d.enableSerialConsoleSystemd(rootFs)
+}
+
+func (d *SOpenRuyiRootFs) DisableSerialConsole(rootFs IDiskPartition) error {
+	d.disableSerialConsoleSystemd(rootFs)
+	return nil
+}

--- a/pkg/hostman/guestfs/fsdriver/openruyi_test.go
+++ b/pkg/hostman/guestfs/fsdriver/openruyi_test.go
@@ -1,0 +1,59 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsdriver
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOpenRuyiRootSignatures(t *testing.T) {
+	driver := NewOpenRuyiRootFs(nil)
+	want := []string{
+		"/etc/os-release",
+		"/usr/lib/rpm/openruyi",
+		"/bin",
+		"/etc",
+		"/boot",
+		"/lib",
+		"/usr",
+	}
+	if got := driver.RootSignatures(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("RootSignatures() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseOpenRuyiVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		osRelease string
+		want      string
+	}{
+		{name: "double quoted", osRelease: "NAME=\"openRuyi\"\nVERSION_ID=\"Creek\"\n", want: "Creek"},
+		{name: "single quoted", osRelease: "VERSION_ID='River'\n", want: "River"},
+		{name: "unquoted", osRelease: "VERSION_ID=Lake\n", want: "Lake"},
+		{name: "whitespace and CRLF", osRelease: "NAME=openRuyi\r\n  VERSION_ID = ignored\r\n VERSION_ID=\"Creek\"  \r\n", want: "Creek"},
+		{name: "similarly named key", osRelease: "BUILD_VERSION_ID=Creek\n", want: ""},
+		{name: "empty value", osRelease: "VERSION_ID=\"\"\n", want: ""},
+		{name: "missing", osRelease: "NAME=\"openRuyi\"\n", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseOpenRuyiVersion(tt.osRelease); got != tt.want {
+				t.Fatalf("parseOpenRuyiVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Cloudpods already supports RISC-V hosts and guests, but the Region usage response does not expose a `riscv64` bucket and host-deployer cannot identify openRuyi guest filesystems. This leaves RISC-V resources out of architecture-specific usage views and prevents openRuyi images from receiving distro-specific guest initialization.

- adds `riscv64` to architecture-specific guest count, CPU, memory, and disk usage;
- adds an openRuyi root filesystem driver selected by `/usr/lib/rpm/openruyi`;
- reads `VERSION_ID` from `/etc/os-release` and reuses the Red Hat-like network and systemd serial-console paths;
- adds unit coverage for root signatures and quoted, unquoted, CRLF, empty, similar-key, and missing release values.

Existing `all`, `x86_64`, and `aarch64` usage results are preserved. The new filesystem driver requires the openRuyi-specific marker, so existing Linux distro detection is not broadened.

<!--
- [x] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

UNKNOWN
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
