### PR TITLE
fix(webconsole): generate session key with crypto/rand

### DIFF
--- a/pkg/webconsole/session/session.go
+++ b/pkg/webconsole/session/session.go
@@ -16,8 +16,9 @@ package session
 
 import (
 	"context"
+	cryptorand "crypto/rand"
+	"encoding/base64"
 	"fmt"
-	"math/rand"
 	"net/url"
 	"path/filepath"
 	"reflect"
@@ -43,7 +44,16 @@ var (
 
 func init() {
 	Manager = NewSessionManager()
-	AES_KEY = fmt.Sprintf("webconsole-%f", rand.Float32())
+	// the key encrypts all console session tokens of this process; it must
+	// be cryptographically unpredictable (previously it was derived from
+	// rand.Float32 with only ~24 bits of entropy and could be brute forced
+	// offline to forge session tokens). Sessions live in process memory
+	// only, so a per-process random key is sufficient.
+	keyBytes := make([]byte, 32)
+	if _, err := cryptorand.Read(keyBytes); err != nil {
+		log.Fatalf("generate session key: %v", err)
+	}
+	AES_KEY = base64.URLEncoding.EncodeToString(keyBytes)
 }
 
 type SSessionManager struct {

--- a/pkg/webconsole/session/session_key_test.go
+++ b/pkg/webconsole/session/session_key_test.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSessionKeyIsRandom(t *testing.T) {
+	if len(AES_KEY) < 32 {
+		t.Fatalf("AES_KEY too short: %d", len(AES_KEY))
+	}
+	if strings.HasPrefix(AES_KEY, "webconsole-") {
+		t.Fatalf("AES_KEY still uses the legacy weak format")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The AES key encrypting all console session tokens (VNC/SPICE/WebSocket/RDP) was derived from `rand.Float32()` with only ~24 bits of entropy. An attacker with one known (session id, token) pair — e.g. from their own console session — could brute force the process-wide key offline in minutes and forge access tokens for arbitrary sessions.

This PR generates the key from 32 `crypto/rand` bytes (base64url encoded, ~192 bits of effective entropy after key derivation truncation). Sessions live in process memory only, so a per-process random key is sufficient — no persistence or cross-instance sharing is needed.

**Does this PR introduce a user-facing change?**:

```release-note
webconsole: session token encryption key is now generated with crypto/rand
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)