### PR TITLE
fix(apigateway): always encrypt the session cookie with the private key

### DIFF
--- a/pkg/apigateway/clientman/authtoken.go
+++ b/pkg/apigateway/clientman/authtoken.go
@@ -16,12 +16,10 @@ package clientman
 
 import (
 	"bytes"
-	"compress/flate"
 	"context"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/binary"
-	"io"
 	"math/rand"
 	"time"
 
@@ -31,6 +29,7 @@ import (
 	"github.com/pquerna/otp/totp"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/apigateway/options"
@@ -96,26 +95,21 @@ func (t SAuthToken) encodeBytes() []byte {
 
 func (t SAuthToken) Encode() string {
 	encBytes := t.encodeBytes()
-	if privateKey != nil {
-		return EncryptString(encBytes)
-	} else {
-		return compressString(encBytes)
+	if privateKey == nil {
+		// never emit an unprotected cookie
+		log.Errorf("clientman: private key not initialized, refuse to encode cookie")
+		return ""
 	}
+	return EncryptString(encBytes)
 }
 
 func Decode(t string) (*SAuthToken, error) {
-	var tBytes []byte
-	var err error
-	if privateKey != nil {
-		tBytes, err = DecryptString(t)
-		if err != nil {
-			return nil, errors.Wrap(err, "decryptString")
-		}
-	} else {
-		tBytes, err = decompressString(t)
-		if err != nil {
-			return nil, errors.Wrap(err, "decompressString")
-		}
+	if privateKey == nil {
+		return nil, errors.Error("private key not initialized")
+	}
+	tBytes, err := DecryptString(t)
+	if err != nil {
+		return nil, errors.Wrap(err, "decryptString")
 	}
 	return decodeBytes(tBytes)
 }
@@ -152,32 +146,9 @@ func decodeBytes(tt []byte) (*SAuthToken, error) {
 	return &ret, nil
 }
 
-func compressString(in []byte) string {
-	buf := new(bytes.Buffer)
-	compressor, _ := flate.NewWriter(buf, 9)
-	compressor.Write(in)
-	compressor.Close()
-	return base64.URLEncoding.EncodeToString(buf.Bytes())
-}
-
 func EncryptString(in []byte) string {
 	enc, _ := jwe.Encrypt(in, jwa.RSA1_5, &privateKey.PublicKey, jwa.A128GCM, jwa.Deflate)
 	return string(enc)
-}
-
-func decompressString(in string) ([]byte, error) {
-	inBytes, err := base64.URLEncoding.DecodeString(in)
-	if err != nil {
-		return nil, errors.Wrap(err, "base64.URLEncoding.DecodeString")
-	}
-	buf := new(bytes.Buffer)
-	decompressor := flate.NewReader(bytes.NewReader(inBytes))
-	_, err = io.Copy(buf, decompressor)
-	if err != nil {
-		return nil, errors.Wrap(err, "decompress")
-	}
-	decompressor.Close()
-	return buf.Bytes(), nil
 }
 
 func DecryptString(in string) ([]byte, error) {

--- a/pkg/apigateway/clientman/authtoken_test.go
+++ b/pkg/apigateway/clientman/authtoken_test.go
@@ -15,42 +15,91 @@
 package clientman
 
 import (
-	"reflect"
+	"bytes"
+	"compress/flate"
+	"encoding/base64"
 	"testing"
+
+	"yunion.io/x/onecloud/pkg/apigateway/options"
 )
 
-func TestEncoeDecode(t *testing.T) {
+var testToken = SAuthToken{
+	token:      `gAAAAABe-gUMAawOPrP-mA4jY6-b1UPalPJw9WlZJVqHZMtc3IBKUOvHTbKm60YyZQtnVBa3O3QDfS2ss5_Xwi_n0L-jfuUstguLHfDyztAvT_IAKupw8YNK0FvJg25LKC4IR3bmDzCNzTwMO-rEeb4ha2e1vkGOwko9GT1Bn-xN7UM2qeEsm5PiLBg0ZTMuv4Jm5RWIXk2K`,
+	verifyTotp: true,
+	enableTotp: false,
+}
+
+func TestEncodeDecode(t *testing.T) {
 	SetupTest()
-	token := SAuthToken{
-		token:      `gAAAAABe-gUMAawOPrP-mA4jY6-b1UPalPJw9WlZJVqHZMtc3IBKUOvHTbKm60YyZQtnVBa3O3QDfS2ss5_Xwi_n0L-jfuUstguLHfDyztAvT_IAKupw8YNK0FvJg25LKC4IR3bmDzCNzTwMO-rEeb4ha2e1vkGOwko9GT1Bn-xN7UM2qeEsm5PiLBg0ZTMuv4Jm5RWIXk2K`,
-		verifyTotp: true,
-		enableTotp: false,
+	enc := testToken.Encode()
+	if enc == "" {
+		t.Fatalf("empty encoded cookie")
 	}
-	et := token.encodeBytes()
-	plainEt := compressString(et)
-	encEt := EncryptString(et)
-	t.Logf("origin token: %s", token.token)
-	t.Logf("plain token: %s (%d)", plainEt, len(plainEt))
-	t.Logf("encrypt token: %s (%d)", encEt, len(encEt))
-
-	decBytes, err := decompressString(plainEt)
+	token2, err := Decode(enc)
 	if err != nil {
-		t.Fatalf("decompressString fail %s", err)
+		t.Fatalf("Decode fail %s", err)
 	}
-	decBytes2, err := DecryptString(encEt)
-	if err != nil {
-		t.Fatalf("decryptString fail %s", err)
-	}
-
-	if !reflect.DeepEqual(decBytes, decBytes2) {
-		t.Fatalf("decompress and decrypt bytes not equal!")
-	}
-
-	token2, err := decodeBytes(decBytes)
-	if err != nil {
-		t.Fatalf("decodeBytes fail %s", err)
-	}
-	if *token2 != token {
+	if *token2 != testToken {
 		t.Fatalf("token2 != token")
+	}
+}
+
+// a tampered cookie must be rejected
+func TestDecodeTampered(t *testing.T) {
+	SetupTest()
+	enc := testToken.Encode()
+	tampered := enc[:len(enc)-8] + "AAAAAAAA"
+	if _, err := Decode(tampered); err == nil {
+		t.Fatalf("tampered cookie accepted")
+	}
+	if _, err := Decode("not-a-jwe-token"); err == nil {
+		t.Fatalf("garbage cookie accepted")
+	}
+}
+
+// cookies in the legacy plain (only flate compressed) format must not be
+// accepted anymore: their content was forgeable
+func TestDecodeLegacyPlainCookieRejected(t *testing.T) {
+	SetupTest()
+	buf := new(bytes.Buffer)
+	compressor, _ := flate.NewWriter(buf, 9)
+	compressor.Write(testToken.encodeBytes())
+	compressor.Close()
+	legacy := base64.URLEncoding.EncodeToString(buf.Bytes())
+	if _, err := Decode(legacy); err == nil {
+		t.Fatalf("legacy plain cookie accepted")
+	}
+}
+
+// without an initialized key no cookie may be emitted or decoded
+func TestNoKeyRefusesCookie(t *testing.T) {
+	saved := privateKey
+	privateKey = nil
+	defer func() { privateKey = saved }()
+
+	if enc := testToken.Encode(); enc != "" {
+		t.Fatalf("cookie emitted without key")
+	}
+	if _, err := Decode("anything"); err == nil {
+		t.Fatalf("decode accepted without key")
+	}
+}
+
+// InitClient must fail when no key file is configured: cookie protection
+// must not silently degrade
+func TestInitClientRequiresKeyFile(t *testing.T) {
+	if options.Options == nil {
+		options.Options = &options.GatewayOptions{}
+	}
+	saved := options.Options.SslKeyfile
+	defer func() { options.Options.SslKeyfile = saved }()
+
+	options.Options.SslKeyfile = ""
+	if err := InitClient(); err == nil {
+		t.Fatalf("InitClient must fail without ssl_keyfile")
+	}
+	options.Options.SslKeyfile = "/nonexistent/key.pem"
+	if err := InitClient(); err == nil {
+		t.Fatalf("InitClient must fail with unreadable ssl_keyfile")
 	}
 }

--- a/pkg/apigateway/clientman/clientman.go
+++ b/pkg/apigateway/clientman/clientman.go
@@ -19,25 +19,31 @@ import (
 	"crypto/rsa"
 	"os"
 
-	"github.com/pkg/errors"
+	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/apigateway/options"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
 )
 
+// InitClient loads the private key used to encrypt and authenticate session
+// cookies. The key is required unconditionally: previously it was only
+// loaded when SSL was enabled, and without it the cookie was only
+// compressed, so its content (keystone token, TOTP flags, retry counters)
+// could be forged. Deployments not serving TLS must still provide
+// ssl_keyfile for cookie protection.
 func InitClient() error {
-	if options.Options.EnableSsl {
-		privData, err := os.ReadFile(options.Options.SslKeyfile)
-		if err != nil {
-			return errors.Wrapf(err, "os.ReadFile %s", options.Options.SslKeyfile)
-		}
-		privateKey, err := seclib2.DecodePrivateKey(privData)
-		if err != nil {
-			return errors.Wrap(err, "decodePrivateKey")
-		}
-		setPrivateKey(privateKey)
+	if len(options.Options.SslKeyfile) == 0 {
+		return errors.Error("ssl_keyfile is required for session cookie encryption")
 	}
-
+	privData, err := os.ReadFile(options.Options.SslKeyfile)
+	if err != nil {
+		return errors.Wrapf(err, "os.ReadFile %s", options.Options.SslKeyfile)
+	}
+	privateKey, err := seclib2.DecodePrivateKey(privData)
+	if err != nil {
+		return errors.Wrap(err, "decodePrivateKey")
+	}
+	setPrivateKey(privateKey)
 	return nil
 }
 

--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -552,7 +552,7 @@ func saveCookie(w http.ResponseWriter, name, val, domain string, expire time.Tim
 		valenc = val
 	}
 	// log.Printf("Set coookie: %s - %s\n", val, valenc)
-	cookie := &http.Cookie{Name: name, Value: valenc, Path: "/", Expires: expire, MaxAge: maxAge, HttpOnly: false}
+	cookie := &http.Cookie{Name: name, Value: valenc, Path: "/", Expires: expire, MaxAge: maxAge, HttpOnly: true}
 
 	if len(domain) > 0 {
 		cookie.Domain = domain
@@ -587,7 +587,7 @@ func getCookie2(r *http.Request, name string, base64 bool) string {
 }
 
 func clearCookie(w http.ResponseWriter, name string, domain string) {
-	cookie := &http.Cookie{Name: name, Expires: time.Now(), Path: "/", MaxAge: -1, HttpOnly: false}
+	cookie := &http.Cookie{Name: name, Expires: time.Now(), Path: "/", MaxAge: -1, HttpOnly: true}
 	if len(domain) > 0 {
 		cookie.Domain = domain
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The session cookie was encrypted (RSA JWE) only when `enable_ssl` was set; without a private key it was merely flate-compressed with no integrity protection. Its content — keystone token, TOTP verified/enabled flags, OTP retry counter and lockout time — could be decoded and forged by anyone, allowing MFA bypass and unlimited OTP brute force.

This is a simplified redo of #25482 without the extra session-key mechanism: the private key from `ssl_keyfile` is now loaded **unconditionally** (independent of `enable_ssl`), the service refuses to start without it, and the plain compressed cookie path is removed entirely. The cookie is also marked `HttpOnly`.

**Behavior notes**:

- Deployments without `ssl_keyfile` configured (including plain HTTP deployments behind a TLS-terminating load balancer) must now provide a key file; apigateway fails to start with a clear error otherwise.
- Cookies issued by older versions are not accepted anymore; users re-login once after upgrade.
- Bonus: the OIDC `SignJWT`/`GetJWKs` endpoints now also work when TLS is served externally.

**Does this PR introduce a user-facing change?**:

```release-note
apigateway: the session cookie is always encrypted and authenticated; ssl_keyfile is now required and users re-login once after upgrade
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)