### PR TITLE
fix: apigateway returns cors_hosts to browser

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -155,6 +155,7 @@ func (h *AuthHandlers) GetRegionsResponse(ctx context.Context, w http.ResponseWr
 		Idps:              []agapi.SIdp{},
 		EncryptPasswd:     true,
 		ApiServer:         options.Options.ApiServer,
+		CorsHosts:         options.Options.CorsHosts,
 	}
 
 	s := auth.GetAdminSession(ctx, regions[0])

--- a/pkg/apis/apigateway/regions.go
+++ b/pkg/apis/apigateway/regions.go
@@ -33,4 +33,6 @@ type SRegionsReponse struct {
 	EncryptPasswd bool `json:"encrypt_passwd"`
 
 	ApiServer string `json:"api_server,allowempty"`
+
+	CorsHosts []string `json:"cors_hosts,allowempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: apigateway returns cors_hosts to browser

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/4.0

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @zexi 