### PR TITLE
fix(region): include disabled hosts in isolated device usage stats

### DIFF
--- a/pkg/compute/models/isolated_devices.go
+++ b/pkg/compute/models/isolated_devices.go
@@ -1290,7 +1290,9 @@ func (manager *SIsolatedDeviceManager) totalCountQ(
 	hosts := hq.SubQuery()
 	devs := manager.Query().SubQuery()
 	q := devs.Query().Join(hosts, sqlchemy.Equals(devs.Field("host_id"), hosts.Field("id")))
-	q = q.Filter(sqlchemy.IsTrue(hosts.Field("enabled")))
+	// 透传设备 usage 统计全部宿主机（含禁用），与 hosts 而非 enabled_hosts 口径一致。
+	// 禁用宿主机上的 GPU 仍需在 usages/hosts 中展示，调度侧仍只使用启用宿主机。
+	// q = q.Filter(sqlchemy.IsTrue(hosts.Field("enabled")))
 	if len(devType) != 0 {
 		q = q.Filter(sqlchemy.In(devs.Field("dev_type"), devType))
 	}


### PR DESCRIPTION
Keep GPU/device usages consistent with hosts inventory; scheduling still uses enabled hosts only.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.11

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
