### PR TITLE
Automated cherry pick of #25492: fix: apigateway returns cors_hosts to browser

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -155,6 +155,7 @@ func (h *AuthHandlers) GetRegionsResponse(ctx context.Context, w http.ResponseWr
 		Idps:              []agapi.SIdp{},
 		EncryptPasswd:     true,
 		ApiServer:         options.Options.ApiServer,
+		CorsHosts:         options.Options.CorsHosts,
 	}
 
 	s := auth.GetAdminSession(ctx, regions[0])

--- a/pkg/apis/apigateway/regions.go
+++ b/pkg/apis/apigateway/regions.go
@@ -33,4 +33,6 @@ type SRegionsReponse struct {
 	EncryptPasswd bool `json:"encrypt_passwd"`
 
 	ApiServer string `json:"api_server,allowempty"`
+
+	CorsHosts []string `json:"cors_hosts,allowempty"`
 }


### PR DESCRIPTION
Cherry pick of #25492 on master.

#25492: fix: apigateway returns cors_hosts to browser