### PR TITLE
fix(apigateway): protect session cookie with AES-GCM when SSL is disabled

### DIFF
--- a/pkg/apigateway/clientman/authtoken.go
+++ b/pkg/apigateway/clientman/authtoken.go
@@ -16,12 +16,13 @@ package clientman
 
 import (
 	"bytes"
-	"compress/flate"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/binary"
-	"io"
 	"math/rand"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/pquerna/otp/totp"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/apigateway/options"
@@ -46,10 +48,17 @@ const (
 
 var (
 	privateKey *rsa.PrivateKey
+	// sessionKey protects session cookies with AES-256-GCM when SSL is not
+	// enabled, so flags and tokens in the cookie can not be forged
+	sessionKey []byte
 )
 
 func setPrivateKey(key *rsa.PrivateKey) {
 	privateKey = key
+}
+
+func setSessionKey(key []byte) {
+	sessionKey = key
 }
 
 type SAuthToken struct {
@@ -98,9 +107,12 @@ func (t SAuthToken) Encode() string {
 	encBytes := t.encodeBytes()
 	if privateKey != nil {
 		return EncryptString(encBytes)
-	} else {
-		return compressString(encBytes)
 	}
+	if sessionKey != nil {
+		return encryptSessionString(encBytes)
+	}
+	log.Errorf("clientman: session key not initialized")
+	return ""
 }
 
 func Decode(t string) (*SAuthToken, error) {
@@ -112,9 +124,9 @@ func Decode(t string) (*SAuthToken, error) {
 			return nil, errors.Wrap(err, "decryptString")
 		}
 	} else {
-		tBytes, err = decompressString(t)
+		tBytes, err = decryptSessionString(t)
 		if err != nil {
-			return nil, errors.Wrap(err, "decompressString")
+			return nil, errors.Wrap(err, "decryptSessionString")
 		}
 	}
 	return decodeBytes(tBytes)
@@ -152,36 +164,55 @@ func decodeBytes(tt []byte) (*SAuthToken, error) {
 	return &ret, nil
 }
 
-func compressString(in []byte) string {
-	buf := new(bytes.Buffer)
-	compressor, _ := flate.NewWriter(buf, 9)
-	compressor.Write(in)
-	compressor.Close()
-	return base64.URLEncoding.EncodeToString(buf.Bytes())
-}
-
 func EncryptString(in []byte) string {
 	enc, _ := jwe.Encrypt(in, jwa.RSA1_5, &privateKey.PublicKey, jwa.A128GCM, jwa.Deflate)
 	return string(enc)
 }
 
-func decompressString(in string) ([]byte, error) {
-	inBytes, err := base64.URLEncoding.DecodeString(in)
+func DecryptString(in string) ([]byte, error) {
+	return jwe.Decrypt([]byte(in), jwa.RSA1_5, privateKey)
+}
+
+// encryptSessionString protects the cookie payload with AES-256-GCM when SSL
+// is not enabled, so flags and tokens in the cookie can not be forged.
+func encryptSessionString(in []byte) string {
+	block, err := aes.NewCipher(sessionKey)
+	if err != nil {
+		log.Errorf("clientman: aes.NewCipher: %v", err)
+		return ""
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		log.Errorf("clientman: cipher.NewGCM: %v", err)
+		return ""
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := cryptorand.Read(nonce); err != nil {
+		log.Errorf("clientman: rand nonce: %v", err)
+		return ""
+	}
+	out := gcm.Seal(nonce, nonce, in, nil)
+	return base64.URLEncoding.EncodeToString(out)
+}
+
+func decryptSessionString(in string) ([]byte, error) {
+	raw, err := base64.URLEncoding.DecodeString(in)
 	if err != nil {
 		return nil, errors.Wrap(err, "base64.URLEncoding.DecodeString")
 	}
-	buf := new(bytes.Buffer)
-	decompressor := flate.NewReader(bytes.NewReader(inBytes))
-	_, err = io.Copy(buf, decompressor)
+	block, err := aes.NewCipher(sessionKey)
 	if err != nil {
-		return nil, errors.Wrap(err, "decompress")
+		return nil, errors.Wrap(err, "aes.NewCipher")
 	}
-	decompressor.Close()
-	return buf.Bytes(), nil
-}
-
-func DecryptString(in string) ([]byte, error) {
-	return jwe.Decrypt([]byte(in), jwa.RSA1_5, privateKey)
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, errors.Wrap(err, "cipher.NewGCM")
+	}
+	if len(raw) < gcm.NonceSize() {
+		return nil, errors.Error("ciphertext too short")
+	}
+	nonce, ciphertext := raw[:gcm.NonceSize()], raw[gcm.NonceSize():]
+	return gcm.Open(nil, nonce, ciphertext, nil)
 }
 
 func (t SAuthToken) GetToken(ctx context.Context) (mcclient.TokenCredential, error) {

--- a/pkg/apigateway/clientman/authtoken_test.go
+++ b/pkg/apigateway/clientman/authtoken_test.go
@@ -15,42 +15,77 @@
 package clientman
 
 import (
-	"reflect"
+	cryptorand "crypto/rand"
+	"encoding/base64"
 	"testing"
 )
 
-func TestEncoeDecode(t *testing.T) {
-	SetupTest()
-	token := SAuthToken{
-		token:      `gAAAAABe-gUMAawOPrP-mA4jY6-b1UPalPJw9WlZJVqHZMtc3IBKUOvHTbKm60YyZQtnVBa3O3QDfS2ss5_Xwi_n0L-jfuUstguLHfDyztAvT_IAKupw8YNK0FvJg25LKC4IR3bmDzCNzTwMO-rEeb4ha2e1vkGOwko9GT1Bn-xN7UM2qeEsm5PiLBg0ZTMuv4Jm5RWIXk2K`,
-		verifyTotp: true,
-		enableTotp: false,
-	}
-	et := token.encodeBytes()
-	plainEt := compressString(et)
-	encEt := EncryptString(et)
-	t.Logf("origin token: %s", token.token)
-	t.Logf("plain token: %s (%d)", plainEt, len(plainEt))
-	t.Logf("encrypt token: %s (%d)", encEt, len(encEt))
+var testToken = SAuthToken{
+	token:      `gAAAAABe-gUMAawOPrP-mA4jY6-b1UPalPJw9WlZJVqHZMtc3IBKUOvHTbKm60YyZQtnVBa3O3QDfS2ss5_Xwi_n0L-jfuUstguLHfDyztAvT_IAKupw8YNK0FvJg25LKC4IR3bmDzCNzTwMO-rEeb4ha2e1vkGOwko9GT1Bn-xN7UM2qeEsm5PiLBg0ZTMuv4Jm5RWIXk2K`,
+	verifyTotp: true,
+	enableTotp: false,
+}
 
-	decBytes, err := decompressString(plainEt)
-	if err != nil {
-		t.Fatalf("decompressString fail %s", err)
-	}
-	decBytes2, err := DecryptString(encEt)
+func TestEncodeDecodeRsa(t *testing.T) {
+	SetupTest()
+	encEt := EncryptString(testToken.encodeBytes())
+	decBytes, err := DecryptString(encEt)
 	if err != nil {
 		t.Fatalf("decryptString fail %s", err)
 	}
-
-	if !reflect.DeepEqual(decBytes, decBytes2) {
-		t.Fatalf("decompress and decrypt bytes not equal!")
-	}
-
 	token2, err := decodeBytes(decBytes)
 	if err != nil {
 		t.Fatalf("decodeBytes fail %s", err)
 	}
-	if *token2 != token {
+	if *token2 != testToken {
 		t.Fatalf("token2 != token")
+	}
+}
+
+func setupSessionKey(t *testing.T) {
+	privateKey = nil
+	key := make([]byte, sessionKeySize)
+	if _, err := cryptorand.Read(key); err != nil {
+		t.Fatalf("rand read: %v", err)
+	}
+	setSessionKey(key)
+}
+
+func TestEncodeDecodeSessionKey(t *testing.T) {
+	setupSessionKey(t)
+	enc := testToken.Encode()
+	if enc == "" {
+		t.Fatalf("empty encoded cookie")
+	}
+	token2, err := Decode(enc)
+	if err != nil {
+		t.Fatalf("Decode fail %s", err)
+	}
+	if *token2 != testToken {
+		t.Fatalf("token2 != token")
+	}
+}
+
+func TestDecodeTamperedSessionCookie(t *testing.T) {
+	setupSessionKey(t)
+	enc := testToken.Encode()
+	raw, err := base64.URLEncoding.DecodeString(enc)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	// flip a bit in the ciphertext (GCM auth tag is at the end)
+	raw[len(raw)-1] ^= 0x01
+	tampered := base64.URLEncoding.EncodeToString(raw)
+	if _, err := Decode(tampered); err == nil {
+		t.Fatalf("tampered cookie accepted")
+	}
+}
+
+func TestDecodeForgedPlaintextCookie(t *testing.T) {
+	setupSessionKey(t)
+	// old-style plain (only compressed) cookies must no longer be accepted
+	plain := base64.URLEncoding.EncodeToString(testToken.encodeBytes())
+	if _, err := Decode(plain); err == nil {
+		t.Fatalf("plaintext cookie accepted")
 	}
 }

--- a/pkg/apigateway/clientman/clientman.go
+++ b/pkg/apigateway/clientman/clientman.go
@@ -18,12 +18,15 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"os"
+	"path/filepath"
 
-	"github.com/pkg/errors"
+	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/apigateway/options"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
 )
+
+const sessionKeySize = 32
 
 func InitClient() error {
 	if options.Options.EnableSsl {
@@ -36,9 +39,45 @@ func InitClient() error {
 			return errors.Wrap(err, "decodePrivateKey")
 		}
 		setPrivateKey(privateKey)
+	} else {
+		key, err := loadOrCreateSessionKey(options.Options.SessionKeyFile)
+		if err != nil {
+			return errors.Wrap(err, "loadOrCreateSessionKey")
+		}
+		setSessionKey(key)
 	}
 
 	return nil
+}
+
+// loadOrCreateSessionKey returns the persistent key protecting session
+// cookies when SSL is not enabled. The key is generated on first start and
+// must be shared across apigateway instances.
+func loadOrCreateSessionKey(path string) ([]byte, error) {
+	if len(path) == 0 {
+		return nil, errors.Error("empty session key file path")
+	}
+	keyBytes, err := os.ReadFile(path)
+	if err == nil {
+		if len(keyBytes) != sessionKeySize {
+			return nil, errors.Errorf("invalid session key file %s", path)
+		}
+		return keyBytes, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, errors.Wrapf(err, "os.ReadFile %s", path)
+	}
+	key := make([]byte, sessionKeySize)
+	if _, err := rand.Read(key); err != nil {
+		return nil, errors.Wrap(err, "rand.Read")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, errors.Wrap(err, "MkdirAll")
+	}
+	if err := os.WriteFile(path, key, 0600); err != nil {
+		return nil, errors.Wrapf(err, "os.WriteFile %s", path)
+	}
+	return key, nil
 }
 
 func SetupTest() {

--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -551,7 +551,7 @@ func saveCookie(w http.ResponseWriter, name, val, domain string, expire time.Tim
 		valenc = val
 	}
 	// log.Printf("Set coookie: %s - %s\n", val, valenc)
-	cookie := &http.Cookie{Name: name, Value: valenc, Path: "/", Expires: expire, MaxAge: maxAge, HttpOnly: false}
+	cookie := &http.Cookie{Name: name, Value: valenc, Path: "/", Expires: expire, MaxAge: maxAge, HttpOnly: true}
 
 	if len(domain) > 0 {
 		cookie.Domain = domain
@@ -586,7 +586,7 @@ func getCookie2(r *http.Request, name string, base64 bool) string {
 }
 
 func clearCookie(w http.ResponseWriter, name string, domain string) {
-	cookie := &http.Cookie{Name: name, Expires: time.Now(), Path: "/", MaxAge: -1, HttpOnly: false}
+	cookie := &http.Cookie{Name: name, Expires: time.Now(), Path: "/", MaxAge: -1, HttpOnly: true}
 	if len(domain) > 0 {
 		cookie.Domain = domain
 	}

--- a/pkg/apigateway/options/options.go
+++ b/pkg/apigateway/options/options.go
@@ -40,6 +40,8 @@ type GatewayOptions struct {
 
 	SessionLevelAuthCookie bool `default:"false" help:"YunionAuth cookie is valid during a browser session"`
 
+	SessionKeyFile string `help:"path to the session cookie protection key file, auto generated if missing, must be shared across apigateway instances" default:"/etc/yunion/apigateway/session.key"`
+
 	// 上报非敏感基础信息，帮助软件更加完善
 	DisableReporting bool `default:"false" help:"Reporting data every 24 hours, report data incloud version, os, platform and usages"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

protect session cookie with AES-GCM when SSL is disabled