### PR TITLE
fix(container): validate host bind paths and create host-path files with argv

### DIFF
--- a/pkg/compute/container_drivers/device/host.go
+++ b/pkg/compute/container_drivers/device/host.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 )
 
 func init() {
@@ -57,6 +58,16 @@ func (h hostDevice) ValidateCreateData(ctx context.Context, userCred mcclient.To
 	if host.ContainerPath == "" {
 		return nil, httperrors.NewNotEmptyError("container_path is empty")
 	}
+	hostPath, err := models.ValidateHostBindPath(userCred, host.HostPath)
+	if err != nil {
+		return nil, err
+	}
+	host.HostPath = hostPath
+	ctrPath, err := fileutils2.CleanHostBindPath(host.ContainerPath)
+	if err != nil {
+		return nil, httperrors.NewInputParameterError("container_path: %v", err)
+	}
+	host.ContainerPath = ctrPath
 	if host.Permissions == "" {
 		return nil, httperrors.NewNotEmptyError("permissions is empty")
 	}

--- a/pkg/compute/container_drivers/device/host_test.go
+++ b/pkg/compute/container_drivers/device/host_test.go
@@ -1,0 +1,57 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or authorized to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package device
+
+import (
+	"context"
+	"testing"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/mcclient"
+)
+
+func TestHostDeviceValidateCreateData(t *testing.T) {
+	ctx := context.Background()
+	drv := newHostDevice()
+	tenant := &mcclient.SSimpleToken{User: "u", Project: "p", Roles: "user"}
+	admin := &mcclient.SSimpleToken{User: "admin", Project: "system", Roles: "admin"}
+
+	dev := &api.ContainerDevice{
+		Type: "host",
+		Host: &api.ContainerHostDevice{
+			HostPath:      "/dev/sda",
+			ContainerPath: "/dev/sda",
+			Permissions:   "rwm",
+		},
+	}
+	if _, err := drv.ValidateCreateData(ctx, tenant, nil, dev); err == nil {
+		t.Fatal("expected tenant host device to fail")
+	}
+	if _, err := drv.ValidateCreateData(ctx, admin, nil, dev); err != nil {
+		t.Fatalf("admin host device: %v", err)
+	}
+
+	rel := &api.ContainerDevice{
+		Type: "host",
+		Host: &api.ContainerHostDevice{
+			HostPath:      "sda",
+			ContainerPath: "/dev/sda",
+			Permissions:   "rwm",
+		},
+	}
+	if _, err := drv.ValidateCreateData(ctx, admin, nil, rel); err == nil {
+		t.Fatal("expected relative host_path to fail")
+	}
+}

--- a/pkg/compute/container_drivers/volume_mount/disk.go
+++ b/pkg/compute/container_drivers/volume_mount/disk.go
@@ -77,7 +77,35 @@ func (d disk) validateDiskCreateData(ctx context.Context, userCred mcclient.Toke
 			return nil, httperrors.NewInputParameterError("index is less than 0")
 		}
 	}
+	if err := d.validateDiskRelPaths(disk); err != nil {
+		return nil, err
+	}
 	return disk, nil
+}
+
+func (d disk) validateDiskRelPaths(disk *apis.ContainerVolumeMountDisk) error {
+	if disk.SubDirectory != "" {
+		clean, err := models.ValidateRelSubpath(disk.SubDirectory)
+		if err != nil {
+			return err
+		}
+		disk.SubDirectory = clean
+	}
+	if disk.StorageSizeFile != "" {
+		clean, err := models.ValidateRelSubpath(disk.StorageSizeFile)
+		if err != nil {
+			return err
+		}
+		disk.StorageSizeFile = clean
+	}
+	for i, p := range disk.CaseInsensitivePaths {
+		clean, err := models.ValidateRelSubpath(p)
+		if err != nil {
+			return err
+		}
+		disk.CaseInsensitivePaths[i] = clean
+	}
+	return nil
 }
 
 func (d disk) validateCreateData(ctx context.Context, userCred mcclient.TokenCredential, vm *apis.ContainerVolumeMount) (*apis.ContainerVolumeMount, error) {
@@ -238,6 +266,9 @@ func (d disk) ValidatePodCreateData(ctx context.Context, userCred mcclient.Token
 			return httperrors.NewInputParameterError("valid overlay %v", err)
 		}
 	}
+	if err := d.ValidatePostOverlay(ctx, userCred, vm); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -322,9 +353,11 @@ func (d diskOverlayDir) validateCommonCreateData(ctx context.Context, userCred m
 		if ld == "" {
 			return httperrors.NewNotEmptyError("empty %d dir", idx)
 		}
-		if ld == "/" {
-			return httperrors.NewInputParameterError("can't use '/' as lower_dir")
+		clean, err := models.ValidateHostBindPath(userCred, ld)
+		if err != nil {
+			return err
 		}
+		input.LowerDir[idx] = clean
 	}
 	return nil
 }

