### PR TITLE
fix(notify): harden verification code generation and verification

### DIFF
--- a/pkg/notify/models/receiver.go
+++ b/pkg/notify/models/receiver.go
@@ -849,6 +849,19 @@ func (r *SReceiver) PerformVerify(ctx context.Context, userCred mcclient.TokenCr
 		return nil, httperrors.NewForbiddenError("The validation expires, please retrieve the verification code again")
 	}
 	if verification.Token != input.Token {
+		_, err := db.Update(verification, func() error {
+			verification.FailedCount += 1
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "update failed count")
+		}
+		if verification.FailedCount >= options.Options.VerifyMaxAttempts {
+			if err := verification.Delete(ctx, userCred); err != nil {
+				log.Errorf("delete verification %s after too many failed attempts: %v", verification.Id, err)
+			}
+			return nil, errors.Wrap(httperrors.ErrTooManyRequests, "too many failed attempts, please request a new verification code")
+		}
 		return nil, httperrors.NewInputParameterError("wrong token")
 	}
 	_, err = db.Update(r, func() error {
@@ -862,7 +875,14 @@ func (r *SReceiver) PerformVerify(ctx context.Context, userCred mcclient.TokenCr
 		}
 		return nil
 	})
-	return nil, err
+	if err != nil {
+		return nil, err
+	}
+	// the code is single use, remove it so it can not be replayed
+	if err := verification.Delete(ctx, userCred); err != nil {
+		log.Errorf("delete verification %s after verified: %v", verification.Id, err)
+	}
+	return nil, nil
 }
 
 func (r *SReceiver) PerformEnable(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformEnableInput) (jsonutils.JSONObject, error) {

--- a/pkg/notify/models/verify.go
+++ b/pkg/notify/models/verify.go
@@ -16,9 +16,10 @@ package models
 
 import (
 	"context"
+	cryptorand "crypto/rand"
 	"database/sql"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"time"
 
 	"yunion.io/x/pkg/errors"
@@ -53,14 +54,20 @@ type SVerification struct {
 	ReceiverId  string `width:"128" nullable:"false"`
 	ContactType string `width:"16" nullable:"false"`
 	Token       string `width:"200" nullable:"false"`
+
+	FailedCount int `default:"0" nullable:"false"`
 }
 
 var ErrVerifyFrequently = errors.Wrap(httperrors.ErrTooManyRequests, "Send validation messages too frequently")
 
-func (vm *SVerificationManager) generateVerifyToken() string {
-	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
-	token := fmt.Sprintf("%06v", rnd.Int31n(1000000))
-	return token
+// generateVerifyToken generates a cryptographically secure 6-digit
+// verification code.
+func (vm *SVerificationManager) generateVerifyToken() (string, error) {
+	n, err := cryptorand.Int(cryptorand.Reader, big.NewInt(1000000))
+	if err != nil {
+		return "", errors.Wrap(err, "cryptorand.Int")
+	}
+	return fmt.Sprintf("%06d", n.Int64()), nil
 }
 
 func (vm *SVerificationManager) Create(ctx context.Context, receiverId, contactType string) (*SVerification, error) {
@@ -70,12 +77,16 @@ func (vm *SVerificationManager) Create(ctx context.Context, receiverId, contactT
 		return nil, err
 	}
 	if ret == nil {
+		token, err := vm.generateVerifyToken()
+		if err != nil {
+			return nil, err
+		}
 		ret = &SVerification{
 			ReceiverId:  receiverId,
 			ContactType: contactType,
-			Token:       vm.generateVerifyToken(),
+			Token:       token,
 		}
-		err := vm.TableSpec().Insert(ctx, ret)
+		err = vm.TableSpec().Insert(ctx, ret)
 		if err != nil {
 			return nil, err
 		}
@@ -84,10 +95,15 @@ func (vm *SVerificationManager) Create(ctx context.Context, receiverId, contactT
 		if now.Before(ret.CreatedAt.Add(time.Duration(options.Options.VerifyExpireInterval) * time.Minute)) {
 			return nil, ErrVerifyFrequently
 		}
-		_, err := db.Update(ret, func() error {
-			ret.Token = vm.generateVerifyToken()
+		token, err := vm.generateVerifyToken()
+		if err != nil {
+			return nil, err
+		}
+		_, err = db.Update(ret, func() error {
+			ret.Token = token
 			ret.CreatedAt = now
 			ret.UpdatedAt = now
+			ret.FailedCount = 0
 			return nil
 		})
 		if err != nil {

--- a/pkg/notify/models/verify_test.go
+++ b/pkg/notify/models/verify_test.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"testing"
+)
+
+func TestGenerateVerifyToken(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 200; i++ {
+		token, err := VerificationManager.generateVerifyToken()
+		if err != nil {
+			t.Fatalf("generateVerifyToken: %v", err)
+		}
+		if len(token) != 6 {
+			t.Fatalf("token length %d, want 6", len(token))
+		}
+		for _, c := range token {
+			if c < '0' || c > '9' {
+				t.Fatalf("token %q contains non-digit", token)
+			}
+		}
+		if seen[token] {
+			t.Fatalf("duplicate token %q generated within 200 draws", token)
+		}
+		seen[token] = true
+	}
+}

--- a/pkg/notify/options/options.go
+++ b/pkg/notify/options/options.go
@@ -34,6 +34,7 @@ type NotifyOption struct {
 
 	VerifyExpireInterval int `help:"expire interval of verify message; minutes" default:"2"`
 	VerifyValidInterval  int `help:"valid interval of verify message; miniutes" default:"20"`
+	VerifyMaxAttempts    int `help:"maximal failed attempts before a verification code is invalidated" default:"5"`
 
 	SyncReceiverIntervalMinutes int  `help:"interval to sync receivers from keystone, in minutes" default:"30"`
 	EnableWatchUser             bool `help:"use etcd to watch user" default:"false"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Login by phone/email verification code (`verify` auth method) was vulnerable to two issues:

1. The 6-digit code was generated with time-seeded `math/rand`, whose state can be recovered by observing outputs, making codes predictable.
2. `PerformVerify` had no attempt limit, so the code could be brute-forced online through the unauthenticated `/v3/auth/tokens` endpoint within the 20-minute validity window, and a valid code could be replayed until expiry.

This PR:

1. Generates codes with `crypto/rand`.
2. Counts failed attempts per verification record and invalidates (deletes) the code after `verify_max_attempts` failures (new option, default 5), returning 429.
3. Deletes the verification record after a successful check, making codes single use.
4. Adds unit tests for code generation.

The existing 2-minute regeneration interval (`ErrVerifyFrequently`) and 20-minute validity window are unchanged.

**Does this PR introduce a user-facing change?**:

```release-note
notify: verification codes are cryptographically random, limited to 5 attempts and single use
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)