### PR TITLE
fix(getport): handle port range edge cases

### DIFF
--- a/pkg/util/netutils2/getport/getport.go
+++ b/pkg/util/netutils2/getport/getport.go
@@ -118,24 +118,34 @@ func GetPortByRange(proto Protocol, start int, end int) (PortResult, error) {
 }
 
 func GetPortByRangeBySets(proto Protocol, start int, end int, usedPorts sets.Int) (PortResult, error) {
+	result := PortResult{
+		IP:   "",
+		Port: -1,
+	}
+	if start > end {
+		return result, errors.Errorf("invalid port range [%d, %d]", start, end)
+	}
+
 	errs := []error{}
-	for i := start; i <= end; i++ {
-		rPort := rand.Intn(end-start) + start
+	for _, offset := range rand.Perm(end - start + 1) {
+		rPort := start + offset
 		if usedPorts.Has(rPort) {
 			continue
 		}
-		result, err := getPort(proto, "", rPort)
+
+		portResult, err := getPort(proto, "", rPort)
 		if err != nil {
 			usedPorts.Insert(rPort)
 			errs = append(errs, errors.Wrapf(err, "check random port: %d", rPort))
-		} else {
-			return result, nil
+			continue
 		}
+		return portResult, nil
 	}
-	return PortResult{
-		IP:   "",
-		Port: -1,
-	}, errors.Wrapf(errors.NewAggregate(errs), "can't get free port in [%d, %d]", start, end)
+
+	if len(errs) == 0 {
+		return result, errors.Errorf("can't get free port in [%d, %d]: all ports are already used", start, end)
+	}
+	return result, errors.Wrapf(errors.NewAggregate(errs), "can't get free port in [%d, %d]", start, end)
 }
 
 // GetTcpPort gets a port for some random available address using either

--- a/pkg/util/netutils2/getport/getport_test.go
+++ b/pkg/util/netutils2/getport/getport_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/util/sets"
 )
 
 func TestGetPort(t *testing.T) {
@@ -205,4 +206,54 @@ func TestListen(t *testing.T) {
 		assert.Empty(t, addr)
 		assert.Error(t, err, "stack not recognized")
 	})
+}
+
+func TestGetPortByRangeBySetsSinglePortUsed(t *testing.T) {
+	const port = 30000
+	var result PortResult
+	var err error
+
+	if !assert.NotPanics(t, func() {
+		result, err = GetPortByRangeBySets(TCP4, port, port, sets.NewInt(port))
+	}) {
+		return
+	}
+
+	assert.Error(t, err)
+	assert.Equal(t, -1, result.Port)
+}
+
+func TestGetPortByRangeBySetsAllPortsUsed(t *testing.T) {
+	const (
+		start = 30000
+		end   = 30001
+	)
+
+	result, err := GetPortByRangeBySets(
+		TCP4,
+		start,
+		end,
+		sets.NewInt(start, end),
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, -1, result.Port)
+}
+
+func TestGetPortByRangeBySetsIncludesEnd(t *testing.T) {
+	const (
+		start = 30000
+		end   = 30001
+	)
+	usedPorts := sets.NewInt(start)
+
+	// Force probe failure without binding a real port.
+	result, err := GetPortByRangeBySets(Protocol(-1), start, end, usedPorts)
+	if !assert.Error(t, err) {
+		return
+	}
+
+	assert.Equal(t, -1, result.Port)
+	assert.Contains(t, err.Error(), "check random port: 30001")
+	assert.True(t, usedPorts.Has(end), "the end port should be probed")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`GetPortByRangeBySets` panics when `start == end` because it calls `rand.Intn(0)`. When all ports are already in `usedPorts`, it returns port `-1` with a nil error because the error list is empty.

This PR replaces repeated random sampling with `rand.Perm(end - start + 1)`, which includes the upper bound and avoids repeating candidates. It also returns an explicit error when all ports are already used and rejects ranges where `start > end`.

Added three regression tests:

- `SinglePortUsed`: a single port already marked as used returns an error and port `-1` without panicking.
- `AllPortsUsed`: a range with all ports marked as used returns an error and port `-1`.
- `IncludesEnd`: the upper bound is probed when the lower bound is already marked as used. An invalid protocol forces the probe to fail without binding a real port.

The package tests and whitespace check passed:

```bash
go test -mod=vendor ./pkg/util/netutils2/getport -count=1
git diff --check
```

**Does this PR need to be backport to the previous release branch?**:

UNKNOWN