### PR TITLE
Automated cherry pick of #25615: fix: classic net distribute default route for default nic

### DIFF
--- a/pkg/hostman/hostinfo/hostdhcp/dhcpserver.go
+++ b/pkg/hostman/hostinfo/hostdhcp/dhcpserver.go
@@ -161,6 +161,9 @@ func (s *SGuestDHCPServer) getGuestConfig(
 	conf.ServerIP = net.ParseIP(v4Ip.NetAddr(int8(masklen)).String())
 	conf.SubnetMask = net.ParseIP(netutils2.Netlen2Mask(int(masklen)))
 	conf.BroadcastAddr = v4Ip.BroadcastAddr(int8(masklen)).ToBytes()
+	if nicdesc.Gateway != "" && nicdesc.IsDefault {
+		conf.Gateway = net.ParseIP(nicdesc.Gateway)
+	}
 	if len(guestDesc.Hostname) > 0 {
 		conf.Hostname = guestDesc.Hostname
 	} else {


### PR DESCRIPTION
Cherry pick of #25615 on release/3.11.

#25615: fix: classic net distribute default route for default nic