### PR TITLE
fix(webconsole): validate ssh target ip against accessible resources

### DIFF
--- a/pkg/webconsole/service/handlers.go
+++ b/pkg/webconsole/service/handlers.go
@@ -259,8 +259,14 @@ func handleSshShell(ctx context.Context, w http.ResponseWriter, r *http.Request)
 			return
 		}
 	} else {
-		// directly ssh IP should be deprecated gradually
-		sshConnInfo.IP = idStr
+		// directly ssh IP: only allow ips belonging to hosts or servers
+		// accessible by the user, so the console can not be used to dial
+		// arbitrary internal addresses
+		err = session.ResolveSSHIPPortByIp(ctx, env.ClientSessin, idStr, sshConnInfo.Port, &sshConnInfo)
+		if err != nil {
+			httperrors.GeneralServerError(ctx, w, err)
+			return
+		}
 	}
 	s := session.NewSshSession(ctx, env.ClientSessin, sshConnInfo)
 	handleSshSession(ctx, s, w)

--- a/pkg/webconsole/session/resolve_sshinfo.go
+++ b/pkg/webconsole/session/resolve_sshinfo.go
@@ -125,6 +125,54 @@ func resolveServerIPPortById(ctx context.Context, s *mcclient.ClientSession, id 
 	return ip, port, guestDetails, nil
 }
 
+// ResolveSSHIPPortByIp validates that the ip belongs to a host or server
+// accessible by the user and fills the connection info accordingly, so the
+// ssh console can not be used to dial arbitrary internal addresses.
+func ResolveSSHIPPortByIp(ctx context.Context, s *mcclient.ClientSession, ip string, port int, conn *SSshConnectionInfo) error {
+	if port <= 0 {
+		port = 22
+	}
+	// try hosts first: the ip must be the access_ip of a host visible to
+	// the user
+	hostQuery := jsonutils.NewDict()
+	hostQuery.Set("any_ip", jsonutils.NewStringArray([]string{ip}))
+	hostRes, err := compute.Hosts.List(s, hostQuery)
+	if err == nil && hostRes.Total > 0 {
+		hostDetails := compute_api.HostDetails{}
+		if err := hostRes.Data[0].Unmarshal(&hostDetails); err != nil {
+			return errors.Wrap(err, "Unmarshal host details")
+		}
+		conn.IP = hostDetails.AccessIp
+		conn.Port = port
+		conn.HostDetails = &hostDetails
+		return nil
+	}
+	// then servers: only servers visible to the user are listed
+	serverQuery := jsonutils.NewDict()
+	serverQuery.Set("ip_addrs", jsonutils.NewStringArray([]string{ip}))
+	serverRes, err := compute.Servers.List(s, serverQuery)
+	if err != nil {
+		return errors.Wrap(err, "Servers.List")
+	}
+	if serverRes.Total == 0 {
+		return errors.Wrapf(httperrors.ErrNotFound, "no server or host found with ip %s", ip)
+	}
+	serverDetails := compute_api.ServerDetails{}
+	if err := serverRes.Data[0].Unmarshal(&serverDetails); err != nil {
+		return errors.Wrap(err, "Unmarshal server details")
+	}
+	// resolve via the standard server path, which also validates the ip
+	// against the server's network interfaces
+	resolvedIp, resolvedPort, guestDetails, err := resolveServerIPPortById(ctx, s, serverDetails.Id, ip, port)
+	if err != nil {
+		return err
+	}
+	conn.IP = resolvedIp
+	conn.Port = resolvedPort
+	conn.GuestDetails = guestDetails
+	return nil
+}
+
 func ResolveHostSSHIPPortById(ctx context.Context, s *mcclient.ClientSession, id string, ip string, port int) (string, int, *compute_api.HostDetails, error) {
 	if port <= 0 {
 		port = 22


### PR DESCRIPTION
**What this PR does / why we need it**:

The ssh console endpoint (`/webconsole/ssh/<ip>`) accepted a raw IP address in the URL path and dialed it directly with user-provided credentials. Any authenticated user could use the webconsole service as an internal SSH proxy (interactive shell on any reachable host accepting the credentials), a port-scan oracle and a credential brute-forcer against internal services.

This PR resolves the IP against resources visible to the **user's own session** before dialing:

1. Hosts: the IP must match the `access_ip` of a host the user can see.
2. Servers: the IP must match `ip_addr` of a server in the user's scope, and the request then goes through the standard `resolveServerIPPortById` path which additionally validates the IP against the server's NIC/EIP addresses and handles port forwarding.

If the IP matches nothing the user can access, the request is rejected with 404.

Access to the user's own servers and hosts by IP keeps working; only unowned/arbitrary addresses are now rejected.

**Does this PR introduce a user-facing change?**:

```release-note
webconsole: ssh console by ip is restricted to hosts and servers accessible by the user
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)