--- a/pkg/compute/container_drivers/volume_mount/disk_pov_host_path.go
+++ b/pkg/compute/container_drivers/volume_mount/disk_pov_host_path.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/onecloud/pkg/apis"
+	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
@@ -37,6 +38,18 @@ func (p povHostPath) validateData(ctx context.Context, userCred mcclient.TokenCr
 		if len(hld) == 0 {
 			return httperrors.NewNotEmptyError("host_lower_dir %d is empty", i)
 		}
+		clean, err := models.ValidateHostBindPath(userCred, hld)
+		if err != nil {
+			return err
+		}
+		ov.HostLowerDir[i] = clean
+	}
+	if ov.HostUpperDir != "" {
+		clean, err := models.ValidateHostBindPath(userCred, ov.HostUpperDir)
+		if err != nil {
+			return err
+		}
+		ov.HostUpperDir = clean
 	}
 	if len(ov.ContainerTargetDir) == 0 {
 		return httperrors.NewNotEmptyError("container_target_dir is required")

--- a/pkg/compute/container_drivers/volume_mount/disk_pov_image.go
+++ b/pkg/compute/container_drivers/volume_mount/disk_pov_image.go
@@ -16,12 +16,15 @@ package volume_mount
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/apis"
 	imageapi "yunion.io/x/onecloud/pkg/apis/image"
+	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/compute/options"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -71,15 +74,76 @@ func (p povImage) validateData(ctx context.Context, userCred mcclient.TokenCrede
 	if len(pov.Image.PathMap) == 0 {
 		pov.Image.PathMap = pathMap
 	}
+	if len(pov.Image.PathMap) > 0 {
+		cleanedMap := make(map[string]string, len(pov.Image.PathMap))
+		for k, v := range pov.Image.PathMap {
+			clean, err := cleanPathMapKey(userCred, k)
+			if err != nil {
+				return err
+			}
+			cleanedMap[clean] = v
+		}
+		pov.Image.PathMap = cleanedMap
+	}
 	if len(pov.Image.HostLowerMap) != 0 {
-		for hostPath, _ := range pov.Image.HostLowerMap {
-			_, ok := pov.Image.PathMap[hostPath]
+		cleanedLower := make(map[string]*apis.HostLowerPath, len(pov.Image.HostLowerMap))
+		for hostPath, hlp := range pov.Image.HostLowerMap {
+			clean, err := cleanPathMapKey(userCred, hostPath)
+			if err != nil {
+				return err
+			}
+			_, ok := pov.Image.PathMap[clean]
 			if !ok {
 				return httperrors.NewNotFoundError("host_path %s of host_lower_map doesn't found in path_map", hostPath)
 			}
+			if hlp != nil {
+				pre, err := validateColonSeparatedHostBindPaths(userCred, hlp.PrePath)
+				if err != nil {
+					return err
+				}
+				hlp.PrePath = pre
+				post, err := validateColonSeparatedHostBindPaths(userCred, hlp.PostPath)
+				if err != nil {
+					return err
+				}
+				hlp.PostPath = post
+			}
+			cleanedLower[clean] = hlp
 		}
+		pov.Image.HostLowerMap = cleanedLower
+	}
+	if img.UpperConfig != nil && img.UpperConfig.Disk != nil && img.UpperConfig.Disk.SubPath != "" {
+		clean, err := models.ValidateRelSubpath(img.UpperConfig.Disk.SubPath)
+		if err != nil {
+			return err
+		}
+		img.UpperConfig.Disk.SubPath = clean
 	}
 	return nil
+}
+
+func cleanPathMapKey(userCred mcclient.TokenCredential, k string) (string, error) {
+	rel := strings.TrimPrefix(strings.TrimSpace(k), string(filepath.Separator))
+	return models.ValidateRelSubpath(rel)
+}
+
+func validateColonSeparatedHostBindPaths(userCred mcclient.TokenCredential, pathStr string) (string, error) {
+	if pathStr == "" {
+		return "", nil
+	}
+	parts := strings.Split(pathStr, ":")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		clean, err := models.ValidateHostBindPath(userCred, p)
+		if err != nil {
+			return "", err
+		}
+		out = append(out, clean)
+	}
+	return strings.Join(out, ":"), nil
 }
 
 func (p povImage) getContainerTargetDirs(ov *apis.ContainerVolumeMountDiskPostOverlay) []string {

--- a/pkg/compute/container_drivers/volume_mount/host_local.go
+++ b/pkg/compute/container_drivers/volume_mount/host_local.go
@@ -60,5 +60,10 @@ func (h hostLocal) ValidatePodCreateData(ctx context.Context, userCred mcclient.
 	if hp.Path == "" {
 		return httperrors.NewNotEmptyError("path is required")
 	}
-	return nil
+	clean, err := models.ValidateHostBindPath(userCred, hp.Path)
+	if err != nil {
+		return err
+	}
+	hp.Path = clean
+	return models.ValidateHostPathAutoCreate(hp.AutoCreate, hp.AutoCreateConfig)
 }

--- a/pkg/compute/container_drivers/volume_mount/host_local_test.go
+++ b/pkg/compute/container_drivers/volume_mount/host_local_test.go
@@ -1,0 +1,130 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or authorized to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package volume_mount
+
+import (
+	"context"
+	"testing"
+
+	"yunion.io/x/onecloud/pkg/apis"
+	"yunion.io/x/onecloud/pkg/mcclient"
+)
+
+func TestHostLocalValidatePodCreateData(t *testing.T) {
+	ctx := context.Background()
+	drv := newHostLocal()
+	tenant := &mcclient.SSimpleToken{User: "u", Project: "p", Roles: "user"}
+	admin := &mcclient.SSimpleToken{User: "admin", Project: "system", Roles: "admin"}
+
+	vm := func(path string) *apis.ContainerVolumeMount {
+		return &apis.ContainerVolumeMount{
+			HostPath: &apis.ContainerVolumeMountHostPath{
+				Type: apis.CONTAINER_VOLUME_MOUNT_HOST_PATH_TYPE_DIRECTORY,
+				Path: path,
+			},
+		}
+	}
+
+	if err := drv.ValidatePodCreateData(ctx, tenant, vm("/data/models/Qwen3-8B"), nil); err != nil {
+		t.Fatalf("tenant data path: %v", err)
+	}
+	if err := drv.ValidatePodCreateData(ctx, tenant, vm("/"), nil); err == nil {
+		t.Fatal("expected / to fail")
+	}
+	if err := drv.ValidatePodCreateData(ctx, tenant, vm("/etc/shadow"), nil); err == nil {
+		t.Fatal("expected tenant /etc/shadow to fail")
+	}
+	if err := drv.ValidatePodCreateData(ctx, admin, vm("/etc/shadow"), nil); err != nil {
+		t.Fatalf("admin /etc/shadow: %v", err)
+	}
+
+	badPerm := vm("/data/models/x")
+	badPerm.HostPath.AutoCreate = true
+	badPerm.HostPath.AutoCreateConfig = &apis.ContainerVolumeMountHostPathAutoCreateConfig{
+		Permissions: "755; id",
+	}
+	if err := drv.ValidatePodCreateData(ctx, tenant, badPerm, nil); err == nil {
+		t.Fatal("expected tenant auto_create to fail")
+	}
+	if err := drv.ValidatePodCreateData(ctx, admin, badPerm, nil); err == nil {
+		t.Fatal("expected invalid permissions to fail")
+	}
+
+	okPerm := vm("/data/models/x")
+	okPerm.HostPath.AutoCreate = true
+	okPerm.HostPath.AutoCreateConfig = &apis.ContainerVolumeMountHostPathAutoCreateConfig{
+		Permissions: "0755",
+	}
+	if err := drv.ValidatePodCreateData(ctx, admin, okPerm, nil); err != nil {
+		t.Fatalf("admin auto_create: %v", err)
+	}
+	if okPerm.HostPath.AutoCreateConfig.Permissions != "755" {
+		t.Fatalf("canon permissions %q", okPerm.HostPath.AutoCreateConfig.Permissions)
+	}
+}
+
+func TestDiskRelPathsAndOverlay(t *testing.T) {
+	ctx := context.Background()
+	tenant := &mcclient.SSimpleToken{User: "u", Project: "p", Roles: "user"}
+	d := newDisk().(*disk)
+	idx := 0
+
+	_, err := d.validateDiskCreateData(ctx, tenant, &apis.ContainerVolumeMountDisk{
+		Index:        &idx,
+		SubDirectory: "../../etc",
+	})
+	if err == nil {
+		t.Fatal("expected sub_directory escape to fail")
+	}
+
+	got, err := d.validateDiskCreateData(ctx, tenant, &apis.ContainerVolumeMountDisk{
+		Index:        &idx,
+		SubDirectory: "foo/./bar",
+	})
+	if err != nil {
+		t.Fatalf("valid sub_directory: %v", err)
+	}
+	if got.SubDirectory != "foo/bar" {
+		t.Fatalf("got %q", got.SubDirectory)
+	}
+
+	ov := diskOverlayDir{}
+	input := &apis.ContainerVolumeMountDiskOverlay{LowerDir: []string{"/"}}
+	if err := ov.validateCommonCreateData(ctx, tenant, input); err == nil {
+		t.Fatal("expected overlay / to fail")
+	}
+	input = &apis.ContainerVolumeMountDiskOverlay{LowerDir: []string{"/etc/shadow"}}
+	if err := ov.validateCommonCreateData(ctx, tenant, input); err == nil {
+		t.Fatal("expected overlay /etc/shadow to fail")
+	}
+	input = &apis.ContainerVolumeMountDiskOverlay{LowerDir: []string{"/data/models"}}
+	if err := ov.validateCommonCreateData(ctx, tenant, input); err != nil {
+		t.Fatalf("overlay data path: %v", err)
+	}
+
+	pov := newDiskPostOverlayHostPath()
+	if err := pov.validateData(ctx, tenant, &apis.ContainerVolumeMountDiskPostOverlay{
+		HostLowerDir:       []string{"/etc/shadow"},
+		ContainerTargetDir: "/models",
+	}); err == nil {
+		t.Fatal("expected host_lower_dir /etc/shadow to fail")
+	}
+	if err := pov.validateData(ctx, tenant, &apis.ContainerVolumeMountDiskPostOverlay{
+		HostLowerDir:       []string{"/data/models"},
+		ContainerTargetDir: "/models",
+	}); err != nil {
+		t.Fatalf("host_lower_dir data path: %v", err)
+	}
+}

--- a/pkg/compute/guestdrivers/pod.go
+++ b/pkg/compute/guestdrivers/pod.go
@@ -159,6 +159,32 @@ func (p *SPodDriver) validateContainerData(ctx context.Context, userCred mcclien
 	if err := p.validateContainerVolumeMounts(ctx, userCred, ctr, input); err != nil {
 		return errors.Wrap(err, "validate container volumes")
 	}
+	if err := p.validateContainerDevices(ctx, userCred, ctr, input); err != nil {
+		return errors.Wrap(err, "validate container devices")
+	}
+	return nil
+}
+
+func (p *SPodDriver) validateContainerDevices(ctx context.Context, userCred mcclient.TokenCredential, ctr *api.PodContainerCreateInput, input *api.ServerCreateInput) error {
+	for idx, dev := range ctr.Devices {
+		if err := p.validateContainerDevice(ctx, userCred, dev, input); err != nil {
+			return errors.Wrapf(err, "validate device %d", idx)
+		}
+	}
+	return nil
+}
+
+func (p *SPodDriver) validateContainerDevice(ctx context.Context, userCred mcclient.TokenCredential, dev *api.ContainerDevice, input *api.ServerCreateInput) error {
+	if dev.Type == "" {
+		return httperrors.NewNotEmptyError("type is required")
+	}
+	drv, err := models.GetContainerDeviceDriverWithError(dev.Type)
+	if err != nil {
+		return errors.Wrapf(err, "get container device driver %s", dev.Type)
+	}
+	if err := drv.ValidatePodCreateData(ctx, userCred, dev, input); err != nil {
+		return errors.Wrapf(err, "validate %s create data", dev.Type)
+	}
 	return nil
 }
 

--- a/pkg/compute/models/container_hostpath.go
+++ b/pkg/compute/models/container_hostpath.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or authorized to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"yunion.io/x/onecloud/pkg/apis"
+	"yunion.io/x/onecloud/pkg/httperrors"
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
+)
+
+// ValidateHostBindPath cleans an absolute host bind path and rejects
+// restricted host locations for non-admin callers.
+func ValidateHostBindPath(userCred mcclient.TokenCredential, path string) (string, error) {
+	clean, err := fileutils2.CleanHostBindPath(path)
+	if err != nil {
+		return "", httperrors.NewInputParameterError("%v", err)
+	}
+	if userCred == nil || !userCred.HasSystemAdminPrivilege() {
+		if fileutils2.IsRestrictedHostBindPath(clean) {
+			return "", httperrors.NewForbiddenError("host path %s is not allowed", clean)
+		}
+	}
+	return clean, nil
+}
+
+// ValidateHostPathAutoCreate checks auto-create options for a host bind path.
+func ValidateHostPathAutoCreate(autoCreate bool, cfg *apis.ContainerVolumeMountHostPathAutoCreateConfig) error {
+	if !autoCreate && cfg == nil {
+		return nil
+	}
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Permissions != "" {
+		_, canon, err := fileutils2.ParseUnixFileMode(cfg.Permissions)
+		if err != nil {
+			return httperrors.NewInputParameterError("invalid auto_create permissions: %v", err)
+		}
+		cfg.Permissions = canon
+	}
+	return nil
+}
+
+// ValidateRelSubpath cleans a relative path that must stay inside a parent dir.
+func ValidateRelSubpath(path string) (string, error) {
+	clean, err := fileutils2.CleanRelSubpath(path)
+	if err != nil {
+		return "", httperrors.NewInputParameterError("%v", err)
+	}
+	return clean, nil
+}

