### PR TITLE
Automated cherry pick of #25504: fix(region): esxi fix ip filter onecloud wires

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3326,6 +3326,13 @@ func (hh *SHost) SyncHostVMs(ctx context.Context, userCred mcclient.TokenCredent
 func (hh *SHost) getNetworkOfIPOnHost(ctx context.Context, ipAddr string) (*SNetwork, error) {
 	netInterfaces := hh.GetHostNetInterfaces()
 	for _, netInterface := range netInterfaces {
+		if hh.HostType == api.HOST_TYPE_ESXI {
+			if wire := netInterface.GetWire(); wire != nil {
+				if wire.GetProviderName() != api.CLOUD_PROVIDER_VMWARE {
+					continue
+				}
+			}
+		}
 		network, err := netInterface.GetCandidateNetworkForIp(ctx, nil, nil, rbacscope.ScopeNone, ipAddr)
 		if err == nil && network != nil {
 			return network, nil


### PR DESCRIPTION
Cherry pick of #25504 on release/4.0.4.

#25504: fix(region): esxi fix ip filter onecloud wires