### PR TITLE
fix(identity): validate rolepolicy create and bind-role requests

### DIFF
--- a/pkg/apis/identity/rolepolicy.go
+++ b/pkg/apis/identity/rolepolicy.go
@@ -23,6 +23,14 @@ import (
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
 )
 
+type RolePolicyCreateInput struct {
+	apis.ResourceBaseCreateInput
+
+	RoleId    string `json:"role_id"`
+	ProjectId string `json:"project_id"`
+	PolicyId  string `json:"policy_id"`
+}
+
 type RolePolicyListInput struct {
 	apis.ResourceBaseListInput
 

--- a/pkg/keystone/models/policies.go
+++ b/pkg/keystone/models/policies.go
@@ -797,7 +797,6 @@ func (policy *SPolicy) fetchMatchableRoles() ([]SRole, error) {
 
 // 绑定角色
 func (policy *SPolicy) PerformBindRole(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input api.PolicyBindRoleInput) (jsonutils.JSONObject, error) {
-	var projectId string
 	prefList := make([]netutils.IPV4Prefix, 0)
 	for _, ipStr := range input.Ips {
 		pref, err := netutils.NewIPV4Prefix(ipStr)
@@ -806,29 +805,11 @@ func (policy *SPolicy) PerformBindRole(ctx context.Context, userCred mcclient.To
 		}
 		prefList = append(prefList, pref)
 	}
-	if len(input.ProjectId) > 0 {
-		proj, err := ProjectManager.FetchByIdOrName(ctx, userCred, input.ProjectId)
-		if err != nil {
-			if errors.Cause(err) == sql.ErrNoRows {
-				return nil, errors.Wrapf(httperrors.ErrNotFound, "%s %s", ProjectManager.Keyword(), input.ProjectId)
-			} else {
-				return nil, errors.Wrap(err, "ProjectManager.FetchByIdOrName")
-			}
-		}
-		projectId = proj.GetId()
-	}
-	if len(input.RoleId) == 0 {
-		return nil, errors.Wrap(httperrors.ErrInputParameter, "missing role_id")
-	}
-	role, err := RoleManager.FetchByIdOrName(ctx, userCred, input.RoleId)
+	roleId, projectId, policyId, err := normalizeRolePolicyBinding(ctx, userCred, input.RoleId, input.ProjectId, policy.Id)
 	if err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
-			return nil, errors.Wrapf(httperrors.ErrNotFound, "%s %s", RoleManager.Keyword(), input.RoleId)
-		} else {
-			return nil, errors.Wrap(err, "RoleManager.FetchByIdOrName")
-		}
+		return nil, err
 	}
-	err = RolePolicyManager.newRecord(ctx, role.GetId(), projectId, policy.Id, tristate.True, prefList, input.ValidSince, input.ValidUntil)
+	err = RolePolicyManager.newRecord(ctx, roleId, projectId, policyId, tristate.True, prefList, input.ValidSince, input.ValidUntil)
 	if err != nil {
 		return nil, errors.Wrap(err, "newRecord")
 	}

--- a/pkg/keystone/models/rolepolicies.go
+++ b/pkg/keystone/models/rolepolicies.go
@@ -32,6 +32,7 @@ import (
 
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	policyman "yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/keystone/options"
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -62,7 +63,7 @@ type SRolePolicy struct {
 	db.SResourceBase
 
 	// 角色ID, 主键
-	RoleId string `width:"128" charset:"ascii" primary:"true" list:"domain" create:"domain_optional"`
+	RoleId string `width:"128" charset:"ascii" primary:"true" list:"domain" create:"domain_required"`
 	// 项目ID，主键
 	ProjectId string `width:"128" charset:"ascii" primary:"true" list:"domain" create:"domain_optional"`
 	// 权限ID, 主键
@@ -103,6 +104,95 @@ func (manager *SRolePolicyManager) newRecord(ctx context.Context, roleId, projec
 		return errors.Wrap(err, "insert role policy")
 	}
 	return nil
+}
+
+func normalizeRolePolicyBinding(ctx context.Context, userCred mcclient.TokenCredential, roleId, projectId, policyId string) (string, string, string, error) {
+	roleId = strings.TrimSpace(roleId)
+	projectId = strings.TrimSpace(projectId)
+	policyId = strings.TrimSpace(policyId)
+	if roleId == "" {
+		return "", "", "", httperrors.NewMissingParameterError("role_id")
+	}
+	if policyId == "" {
+		return "", "", "", httperrors.NewMissingParameterError("policy_id")
+	}
+
+	roleObj, err := RoleManager.FetchByIdOrName(ctx, userCred, roleId)
+	if err != nil {
+		if errors.Cause(err) == sql.ErrNoRows {
+			return "", "", "", httperrors.NewResourceNotFoundError2(RoleManager.Keyword(), roleId)
+		}
+		return "", "", "", errors.Wrap(err, "RoleManager.FetchByIdOrName")
+	}
+	role := roleObj.(*SRole)
+
+	policyObj, err := PolicyManager.FetchByIdOrName(ctx, userCred, policyId)
+	if err != nil {
+		if errors.Cause(err) == sql.ErrNoRows {
+			return "", "", "", httperrors.NewResourceNotFoundError2(PolicyManager.Keyword(), policyId)
+		}
+		return "", "", "", errors.Wrap(err, "PolicyManager.FetchByIdOrName")
+	}
+	pol := policyObj.(*SPolicy)
+
+	if projectId != "" {
+		projObj, err := ProjectManager.FetchByIdOrName(ctx, userCred, projectId)
+		if err != nil {
+			if errors.Cause(err) == sql.ErrNoRows {
+				return "", "", "", httperrors.NewResourceNotFoundError2(ProjectManager.Keyword(), projectId)
+			}
+			return "", "", "", errors.Wrap(err, "ProjectManager.FetchByIdOrName")
+		}
+		projectId = projObj.GetId()
+	}
+
+	isBootStrap, err := RolePolicyManager.isBootstrapRolePolicy()
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "isBootstrapRolePolicy")
+	}
+	if !isBootStrap {
+		if err := db.IsObjectRbacAllowed(ctx, role, userCred, policyman.PolicyActionPerform, "add-policy"); err != nil {
+			return "", "", "", err
+		}
+		if err := db.IsObjectRbacAllowed(ctx, pol, userCred, policyman.PolicyActionPerform, "bind-role"); err != nil {
+			return "", "", "", err
+		}
+		rps, err := RolePolicyManager.fetchByRoleId(role.Id)
+		if err != nil {
+			return "", "", "", errors.Wrap(err, "fetchByRoleId")
+		}
+		policyIds := stringutils2.NewSortedStrings(nil)
+		for i := range rps {
+			policyIds = stringutils2.Append(policyIds, rps[i].PolicyId)
+		}
+		policyIds = stringutils2.Append(policyIds, pol.Id)
+		if err := validateRolePolicies(userCred, policyIds); err != nil {
+			return "", "", "", errors.Wrap(err, "validateRolePolicies")
+		}
+	}
+	return role.Id, projectId, pol.Id, nil
+}
+
+func (manager *SRolePolicyManager) ValidateCreateData(
+	ctx context.Context,
+	userCred mcclient.TokenCredential,
+	ownerId mcclient.IIdentityProvider,
+	query jsonutils.JSONObject,
+	input api.RolePolicyCreateInput,
+) (api.RolePolicyCreateInput, error) {
+	var err error
+	input.ResourceBaseCreateInput, err = manager.SResourceBaseManager.ValidateCreateData(ctx, userCred, ownerId, query, input.ResourceBaseCreateInput)
+	if err != nil {
+		return input, errors.Wrap(err, "SResourceBaseManager.ValidateCreateData")
+	}
+	roleId, projectId, policyId, err := normalizeRolePolicyBinding(ctx, userCred, input.RoleId, input.ProjectId, input.PolicyId)
+	if err != nil {
+		return input, err
+	}
+	input.RoleId = roleId
+	input.ProjectId = projectId
+	input.PolicyId = policyId
+	return input, nil
 }
 
 func (manager *SRolePolicyManager) deleteRecord(ctx context.Context, roleId, projectId, policyId string) error {
@@ -360,14 +450,12 @@ func (manager *SRolePolicyManager) getMatchPolicyIds(userCred rbacutils.IRbacIde
 }
 
 func (manager *SRolePolicyManager) getMatchPolicyIds2(isGuest bool, roleIds []string, pid string, loginIp string, tm time.Time) ([]string, error) {
+	if !isGuest && len(roleIds) == 0 {
+		return []string{}, nil
+	}
 	q := manager.Query()
 	if !isGuest {
-		if len(roleIds) > 0 {
-			q = q.Filter(sqlchemy.OR(
-				sqlchemy.IsNullOrEmpty(q.Field("role_id")),
-				sqlchemy.In(q.Field("role_id"), roleIds),
-			))
-		}
+		q = q.In("role_id", roleIds)
 		if len(pid) > 0 {
 			q = q.Filter(sqlchemy.OR(
 				sqlchemy.IsNullOrEmpty(q.Field("project_id")),

--- a/pkg/keystone/models/rolepolicies_test.go
+++ b/pkg/keystone/models/rolepolicies_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"yunion.io/x/onecloud/pkg/mcclient"
+)
+
+func TestNormalizeRolePolicyBindingRequiresRoleAndPolicy(t *testing.T) {
+	ctx := context.Background()
+	userCred := &mcclient.SSimpleToken{}
+	_, _, _, err := normalizeRolePolicyBinding(ctx, userCred, "", "project-1", "policy-1")
+	if err == nil {
+		t.Fatal("empty role_id: expected error")
+	}
+	_, _, _, err = normalizeRolePolicyBinding(ctx, userCred, "   ", "project-1", "policy-1")
+	if err == nil {
+		t.Fatal("whitespace role_id: expected error")
+	}
+	_, _, _, err = normalizeRolePolicyBinding(ctx, userCred, "role-1", "project-1", "")
+	if err == nil {
+		t.Fatal("empty policy_id: expected error")
+	}
+	_, _, _, err = normalizeRolePolicyBinding(ctx, userCred, "role-1", "project-1", "  ")
+	if err == nil {
+		t.Fatal("whitespace policy_id: expected error")
+	}
+}
+
+func TestGetMatchPolicyIds2NoRoles(t *testing.T) {
+	ids, err := RolePolicyManager.getMatchPolicyIds2(false, nil, "project-1", "", time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("got %v, want empty", ids)
+	}
+}


### PR DESCRIPTION
## Summary
- Require `role_id` when creating a rolepolicy and resolve the role and policy with the caller session.
- Reuse the same checks for policy bind-role, including role add-policy permission.
- Match rolepolicy bindings by the caller's role ids.

## Test plan
- [ ] `go test ./pkg/keystone/models/`
- [ ] Role add-policy / set-policies for a role in the caller domain still works
- [ ] Creating a rolepolicy without `role_id` is rejected
- [ ] Policy bind-role with a valid role still works


Made with [Cursor](https://cursor.com)