--- a/pkg/compute/models/container_hostpath_test.go
+++ b/pkg/compute/models/container_hostpath_test.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or authorized to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"testing"
+
+	"yunion.io/x/onecloud/pkg/apis"
+	"yunion.io/x/onecloud/pkg/mcclient"
+)
+
+func TestValidateHostBindPath(t *testing.T) {
+	tenant := &mcclient.SSimpleToken{User: "u", Project: "p", Roles: "user"}
+	admin := &mcclient.SSimpleToken{User: "admin", Project: "system", Roles: "admin"}
+
+	got, err := ValidateHostBindPath(tenant, "/data/models/Qwen3-8B")
+	if err != nil {
+		t.Fatalf("tenant data path: %v", err)
+	}
+	if got != "/data/models/Qwen3-8B" {
+		t.Fatalf("got %q", got)
+	}
+
+	if _, err := ValidateHostBindPath(tenant, "/"); err == nil {
+		t.Fatal("expected error for /")
+	}
+	if _, err := ValidateHostBindPath(tenant, "/etc/shadow"); err == nil {
+		t.Fatal("expected tenant /etc/shadow to fail")
+	}
+	if _, err := ValidateHostBindPath(admin, "/etc/shadow"); err != nil {
+		t.Fatalf("admin /etc/shadow: %v", err)
+	}
+}
+
+func TestValidateHostPathAutoCreate(t *testing.T) {
+	if err := ValidateHostPathAutoCreate(true, nil); err != nil {
+		t.Fatalf("auto_create: %v", err)
+	}
+
+	cfg := &apis.ContainerVolumeMountHostPathAutoCreateConfig{Permissions: "755; id"}
+	if err := ValidateHostPathAutoCreate(true, cfg); err == nil {
+		t.Fatal("expected invalid permissions to fail")
+	}
+	cfg = &apis.ContainerVolumeMountHostPathAutoCreateConfig{Permissions: "0755"}
+	if err := ValidateHostPathAutoCreate(true, cfg); err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if cfg.Permissions != "755" {
+		t.Fatalf("canon permissions %q", cfg.Permissions)
+	}
+}

