### PR TITLE
feat(host): support QEMU 11.0.1 on riscv64

### DIFF
--- a/pkg/hostman/guestman/qemu/qemu.go
+++ b/pkg/hostman/guestman/qemu/qemu.go
@@ -38,6 +38,7 @@ const (
 	Version_9_0_1  Version = "9.0.1"
 	Version_10_0_3 Version = "10.0.3"
 	Version_10_0_7 Version = "10.0.7"
+	Version_11_0_1 Version = "11.0.1"
 )
 
 type Arch string

--- a/pkg/hostman/guestman/qemu/qemu_test.go
+++ b/pkg/hostman/guestman/qemu/qemu_test.go
@@ -44,3 +44,11 @@ func Test_baseOptions(t *testing.T) {
 	assert.Equal("-vnc :5900,password", opt.VNC(5900, true))
 	assert.Equal("-vnc :5900", opt.VNC(5900, false))
 }
+
+func TestQemu1101Riscv64Registered(t *testing.T) {
+	cmd, ok := GetCommand(Version_11_0_1, Arch_riscv64)
+	if assert.True(t, ok) {
+		assert.Equal(t, Version_11_0_1, cmd.GetVersion())
+		assert.Equal(t, Arch_riscv64, cmd.GetArch())
+	}
+}

--- a/pkg/hostman/guestman/qemu/v11_0_1.go
+++ b/pkg/hostman/guestman/qemu/v11_0_1.go
@@ -1,0 +1,25 @@
+package qemu
+
+func init() {
+	RegisterCmd(newCmd_11_0_1_riscv64())
+}
+
+type opt_1101_riscv64 struct {
+	*baseOptions_riscv64
+	*baseOptions_ge_310
+}
+
+func newCmd_11_0_1_riscv64() QemuCommand {
+	return newBaseCommand(
+		Version_11_0_1,
+		Arch_riscv64,
+		newOpt_11_0_1_riscv64(),
+	)
+}
+
+func newOpt_11_0_1_riscv64() QemuOptions {
+	return &opt_1101_riscv64{
+		baseOptions_riscv64: newBaseOptions_riscv64(),
+		baseOptions_ge_310:  newBaseOptionsGE310(),
+	}
+}


### PR DESCRIPTION
Register the QEMU 11.0.1 command implementation for riscv64 hosts.

openRuyi Creek 2026.08 publishes QEMU 11.0.1 as its native system package, so Cloudpods needs an exact version driver instead of replacing the distribution package with a custom QEMU build. The implementation reuses the existing RISC-V and QEMU >=3.1 options and includes a registration test.

Validation: `go test ./pkg/hostman/guestman/qemu`.