--- a/pkg/hostman/container/volume_mount/disk/disk.go
+++ b/pkg/hostman/container/volume_mount/disk/disk.go
@@ -33,6 +33,7 @@ import (
 	"yunion.io/x/onecloud/pkg/hostman/guestman/desc"
 	"yunion.io/x/onecloud/pkg/hostman/storageman"
 	"yunion.io/x/onecloud/pkg/httperrors"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/mountutils"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 )
@@ -86,10 +87,18 @@ func (d disk) getRuntimeMountHostPath(pod volume_mount.IPodInfo, vm *hostapi.Con
 	}
 	diskInput := vm.Disk
 	if diskInput.SubDirectory != "" {
-		return filepath.Join(hostPath, diskInput.SubDirectory), nil
+		joined, err := fileutils2.JoinInside(hostPath, diskInput.SubDirectory)
+		if err != nil {
+			return "", errors.Wrap(err, "sub_directory")
+		}
+		return joined, nil
 	}
 	if diskInput.StorageSizeFile != "" {
-		return filepath.Join(hostPath, diskInput.StorageSizeFile), nil
+		joined, err := fileutils2.JoinInside(hostPath, diskInput.StorageSizeFile)
+		if err != nil {
+			return "", errors.Wrap(err, "storage_size_file")
+		}
+		return joined, nil
 	}
 	return hostPath, nil
 }
@@ -264,12 +273,18 @@ func (d disk) Mount(pod volume_mount.IPodInfo, ctrId string, vm *hostapi.Contain
 
 	vmDisk := vm.Disk
 	if vmDisk.SubDirectory != "" {
-		subDir := filepath.Join(mntPoint, vmDisk.SubDirectory)
+		subDir, err := fileutils2.JoinInside(mntPoint, vmDisk.SubDirectory)
+		if err != nil {
+			return errors.Wrap(err, "sub_directory")
+		}
 		if err := volume_mount.EnsureDir(subDir); err != nil {
 			return errors.Wrapf(err, "make sub_directory %s inside %s", vmDisk.SubDirectory, mntPoint)
 		}
 		for _, cd := range vmDisk.CaseInsensitivePaths {
-			cdp := filepath.Join(subDir, cd)
+			cdp, err := fileutils2.JoinInside(subDir, cd)
+			if err != nil {
+				return errors.Wrap(err, "case_insensitive_path")
+			}
 			if err := volume_mount.EnsureDir(cdp); err != nil {
 				return errors.Wrapf(err, "make %s inside %s", cdp, vmDisk.SubDirectory)
 			}
@@ -306,11 +321,13 @@ func (d disk) createStorageSizeFile(iDisk storageman.IDisk, mntPoint string, inp
 	if err != nil {
 		return errors.Wrapf(err, "get disk_size from %s", desc.String())
 	}
-	sp := filepath.Join(mntPoint, input.StorageSizeFile)
-	sizeBytes := diskSizeMB * 1024
-	out, err := procutils.NewRemoteCommandAsFarAsPossible("bash", "-c", fmt.Sprintf("echo %d > %s", sizeBytes, sp)).Output()
+	sp, err := fileutils2.JoinInside(mntPoint, input.StorageSizeFile)
 	if err != nil {
-		return errors.Wrapf(err, "write %d to %s: %s", sizeBytes, sp, out)
+		return errors.Wrap(err, "storage_size_file")
+	}
+	sizeBytes := diskSizeMB * 1024
+	if err := volume_mount.WriteFile(sp, fmt.Sprintf("%d\n", sizeBytes)); err != nil {
+		return errors.Wrapf(err, "write %d to %s", sizeBytes, sp)
 	}
 	return nil
 }

--- a/pkg/hostman/container/volume_mount/disk/overlay.go
+++ b/pkg/hostman/container/volume_mount/disk/overlay.go
@@ -25,6 +25,7 @@ import (
 	hostapi "yunion.io/x/onecloud/pkg/apis/host"
 	container_storage "yunion.io/x/onecloud/pkg/hostman/container/storage"
 	"yunion.io/x/onecloud/pkg/hostman/container/volume_mount"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/mountutils"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 )
@@ -55,7 +56,14 @@ func newDiskOverlayDir() iDiskOverlay {
 
 func (dod diskOverlayDir) mount(d disk, pod volume_mount.IPodInfo, ctrId string, vm *hostapi.ContainerVolumeMount) error {
 	vmDisk := vm.Disk
-	lowerDir := vmDisk.Overlay.LowerDir
+	lowerDir := make([]string, 0, len(vmDisk.Overlay.LowerDir))
+	for i, p := range vmDisk.Overlay.LowerDir {
+		clean, err := fileutils2.CleanHostBindPath(p)
+		if err != nil {
+			return errors.Wrapf(err, "overlay lower_dir %d", i)
+		}
+		lowerDir = append(lowerDir, clean)
+	}
 	upperDir, err := d.getRuntimeMountHostPath(pod, vm)
 	if err != nil {
 		return errors.Wrap(err, "getRuntimeMountHostPath")

--- a/pkg/hostman/container/volume_mount/disk/post_overlay.go
+++ b/pkg/hostman/container/volume_mount/disk/post_overlay.go
@@ -27,6 +27,7 @@ import (
 	"yunion.io/x/onecloud/pkg/apis"
 	hostapi "yunion.io/x/onecloud/pkg/apis/host"
 	"yunion.io/x/onecloud/pkg/hostman/container/volume_mount"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 )
 
 const (
@@ -70,7 +71,10 @@ func (d disk) GetPostOverlayRootUpperDir(pod volume_mount.IPodInfo, vm *hostapi.
 		if err != nil {
 			return "", errors.Wrap(err, "get host disk root path")
 		}
-		upperDir := filepath.Join(hostPath, vm.Disk.SubDirectory, config.Disk.SubPath)
+		upperDir, err := fileutils2.JoinInsideAll(hostPath, vm.Disk.SubDirectory, config.Disk.SubPath)
+		if err != nil {
+			return "", errors.Wrap(err, "upper config sub_path")
+		}
 		return upperDir, nil
 	}
 	return d.getPostOverlayRootPrefixDir(POST_OVERLAY_PREFIX_UPPER_DIR, pod, vm, ctrId)
@@ -173,9 +177,15 @@ func (d diskPostOverlay) getPostOverlayDirWithPrefix(
 		return "", errors.Wrap(err, "get post overlay root path")
 	}
 
-	workDir := filepath.Join(rootPath, ov.ContainerTargetDir)
+	elem := ov.ContainerTargetDir
 	if ov.FlattenLayers {
-		workDir = filepath.Join(rootPath, strings.ReplaceAll(ov.ContainerTargetDir, "/", "_"))
+		elem = strings.ReplaceAll(ov.ContainerTargetDir, "/", "_")
+	} else {
+		elem = strings.TrimPrefix(elem, string(filepath.Separator))
+	}
+	workDir, err := fileutils2.JoinInside(rootPath, elem)
+	if err != nil {
+		return "", errors.Wrap(err, "container_target_dir")
 	}
 	if ensure {
 		if err := volume_mount.EnsureDir(workDir); err != nil {
@@ -201,7 +211,11 @@ func (d diskPostOverlay) getPostOverlayUpperDir(
 	ensure bool,
 ) (string, error) {
 	if ov.HostUpperDir != "" {
-		return ov.HostUpperDir, nil
+		clean, err := fileutils2.CleanHostBindPath(ov.HostUpperDir)
+		if err != nil {
+			return "", errors.Wrap(err, "host_upper_dir")
+		}
+		return clean, nil
 	}
 	return d.getPostOverlayDirWithPrefix(POST_OVERLAY_PREFIX_UPPER_DIR, pod, ctrId, vm, ov, ensure)
 }
@@ -226,7 +240,11 @@ func (d diskPostOverlay) getPostOverlayMountpoint(pod volume_mount.IPodInfo, ctr
 	}
 	// remove hostPath sub_directory path
 	ctrMountHostPath = strings.TrimSuffix(ctrMountHostPath, vm.Disk.SubDirectory)
-	mergedDir := filepath.Join(ctrMountHostPath, ov.ContainerTargetDir)
+	elem := strings.TrimPrefix(ov.ContainerTargetDir, string(filepath.Separator))
+	mergedDir, err := fileutils2.JoinInside(ctrMountHostPath, elem)
+	if err != nil {
+		return "", errors.Wrap(err, "container_target_dir")
+	}
 	if ensure {
 		if err := volume_mount.EnsureDir(mergedDir); err != nil {
 			return "", errors.Wrap(err, "make merged mountpoint dir")

--- a/pkg/hostman/container/volume_mount/disk/post_overlay_hostpath.go
+++ b/pkg/hostman/container/volume_mount/disk/post_overlay_hostpath.go
@@ -35,6 +35,24 @@ func newPostOverlayHostPath() iDiskPostOverlayDriver {
 	return &postOverlayHostPath{}
 }
 
+func cleanPostOverlayHostPaths(ov *apis.ContainerVolumeMountDiskPostOverlay) error {
+	for i, p := range ov.HostLowerDir {
+		clean, err := fileutils.CleanHostBindPath(p)
+		if err != nil {
+			return errors.Wrapf(err, "host_lower_dir %d", i)
+		}
+		ov.HostLowerDir[i] = clean
+	}
+	if ov.HostUpperDir != "" {
+		clean, err := fileutils.CleanHostBindPath(ov.HostUpperDir)
+		if err != nil {
+			return errors.Wrap(err, "host_upper_dir")
+		}
+		ov.HostUpperDir = clean
+	}
+	return nil
+}
+
 type postOverlayHostPath struct {
 }
 
@@ -154,6 +172,9 @@ func (p postOverlayHostPath) mountSingleFile(singleFilePath string, d diskPostOv
 }
 
 func (p postOverlayHostPath) Mount(d diskPostOverlay, pod volume_mount.IPodInfo, ctrId string, vm *hostapi.ContainerVolumeMount, ov *apis.ContainerVolumeMountDiskPostOverlay) error {
+	if err := cleanPostOverlayHostPaths(ov); err != nil {
+		return err
+	}
 	// 支持单文件挂载
 	singleFilePath := ""
 	if len(ov.HostLowerDir) == 1 && fileutils.IsFile(ov.HostLowerDir[0]) {
@@ -250,6 +271,9 @@ func (p postOverlayHostPath) unmountSingleFile(singleFilePath string, d diskPost
 }
 
 func (p postOverlayHostPath) Unmount(d diskPostOverlay, pod volume_mount.IPodInfo, ctrId string, vm *hostapi.ContainerVolumeMount, ov *apis.ContainerVolumeMountDiskPostOverlay, useLazy bool, cleanLayers bool) error {
+	if err := cleanPostOverlayHostPaths(ov); err != nil {
+		return err
+	}
 	// 支持单文件卸载
 	singleFilePath := ""
 	if len(ov.HostLowerDir) == 1 && fileutils.IsFile(ov.HostLowerDir[0]) {

--- a/pkg/hostman/container/volume_mount/disk/post_overlay_image.go
+++ b/pkg/hostman/container/volume_mount/disk/post_overlay_image.go
@@ -58,7 +58,10 @@ func (i postOverlayImage) getCachedImagePaths(d diskPostOverlay, pod volume_moun
 	result := make(map[string]string)
 	lowerResult := make(map[string]*apis.HostLowerPath)
 	for hostPathSuffix, ctrPath := range img.PathMap {
-		hostPath := filepath.Join(cachedImgDir, hostPathSuffix)
+		hostPath, err := joinCachedImagePath(cachedImgDir, hostPathSuffix)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "path_map key %s", hostPathSuffix)
+		}
 		result[hostPath] = ctrPath
 		hostLowerPath := hostLowerMap[hostPathSuffix]
 		if hostLowerPath != nil {
@@ -66,6 +69,14 @@ func (i postOverlayImage) getCachedImagePaths(d diskPostOverlay, pod volume_moun
 		}
 	}
 	return result, lowerResult, nil
+}
+
+func joinCachedImagePath(cachedImgDir, imagePath string) (string, error) {
+	rel := strings.TrimPrefix(strings.TrimSpace(imagePath), string(filepath.Separator))
+	if rel == "" || rel == "." {
+		return "", errors.Errorf("empty image path")
+	}
+	return fileutils.JoinInside(cachedImgDir, rel)
 }
 
 // parseColonSeparatedPaths 解析冒号分隔的路径字符串，过滤空字符串并返回路径列表
@@ -121,7 +132,10 @@ func (i postOverlayImage) withAction(
 		if err != nil {
 			return errors.Wrap(err, "get host disk root path")
 		}
-		hostUpperDir = filepath.Join(hostPath, vm.Disk.SubDirectory, config.Disk.SubPath)
+		hostUpperDir, err = fileutils.JoinInsideAll(hostPath, vm.Disk.SubDirectory, config.Disk.SubPath)
+		if err != nil {
+			return errors.Wrap(err, "upper config sub_path")
+		}
 		if !fileutils.Exists(hostUpperDir) {
 			if err := volume_mount.EnsureDir(hostUpperDir); err != nil {
 				return errors.Wrapf(err, "ensure dir %s", hostUpperDir)

--- a/pkg/hostman/container/volume_mount/disk/post_overlay_image_test.go
+++ b/pkg/hostman/container/volume_mount/disk/post_overlay_image_test.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"testing"
+)
+
+func TestJoinCachedImagePath(t *testing.T) {
+	base := "/opt/cloud/workspace/image_cache/img1"
+	got, err := joinCachedImagePath(base, "/Qwen3.8-27B-NVFP4")
+	if err != nil {
+		t.Fatalf("abs key: %v", err)
+	}
+	if got != base+"/Qwen3.8-27B-NVFP4" {
+		t.Fatalf("got %q", got)
+	}
+	got, err = joinCachedImagePath(base, "Qwen3.8-27B-NVFP4")
+	if err != nil {
+		t.Fatalf("rel key: %v", err)
+	}
+	if got != base+"/Qwen3.8-27B-NVFP4" {
+		t.Fatalf("got %q", got)
+	}
+	if _, err := joinCachedImagePath(base, "../etc"); err == nil {
+		t.Fatal("expected escape to fail")
+	}
+	if _, err := joinCachedImagePath(base, "/"); err == nil {
+		t.Fatal("expected root key to fail")
+	}
+}

--- a/pkg/hostman/container/volume_mount/helper.go
+++ b/pkg/hostman/container/volume_mount/helper.go
@@ -16,6 +16,7 @@ package volume_mount
 
 import (
 	"fmt"
+	"io"
 
 	"yunion.io/x/pkg/errors"
 
@@ -80,6 +81,39 @@ func CopyFile(src, dst string) error {
 	out, err := procutils.NewRemoteCommandAsFarAsPossible("cp", src, dst).Output()
 	if err != nil {
 		return errors.Wrapf(err, "cp %s %s: %s", src, dst, string(out))
+	}
+	return nil
+}
+
+func Chmod(path string, mode string) error {
+	out, err := procutils.NewRemoteCommandAsFarAsPossible("chmod", mode, path).Output()
+	if err != nil {
+		return errors.Wrapf(err, "chmod %s %s: %s", mode, path, string(out))
+	}
+	return nil
+}
+
+func WriteFile(path string, content string) error {
+	cmd := procutils.NewRemoteCommandAsFarAsPossible("tee", path)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return errors.Wrapf(err, "stdin pipe for tee %s", path)
+	}
+	if err := cmd.Start(); err != nil {
+		stdin.Close()
+		return errors.Wrapf(err, "start tee %s", path)
+	}
+	if _, err := io.WriteString(stdin, content); err != nil {
+		stdin.Close()
+		_ = cmd.Kill()
+		return errors.Wrapf(err, "write tee %s", path)
+	}
+	if err := stdin.Close(); err != nil {
+		_ = cmd.Kill()
+		return errors.Wrapf(err, "close stdin tee %s", path)
+	}
+	if err := cmd.Wait(); err != nil {
+		return errors.Wrapf(err, "tee %s", path)
 	}
 	return nil
 }

--- a/pkg/hostman/container/volume_mount/host_path.go
+++ b/pkg/hostman/container/volume_mount/host_path.go
@@ -15,7 +15,7 @@
 package volume_mount
 
 import (
-	"fmt"
+	"os"
 	"path/filepath"
 
 	"yunion.io/x/pkg/errors"
@@ -23,6 +23,7 @@ import (
 	"yunion.io/x/onecloud/pkg/apis"
 	hostapi "yunion.io/x/onecloud/pkg/apis/host"
 	"yunion.io/x/onecloud/pkg/httperrors"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 )
 
@@ -56,6 +57,11 @@ func (h hostLocal) GetRuntimeMountHostPath(pod IPodInfo, ctrId string, vm *hosta
 	if vm.FsUser != nil || vm.FsGroup != nil {
 		return "", httperrors.NewInputParameterError("cannot use fs_user and fs_group for host_local volume")
 	}
+	clean, err := fileutils2.CleanHostBindPath(host.Path)
+	if err != nil {
+		return "", httperrors.NewInputParameterError("%v", err)
+	}
+	host.Path = clean
 	switch host.Type {
 	case "", apis.CONTAINER_VOLUME_MOUNT_HOST_PATH_TYPE_FILE:
 		return h.getFilePath(host)
@@ -66,89 +72,83 @@ func (h hostLocal) GetRuntimeMountHostPath(pod IPodInfo, ctrId string, vm *hosta
 }
 
 func (h hostLocal) getFilePath(input *apis.ContainerVolumeMountHostPath) (string, error) {
-	if input.Type != apis.CONTAINER_VOLUME_MOUNT_HOST_PATH_TYPE_FILE {
+	if input.Type != "" && input.Type != apis.CONTAINER_VOLUME_MOUNT_HOST_PATH_TYPE_FILE {
 		return "", httperrors.NewInputParameterError("unsupported type %q", input.Type)
 	}
-	filePath := input.Path
-
-	// 检查文件是否存在
-	checkCmd := fmt.Sprintf("test -f '%s'", filePath)
-	if _, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", checkCmd).Output(); err != nil {
-		// 文件不存在，需要创建
-		if !input.AutoCreate {
-			return "", errors.Wrapf(err, "file %s does not exist and no auto_create specified", filePath)
-		}
-
-		// 先确保父目录存在
-		parentDirCmd := fmt.Sprintf("mkdir -p '%s'", filepath.Dir(filePath))
-		if out, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", parentDirCmd).Output(); err != nil {
-			return "", errors.Wrapf(err, "create parent directory for %s: %s", filePath, out)
-		}
-
-		// 创建文件
-		createCmd := fmt.Sprintf("touch '%s'", filePath)
-		if out, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", createCmd).Output(); err != nil {
-			return "", errors.Wrapf(err, "create file %s: %s", filePath, out)
-		}
-
-		if input.AutoCreateConfig != nil {
-			// 设置权限
-			if input.AutoCreateConfig.Permissions != "" {
-				chmodCmd := fmt.Sprintf("chmod %s '%s'", input.AutoCreateConfig.Permissions, filePath)
-				if out, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", chmodCmd).Output(); err != nil {
-					return "", errors.Wrapf(err, "chmod %s %s: %s", input.AutoCreateConfig.Permissions, filePath, out)
-				}
-			}
-
-			// 设置所有者
-			if input.AutoCreateConfig.Uid > 0 || input.AutoCreateConfig.Gid > 0 {
-				chownCmd := fmt.Sprintf("chown %d:%d '%s'", input.AutoCreateConfig.Uid, input.AutoCreateConfig.Gid, filePath)
-				if out, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", chownCmd).Output(); err != nil {
-					return "", errors.Wrapf(err, "chown %d:%d %s: %s", input.AutoCreateConfig.Uid, input.AutoCreateConfig.Gid, filePath, out)
-				}
-			}
-		}
+	if err := h.ensureHostPath(input.Path, false, input); err != nil {
+		return "", err
 	}
-
-	return filePath, nil
+	return input.Path, nil
 }
 
 func (h hostLocal) getDirectoryPath(input *apis.ContainerVolumeMountHostPath) (string, error) {
 	if input.Type != apis.CONTAINER_VOLUME_MOUNT_HOST_PATH_TYPE_DIRECTORY {
 		return "", httperrors.NewInputParameterError("unsupported type %q", input.Type)
 	}
-	dirPath := input.Path
+	if err := h.ensureHostPath(input.Path, true, input); err != nil {
+		return "", err
+	}
+	return input.Path, nil
+}
 
-	// 检查目录是否存在
-	checkCmd := fmt.Sprintf("test -d '%s'", dirPath)
-	if _, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", checkCmd).Output(); err != nil {
+func (h hostLocal) ensureHostPath(path string, isDir bool, input *apis.ContainerVolumeMountHostPath) error {
+	fi, err := procutils.RemoteStat(path)
+	if err != nil {
+		if errors.Cause(err) != os.ErrNotExist {
+			return errors.Wrapf(err, "stat %s", path)
+		}
 		if !input.AutoCreate {
-			return "", errors.Wrapf(err, "dir %s does not exist and no auto_create specified", dirPath)
+			return errors.Wrapf(err, "path %s does not exist and auto_create is not set", path)
 		}
-		// 创建目录
-		createCmd := fmt.Sprintf("mkdir -p '%s'", dirPath)
-		if out, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", createCmd).Output(); err != nil {
-			return "", errors.Wrapf(err, "create directory %s: %s", dirPath, out)
+		if isDir {
+			if err := EnsureDir(path); err != nil {
+				return err
+			}
+		} else {
+			if err := EnsureDir(filepath.Dir(path)); err != nil {
+				return errors.Wrapf(err, "create parent directory for %s", path)
+			}
+			if err := TouchFile(path); err != nil {
+				return err
+			}
 		}
+		return applyHostPathAutoCreateConfig(path, input.AutoCreateConfig)
+	}
+	if isDir && !fi.IsDir() {
+		return httperrors.NewInputParameterError("%s is not a directory", path)
+	}
+	if !isDir && fi.IsDir() {
+		return httperrors.NewInputParameterError("%s is a directory", path)
+	}
+	return nil
+}
 
-		if input.AutoCreateConfig != nil {
-			// 设置权限
-			if input.AutoCreateConfig.Permissions != "" {
-				chmodCmd := fmt.Sprintf("chmod %s '%s'", input.AutoCreateConfig.Permissions, dirPath)
-				if out, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", chmodCmd).Output(); err != nil {
-					return "", errors.Wrapf(err, "chmod %s %s: %s", input.AutoCreateConfig.Permissions, dirPath, out)
-				}
-			}
-
-			// 设置所有者
-			if input.AutoCreateConfig.Uid > 0 || input.AutoCreateConfig.Gid > 0 {
-				chownCmd := fmt.Sprintf("chown %d:%d '%s'", input.AutoCreateConfig.Uid, input.AutoCreateConfig.Gid, dirPath)
-				if out, err := procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", chownCmd).Output(); err != nil {
-					return "", errors.Wrapf(err, "chown %d:%d %s: %s", input.AutoCreateConfig.Uid, input.AutoCreateConfig.Gid, dirPath, out)
-				}
-			}
+func applyHostPathAutoCreateConfig(path string, cfg *apis.ContainerVolumeMountHostPathAutoCreateConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Permissions != "" {
+		_, canon, err := fileutils2.ParseUnixFileMode(cfg.Permissions)
+		if err != nil {
+			return errors.Wrap(err, "permissions")
+		}
+		if err := Chmod(path, canon); err != nil {
+			return err
 		}
 	}
-
-	return dirPath, nil
+	if cfg.Uid > 0 || cfg.Gid > 0 {
+		var uid, gid *int64
+		if cfg.Uid > 0 {
+			u := int64(cfg.Uid)
+			uid = &u
+		}
+		if cfg.Gid > 0 {
+			g := int64(cfg.Gid)
+			gid = &g
+		}
+		if err := ChangeDirOwnerDirectly(path, uid, gid); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/hostman/container/volume_mount/host_path_test.go
+++ b/pkg/hostman/container/volume_mount/host_path_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or authorized to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package volume_mount
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"yunion.io/x/onecloud/pkg/apis"
+	hostapi "yunion.io/x/onecloud/pkg/apis/host"
+)
+
+func TestHostLocalGetRuntimeMountHostPath(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "f")
+	if err := os.WriteFile(filePath, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := hostLocal{}
+	got, err := h.GetRuntimeMountHostPath(nil, "", &hostapi.ContainerVolumeMount{
+		HostPath: &apis.ContainerVolumeMountHostPath{
+			Type: apis.CONTAINER_VOLUME_MOUNT_HOST_PATH_TYPE_FILE,
+			Path: filePath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("existing file: %v", err)
+	}
+	if got != filePath {
+		t.Fatalf("got %q", got)
+	}
+
+	if _, err := h.GetRuntimeMountHostPath(nil, "", &hostapi.ContainerVolumeMount{
+		HostPath: &apis.ContainerVolumeMountHostPath{
+			Type: apis.CONTAINER_VOLUME_MOUNT_HOST_PATH_TYPE_DIRECTORY,
+			Path: "/",
+		},
+	}); err == nil {
+		t.Fatal("expected / to fail")
+	}
+
+	if _, err := h.GetRuntimeMountHostPath(nil, "", &hostapi.ContainerVolumeMount{
+		HostPath: &apis.ContainerVolumeMountHostPath{
+			Type: apis.CONTAINER_VOLUME_MOUNT_HOST_PATH_TYPE_FILE,
+			Path: filepath.Join(dir, "missing"),
+		},
+	}); err == nil {
+		t.Fatal("expected missing file without auto_create to fail")
+	}
+}

--- a/pkg/util/fileutils2/hostpath.go
+++ b/pkg/util/fileutils2/hostpath.go
@@ -1,0 +1,150 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileutils2
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"yunion.io/x/pkg/errors"
+)
+
+var unixFileModeRe = regexp.MustCompile(`^[0-7]{3,4}$`)
+
+var restrictedHostBindPrefixes = []string{
+	"/etc",
+	"/root",
+	"/proc",
+	"/sys",
+	"/boot",
+	"/dev",
+	"/run",
+	"/var/run",
+	"/var/lib",
+	"/usr",
+	"/bin",
+	"/sbin",
+	"/lib",
+	"/lib64",
+}
+
+// CleanHostBindPath returns a cleaned absolute host path suitable for bind-mount.
+// The root filesystem path "/" is rejected.
+func CleanHostBindPath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", errors.Errorf("path is empty")
+	}
+	if !filepath.IsAbs(p) {
+		return "", errors.Errorf("path %q must be absolute", p)
+	}
+	clean := filepath.Clean(p)
+	if !filepath.IsAbs(clean) {
+		return "", errors.Errorf("path %q is not absolute after cleaning", p)
+	}
+	if clean == string(filepath.Separator) {
+		return "", errors.Errorf("path %q is not allowed", p)
+	}
+	return clean, nil
+}
+
+// IsRestrictedHostBindPath reports whether a cleaned absolute path is under a
+// host location that ordinary users must not bind into a container.
+func IsRestrictedHostBindPath(p string) bool {
+	p = filepath.Clean(p)
+	for _, prefix := range restrictedHostBindPrefixes {
+		if p == prefix || strings.HasPrefix(p, prefix+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseUnixFileMode parses a chmod-style octal mode (e.g. "755" or "0755").
+// The returned string is the canonical octal form without a leading zero.
+func ParseUnixFileMode(perm string) (os.FileMode, string, error) {
+	perm = strings.TrimSpace(perm)
+	if perm == "" {
+		return 0, "", errors.Errorf("file mode is empty")
+	}
+	if !unixFileModeRe.MatchString(perm) {
+		return 0, "", errors.Errorf("invalid file mode %q", perm)
+	}
+	v, err := strconv.ParseUint(perm, 8, 32)
+	if err != nil {
+		return 0, "", errors.Wrapf(err, "invalid file mode %q", perm)
+	}
+	if v > 0o777 {
+		return 0, "", errors.Errorf("invalid file mode %q", perm)
+	}
+	return os.FileMode(v), strconv.FormatUint(v, 8), nil
+}
+
+// CleanRelSubpath cleans a relative path and rejects absolute paths or parent
+// directory traversal.
+func CleanRelSubpath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", errors.Errorf("path is empty")
+	}
+	if filepath.IsAbs(p) {
+		return "", errors.Errorf("path %q must be relative", p)
+	}
+	clean := filepath.Clean(p)
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", errors.Errorf("path %q is not allowed", p)
+	}
+	if filepath.IsAbs(clean) {
+		return "", errors.Errorf("path %q must be relative", p)
+	}
+	return clean, nil
+}
+
+// JoinInside joins elem onto base and requires the result to stay inside base.
+func JoinInside(base, elem string) (string, error) {
+	base = filepath.Clean(base)
+	if elem == "" {
+		return base, nil
+	}
+	rel, err := CleanRelSubpath(elem)
+	if err != nil {
+		return "", err
+	}
+	joined := filepath.Join(base, rel)
+	if !IsPathInside(base, joined) {
+		return "", errors.Errorf("path %q escapes %q", elem, base)
+	}
+	return joined, nil
+}
+
+// JoinInsideAll joins elems onto base in order and requires each step to stay
+// inside the previous result.
+func JoinInsideAll(base string, elems ...string) (string, error) {
+	cur := filepath.Clean(base)
+	for _, e := range elems {
+		if e == "" {
+			continue
+		}
+		next, err := JoinInside(cur, e)
+		if err != nil {
+			return "", err
+		}
+		cur = next
+	}
+	return cur, nil
+}

--- a/pkg/util/fileutils2/hostpath_test.go
+++ b/pkg/util/fileutils2/hostpath_test.go
@@ -1,0 +1,124 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileutils2
+
+import (
+	"testing"
+)
+
+func TestCleanHostBindPath(t *testing.T) {
+	got, err := CleanHostBindPath("/data/models/Qwen")
+	if err != nil {
+		t.Fatalf("valid path: %v", err)
+	}
+	if got != "/data/models/Qwen" {
+		t.Fatalf("got %q", got)
+	}
+	got, err = CleanHostBindPath("/data/models/../models/Qwen")
+	if err != nil {
+		t.Fatalf("cleaned path: %v", err)
+	}
+	if got != "/data/models/Qwen" {
+		t.Fatalf("got %q", got)
+	}
+	for _, p := range []string{"", "relative", "/", "/.", "/tmp/../.."} {
+		if _, err := CleanHostBindPath(p); err == nil {
+			t.Fatalf("expected error for %q", p)
+		}
+	}
+}
+
+func TestIsRestrictedHostBindPath(t *testing.T) {
+	for _, p := range []string{"/etc", "/etc/shadow", "/root/.ssh", "/proc/1", "/var/lib/mysql", "/dev/sda"} {
+		if !IsRestrictedHostBindPath(p) {
+			t.Fatalf("%q should be restricted", p)
+		}
+	}
+	for _, p := range []string{"/data/models", "/tmp/foo", "/opt/models", "/mnt/disk", "/home/admin", "/opt/cloud/workspace"} {
+		if IsRestrictedHostBindPath(p) {
+			t.Fatalf("%q should not be restricted", p)
+		}
+	}
+}
+
+func TestParseUnixFileMode(t *testing.T) {
+	mode, canon, err := ParseUnixFileMode("755")
+	if err != nil {
+		t.Fatalf("755: %v", err)
+	}
+	if uint32(mode) != 0o755 || canon != "755" {
+		t.Fatalf("mode=%o canon=%s", mode, canon)
+	}
+	_, canon, err = ParseUnixFileMode("0755")
+	if err != nil {
+		t.Fatalf("0755: %v", err)
+	}
+	if canon != "755" {
+		t.Fatalf("canon=%s", canon)
+	}
+	for _, p := range []string{"", "755; id", "rwx", "999", "12", "0755 extra"} {
+		if _, _, err := ParseUnixFileMode(p); err == nil {
+			t.Fatalf("expected error for %q", p)
+		}
+	}
+}
+
+func TestCleanRelSubpath(t *testing.T) {
+	got, err := CleanRelSubpath("foo/bar")
+	if err != nil {
+		t.Fatalf("valid: %v", err)
+	}
+	if got != "foo/bar" {
+		t.Fatalf("got %q", got)
+	}
+	got, err = CleanRelSubpath("foo/./bar")
+	if err != nil {
+		t.Fatalf("dot: %v", err)
+	}
+	if got != "foo/bar" {
+		t.Fatalf("got %q", got)
+	}
+	for _, p := range []string{"", "/abs", "../etc", "foo/../../etc", ".."} {
+		if _, err := CleanRelSubpath(p); err == nil {
+			t.Fatalf("expected error for %q", p)
+		}
+	}
+}
+
+func TestJoinInside(t *testing.T) {
+	got, err := JoinInside("/mnt/disk", "sub/dir")
+	if err != nil {
+		t.Fatalf("join: %v", err)
+	}
+	if got != "/mnt/disk/sub/dir" {
+		t.Fatalf("got %q", got)
+	}
+	if _, err := JoinInside("/mnt/disk", "../etc"); err == nil {
+		t.Fatal("expected escape to fail")
+	}
+	if _, err := JoinInside("/mnt/disk", "/etc"); err == nil {
+		t.Fatal("expected absolute to fail")
+	}
+	got, err = JoinInsideAll("/mnt/disk", "sub", "dir")
+	if err != nil {
+		t.Fatalf("join all: %v", err)
+	}
+	if got != "/mnt/disk/sub/dir" {
+		t.Fatalf("got %q", got)
+	}
+	if _, err := JoinInsideAll("/mnt/disk", "sub", "../.."); err == nil {
+		t.Fatal("expected join all escape to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- Validate container host path, overlay, and disk subdirectory inputs, and rewrite them to cleaned paths.
- Create host-path files and directories with argv helpers, and parse auto_create permissions as octal modes.
- Validate host devices on pod create, and keep relative disk paths inside the disk mount.

## Test plan
- [x] `go test ./pkg/util/fileutils2/ ./pkg/compute/models/ ./pkg/compute/container_drivers/volume_mount/ ./pkg/compute/container_drivers/device/ ./pkg/hostman/container/volume_mount/ ./pkg/compute/guestdrivers/`
- [x] Create a pod with a host path under `/data/...`
- [x] Confirm invalid host paths and auto_create permissions are rejected


Made with [Cursor](https://cursor.com)